### PR TITLE
restructured transactions

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -112,13 +112,11 @@ public class OidcApiController implements OidcApi {
       String provider, List<String> scopes, String redirectUri, String state, String oauthcode) {
     var userId = getUserIdFromSam();
 
-    // calling services from here allows for @transactions
     var linkedAccountWithPassportAndVisas =
-        providerService.useAuthorizationCodeToGetLinkedAccount(
+        providerService.createLink(
             provider, userId, oauthcode, redirectUri, Set.copyOf(scopes), state);
-    var savedLinkedAccount =
-        linkedAccountService.saveLinkedAccount(linkedAccountWithPassportAndVisas);
 
-    return ResponseEntity.ok(getLinkInfoFromLinkedAccount(savedLinkedAccount));
+    return ResponseEntity.ok(
+        getLinkInfoFromLinkedAccount(linkedAccountWithPassportAndVisas.getLinkedAccount()));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/BaseTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/BaseTest.java
@@ -1,8 +1,12 @@
 package bio.terra.externalcreds;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest({"DATABASE_NAME=ecm_test"})
 @ActiveProfiles("human-readable-logging")
+@Transactional
+@Rollback
 public class BaseTest {}

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAOTest.java
@@ -19,8 +19,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
 
 public class GA4GHPassportDAOTest extends BaseTest {
 
@@ -52,8 +50,6 @@ public class GA4GHPassportDAOTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testCreateAndGetPassport() {
     var savedAccountId = linkedAccountDAO.upsertLinkedAccount(linkedAccount).getId();
     var savedPassport = passportDAO.insertPassport(passport.withLinkedAccountId(savedAccountId));
@@ -69,8 +65,6 @@ public class GA4GHPassportDAOTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testPassportIsUniqueForLinkedAccount() {
     var savedAccountId = linkedAccountDAO.upsertLinkedAccount(linkedAccount).getId();
     var savedPassport = passportDAO.insertPassport(passport.withLinkedAccountId(savedAccountId));
@@ -86,8 +80,6 @@ public class GA4GHPassportDAOTest extends BaseTest {
   class DeletePassport {
 
     @Test
-    @Transactional
-    @Rollback
     void testDeletePassportIfExists() {
       var savedAccountId = linkedAccountDAO.upsertLinkedAccount(linkedAccount).getId();
       passportDAO.insertPassport(passport.withLinkedAccountId(savedAccountId));
@@ -98,15 +90,11 @@ public class GA4GHPassportDAOTest extends BaseTest {
     }
 
     @Test
-    @Transactional
-    @Rollback
     void testDeleteNonexistentPassport() {
       assertFalse(passportDAO.deletePassport(-1));
     }
 
     @Test
-    @Transactional
-    @Rollback
     void testAlsoDeletesVisa() {
       var savedAccountId = linkedAccountDAO.upsertLinkedAccount(linkedAccount).getId();
       var savedPassport = passportDAO.insertPassport(passport.withLinkedAccountId(savedAccountId));

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAOTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
 
 public class LinkedAccountDAOTest extends BaseTest {
 
@@ -44,8 +42,6 @@ public class LinkedAccountDAOTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testCreateAndGetLinkedAccount() {
     var savedLinkedAccount = linkedAccountDAO.upsertLinkedAccount(linkedAccount);
     assertTrue(savedLinkedAccount.getId() > 0);
@@ -57,8 +53,6 @@ public class LinkedAccountDAOTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testUpsertLinkedAccounts() {
     var createdLinkedAccount = linkedAccountDAO.upsertLinkedAccount(linkedAccount);
 
@@ -84,8 +78,6 @@ public class LinkedAccountDAOTest extends BaseTest {
   class DeleteLinkedAccount {
 
     @Test
-    @Transactional
-    @Rollback
     void testDeleteLinkedAccountIfExists() {
       var createdLinkedAccount = linkedAccountDAO.upsertLinkedAccount(linkedAccount);
       var deletionSucceeded =
@@ -98,8 +90,6 @@ public class LinkedAccountDAOTest extends BaseTest {
     }
 
     @Test
-    @Transactional
-    @Rollback
     void testDeleteNonexistentLinkedAccount() {
       var userId = UUID.randomUUID().toString();
       var deletionSucceeded = linkedAccountDAO.deleteLinkedAccountIfExists(userId, "fake_provider");
@@ -108,8 +98,6 @@ public class LinkedAccountDAOTest extends BaseTest {
     }
 
     @Test
-    @Transactional
-    @Rollback
     void testAlsoDeletesPassport() {
       var savedLinkedAccount = linkedAccountDAO.upsertLinkedAccount(linkedAccount);
       var passport =

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/WriteTransactionTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/WriteTransactionTest.java
@@ -2,14 +2,18 @@ package bio.terra.externalcreds.dataAccess;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import bio.terra.externalcreds.BaseTest;
 import java.util.concurrent.CyclicBarrier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-public class WriteTransactionTest extends BaseTest {
+// BaseTest includes @Transactional annotation which interferes with tests in this class
+@SpringBootTest({"DATABASE_NAME=ecm_test"})
+@ActiveProfiles("human-readable-logging")
+public class WriteTransactionTest {
   @Autowired private WriteTransactionProbe writeTransactionProbe;
 
   @BeforeEach

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -243,7 +243,7 @@ public class AuthorizationCodeExchangeTest extends BaseTest {
         expectedLinkedAccount, expectedPassport, authorizationCode, redirectUri, scopes, state);
 
     var linkedAccountWithPassportAndVisas =
-        providerService.useAuthorizationCodeToGetLinkedAccount(
+        providerService.createLink(
             expectedLinkedAccount.getProviderId(),
             expectedLinkedAccount.getUserId(),
             authorizationCode,
@@ -253,15 +253,21 @@ public class AuthorizationCodeExchangeTest extends BaseTest {
 
     assertEquals(
         expectedLinkedAccount,
-        linkedAccountWithPassportAndVisas.getLinkedAccount().withExpires(null));
-    assertEquals(expectedPassport, linkedAccountWithPassportAndVisas.getPassport());
-    var visasWithoutLastValidated =
+        linkedAccountWithPassportAndVisas.getLinkedAccount().withExpires(null).withId(0));
+
+    var stablePassport =
+        linkedAccountWithPassportAndVisas.getPassport() == null
+            ? null
+            : linkedAccountWithPassportAndVisas.getPassport().withId(0).withLinkedAccountId(0);
+    assertEquals(expectedPassport, stablePassport);
+
+    var stableVisas =
         linkedAccountWithPassportAndVisas.getVisas() == null
             ? null
             : linkedAccountWithPassportAndVisas.getVisas().stream()
-                .map(visa -> visa.withLastValidated(null))
+                .map(visa -> visa.withLastValidated(null).withId(0).withPassportId(0))
                 .collect(Collectors.toList());
-    assertEquals(expectedVisas, visasWithoutLastValidated);
+    assertEquals(expectedVisas, stableVisas);
   }
 
   private String createPassportJwtString(Date expires, List<String> visaJwts) throws JOSEException {

--- a/service/src/test/java/bio/terra/externalcreds/services/LinkedAccountServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/LinkedAccountServiceTest.java
@@ -20,8 +20,6 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.annotation.Rollback;
-import org.springframework.transaction.annotation.Transactional;
 
 public class LinkedAccountServiceTest extends BaseTest {
   @Autowired private LinkedAccountService linkedAccountService;
@@ -30,8 +28,6 @@ public class LinkedAccountServiceTest extends BaseTest {
   @Autowired private GA4GHVisaDAO visaDAO;
 
   @Test
-  @Transactional
-  @Rollback
   void testGetLinkedAccount() {
     var linkedAccount = createRandomLinkedAccount();
     linkedAccountDAO.upsertLinkedAccount(linkedAccount);
@@ -43,8 +39,6 @@ public class LinkedAccountServiceTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testSaveLinkedAccountWithPassportAndVisas() {
     var linkedAccount = createRandomLinkedAccount();
     var passport = createRandomPassport();
@@ -61,8 +55,6 @@ public class LinkedAccountServiceTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testSaveLinkedAccountWithPassportNoVisas() {
     var linkedAccount = createRandomLinkedAccount();
     var passport = createRandomPassport();
@@ -70,8 +62,6 @@ public class LinkedAccountServiceTest extends BaseTest {
   }
 
   @Test
-  @Transactional
-  @Rollback
   void testSaveLinkedAccountWithoutPassport() {
     var linkedAccount = createRandomLinkedAccount();
     saveAndValidateLinkedAccount(linkedAccount, null, Collections.emptyList());
@@ -79,7 +69,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
   private LinkedAccount saveAndValidateLinkedAccount(
       LinkedAccount linkedAccount, GA4GHPassport passport, List<GA4GHVisa> visas) {
-    var savedLinkedAccount =
+    var saved =
         linkedAccountService.saveLinkedAccount(
             LinkedAccountWithPassportAndVisas.builder()
                 .linkedAccount(linkedAccount)
@@ -87,10 +77,10 @@ public class LinkedAccountServiceTest extends BaseTest {
                 .visas(visas)
                 .build());
 
-    assertEquals(linkedAccount, savedLinkedAccount.withId(0));
-    assertTrue(savedLinkedAccount.getId() > 0);
+    assertEquals(linkedAccount, saved.getLinkedAccount().withId(0));
+    assertTrue(saved.getLinkedAccount().getId() > 0);
 
-    var savedPassport = passportDAO.getPassport(savedLinkedAccount.getId());
+    var savedPassport = passportDAO.getPassport(saved.getLinkedAccount().getId());
     if (passport == null) {
       assertNull(savedPassport);
     } else {
@@ -101,7 +91,7 @@ public class LinkedAccountServiceTest extends BaseTest {
           savedVisas.stream().map(v -> v.withId(0).withPassportId(0)).collect(Collectors.toList()));
     }
 
-    return savedLinkedAccount;
+    return saved.getLinkedAccount();
   }
 
   private Timestamp getRandomTimestamp() {


### PR DESCRIPTION
This started out as making `ProviderService` call `linkedAccountService.saveLinkedAccount` instead of `OidcApiController`. This led to propagating database ids in return types (`saveLinkedAccount` returns `LinkedAccountWithPassportAndVisas` with populated database ids).

Then I discovered that `OidcApiController` did not have a test for `createLink`.

Then I moved the `@Transactional` and `@Rollback` annotations to `BaseTest` because I noticed some tests did not have them and were littering the db and really almost all tests should have them (except those testing fancy transaction dances).

And that was my morning.
