### PR TITLE
Fix nondeterminism

### DIFF
--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -20,6 +20,8 @@ import bio.terra.externalcreds.services.LinkedAccountService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.services.ProviderService;
 import bio.terra.externalcreds.services.SamService;
+import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.util.List;
@@ -167,7 +169,8 @@ public class OidcApiControllerTest extends BaseTest {
   @Test
   void testCreateLink() throws Exception {
     var accessToken = "testToken";
-    var inputLinkedAccount = TestUtils.createRandomLinkedAccount();
+    var inputLinkedAccount =
+        TestUtils.createRandomLinkedAccount().withExpires(Timestamp.from(Instant.MIN));
 
     var scopes = new String[] {"email", "foo"};
     var redirectUri = "http://redirect";


### PR DESCRIPTION
It looks like this test had been failing randomly (and infrequently) when the linkedAccount's timestamp ended in a zero. Basically, one style of `Timestamp`->`OffsetDateTime`->`String` conversion prints with the final zero, while the other prints without. Kai and I confirmed that both formats are fine (both can be converted back to an `OffsetDateTime` without issue). 

This fix is just to avoid using a random timestamp in the test. 

Screenshot of the failed test output: 
![image](https://user-images.githubusercontent.com/23193756/132538803-977370f8-2354-443e-83ec-06a8437ec68b.png)
