### PR TITLE
Enable tracing

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/ExternalCredsApplication.java
+++ b/service/src/main/java/bio/terra/externalcreds/ExternalCredsApplication.java
@@ -8,7 +8,8 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
     scanBasePackages = {
       "bio.terra.externalcreds",
       "bio.terra.common.logging",
-      "bio.terra.common.retry.transaction"
+      "bio.terra.common.retry.transaction",
+      "bio.terra.common.tracing"
     })
 public class ExternalCredsApplication {
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -35,7 +35,6 @@ spring:
           must-revalidate: true
         use-last-modified: false
 
-# test
 terra.common:
   tracing:
     stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -34,3 +34,8 @@ spring:
           max-age: 0
           must-revalidate: true
         use-last-modified: false
+
+terra.common:
+  tracing:
+    stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}
+    samplingRate: ${SAMPLING_PROBABILITY:0}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -35,6 +35,7 @@ spring:
           must-revalidate: true
         use-last-modified: false
 
+# test
 terra.common:
   tracing:
     stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}


### PR DESCRIPTION
Following WSM's lead on how to set this up:

This PR just adds a references to the terra-common-lib tracing utils and then defaults the tracing to "off" so that it's off when running locally. It will be turned on in our dev environment because of the configs set [here](https://github.com/broadinstitute/terra-helmfile/blob/master/values/app/externalcreds/live.yaml) in terra-helfile. 