### PR TITLE
Fix visa validation [POL-89]

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/ExternalCredsCronApplication.java
+++ b/service/src/main/java/bio/terra/externalcreds/ExternalCredsCronApplication.java
@@ -50,7 +50,7 @@ public class ExternalCredsCronApplication {
 
     // check and validate visas not validated since job was last run
     log.info("beginning validateVisas");
-    var checkedPassportCount = providerService.validatePassportsWithAccessTokenVisas();
+    var checkedPassportCount = providerService.validateAccessTokenVisas();
     log.info("completed validateVisas", Map.of("checked_passport_count", checkedPassportCount));
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAO.java
@@ -2,12 +2,8 @@ package bio.terra.externalcreds.dataAccess;
 
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.models.GA4GHPassport;
-import bio.terra.externalcreds.models.PassportVerificationDetails;
-import bio.terra.externalcreds.models.TokenTypeEnum;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.List;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.support.DataAccessUtils;
@@ -75,23 +71,6 @@ public class GA4GHPassportDAO {
             jdbcTemplate.query(query, namedParameters, new GA4GHPassportRowMapper())));
   }
 
-  public List<PassportVerificationDetails> getPassportsWithUnvalidatedAccessTokenVisas(
-      Timestamp validationCutoff) {
-    var namedParameters = new MapSqlParameterSource("validationCutoff", validationCutoff);
-
-    var query =
-        "SELECT DISTINCT la.id as linked_account_id, la.provider_id, p.jwt as passport_jwt FROM linked_account la"
-            + " JOIN ga4gh_passport p"
-            + " ON p.linked_account_id = la.id"
-            + " JOIN ga4gh_visa v"
-            + " ON v.passport_id = p.id"
-            + " WHERE v.token_type = "
-            + String.format("'%s'", TokenTypeEnum.access_token)
-            + " AND v.last_validated <= :validationCutoff";
-
-    return jdbcTemplate.query(query, namedParameters, new PassportVerificationDetailsRowMapper());
-  }
-
   private static class GA4GHPassportRowMapper implements RowMapper<GA4GHPassport> {
 
     @Override
@@ -101,19 +80,6 @@ public class GA4GHPassportDAO {
           .linkedAccountId(rs.getInt("linked_account_id"))
           .jwt(rs.getString("jwt"))
           .expires(rs.getTimestamp("expires"))
-          .build();
-    }
-  }
-
-  private static class PassportVerificationDetailsRowMapper
-      implements RowMapper<PassportVerificationDetails> {
-
-    @Override
-    public PassportVerificationDetails mapRow(ResultSet rs, int rowNum) throws SQLException {
-      return new PassportVerificationDetails.Builder()
-          .linkedAccountId(rs.getInt("linked_account_id"))
-          .providerId(rs.getString("provider_id"))
-          .passportJwt(rs.getString("passport_jwt"))
           .build();
     }
   }

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
@@ -67,16 +67,17 @@ public class GA4GHVisaDAO {
 
   public List<VisaVerificationDetails> getUnvalidatedAccessTokenVisaDetails(
       Timestamp validationCutoff) {
-    var namedParameters = new MapSqlParameterSource("validationCutoff", validationCutoff);
+    var namedParameters =
+        new MapSqlParameterSource("tokenType", TokenTypeEnum.access_token.toString())
+            .addValue("validationCutoff", validationCutoff);
 
     var query =
-        "SELECT DISTINCT la.id as linked_account_id, la.provider_id, v.jwt FROM linked_account la"
+        "SELECT DISTINCT la.id as linked_account_id, la.provider_id as provider_id, v.jwt as jwt FROM linked_account la"
             + " JOIN ga4gh_passport p"
             + " ON p.linked_account_id = la.id"
             + " JOIN ga4gh_visa v"
             + " ON v.passport_id = p.id"
-            + " WHERE v.token_type = "
-            + String.format("'%s'", TokenTypeEnum.access_token)
+            + " WHERE v.token_type = :tokenType::token_type_enum"
             + " AND v.last_validated <= :validationCutoff";
 
     return jdbcTemplate.query(query, namedParameters, new VisaVerificationDetailsRowMapper());

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
@@ -2,8 +2,10 @@ package bio.terra.externalcreds.dataAccess;
 
 import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.TokenTypeEnum;
+import bio.terra.externalcreds.models.VisaVerificationDetails;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.List;
 import java.util.Optional;
@@ -57,6 +59,23 @@ public class GA4GHVisaDAO {
     return jdbcTemplate.query(query, namedParameters, new GA4GHVisaRowMapper());
   }
 
+  public List<VisaVerificationDetails> getUnvalidatedAccessTokenVisaDetails(
+      Timestamp validationCutoff) {
+    var namedParameters = new MapSqlParameterSource("validationCutoff", validationCutoff);
+
+    var query =
+        "SELECT DISTINCT la.id as linked_account_id, la.provider_id, v.jwt FROM linked_account la"
+            + " JOIN ga4gh_passport p"
+            + " ON p.linked_account_id = la.id"
+            + " JOIN ga4gh_visa v"
+            + " ON v.passport_id = p.id"
+            + " WHERE v.token_type = "
+            + String.format("'%s'", TokenTypeEnum.access_token)
+            + " AND v.last_validated <= :validationCutoff";
+
+    return jdbcTemplate.query(query, namedParameters, new VisaVerificationDetailsRowMapper());
+  }
+
   private static class GA4GHVisaRowMapper implements RowMapper<GA4GHVisa> {
 
     @Override
@@ -70,6 +89,19 @@ public class GA4GHVisaDAO {
           .tokenType(TokenTypeEnum.valueOf(rs.getString("token_type")))
           .lastValidated(Optional.ofNullable(rs.getTimestamp("last_validated")))
           .visaType(rs.getString("visa_type"))
+          .build();
+    }
+  }
+
+  private static class VisaVerificationDetailsRowMapper
+      implements RowMapper<VisaVerificationDetails> {
+
+    @Override
+    public VisaVerificationDetails mapRow(ResultSet rs, int rowNum) throws SQLException {
+      return new VisaVerificationDetails.Builder()
+          .linkedAccountId(rs.getInt("linked_account_id"))
+          .providerId(rs.getString("provider_id"))
+          .visaJwt(rs.getString("jwt"))
           .build();
     }
   }

--- a/service/src/main/java/bio/terra/externalcreds/models/VisaVerificationDetails.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/VisaVerificationDetails.java
@@ -3,12 +3,12 @@ package bio.terra.externalcreds.models;
 import org.immutables.value.Value;
 
 @Value.Immutable
-public interface PassportVerificationDetails {
+public interface VisaVerificationDetails {
   Integer getLinkedAccountId();
 
   String getProviderId();
 
-  String getPassportJwt();
+  String getVisaJwt();
 
-  class Builder extends ImmutablePassportVerificationDetails.Builder {}
+  class Builder extends ImmutableVisaVerificationDetails.Builder {}
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -3,8 +3,9 @@ package bio.terra.externalcreds.services;
 import bio.terra.common.db.ReadTransaction;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.GA4GHPassportDAO;
+import bio.terra.externalcreds.dataAccess.GA4GHVisaDAO;
 import bio.terra.externalcreds.models.GA4GHPassport;
-import bio.terra.externalcreds.models.PassportVerificationDetails;
+import bio.terra.externalcreds.models.VisaVerificationDetails;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
@@ -18,10 +19,13 @@ public class PassportService {
 
   private final GA4GHPassportDAO passportDAO;
   private final ExternalCredsConfig externalCredsConfig;
+  private final GA4GHVisaDAO visaDAO;
 
-  public PassportService(GA4GHPassportDAO passportDAO, ExternalCredsConfig externalCredsConfig) {
+  public PassportService(
+      GA4GHPassportDAO passportDAO, ExternalCredsConfig externalCredsConfig, GA4GHVisaDAO visaDAO) {
     this.passportDAO = passportDAO;
     this.externalCredsConfig = externalCredsConfig;
+    this.visaDAO = visaDAO;
   }
 
   @ReadTransaction
@@ -30,10 +34,10 @@ public class PassportService {
   }
 
   @ReadTransaction
-  public List<PassportVerificationDetails> getPassportsWithUnvalidatedAccessTokenVisas() {
+  public List<VisaVerificationDetails> getUnvalidatedAccessTokenVisaDetails() {
     var validationCutoff =
         new Timestamp(
             Instant.now().minus(externalCredsConfig.getTokenValidationDuration()).toEpochMilli());
-    return passportDAO.getPassportsWithUnvalidatedAccessTokenVisas(validationCutoff);
+    return visaDAO.getUnvalidatedAccessTokenVisaDetails(validationCutoff);
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
@@ -193,10 +194,6 @@ public class ProviderService {
 
           // If the response is not "valid", get a new passport.
           if (!responseBody.equalsIgnoreCase("valid")) {
-            log.info(
-                String.format(
-                    "Found a visa that is not valid, with validation response '%s'. Refreshing passport.",
-                    responseBody));
             var linkedAccount = linkedAccountService.getLinkedAccount(pd.getLinkedAccountId());
             try {
               linkedAccount.ifPresentOrElse(
@@ -206,6 +203,12 @@ public class ProviderService {
               log.info("Failed to refresh passport, will try again at the next interval.", e);
             }
           }
+          log.info(
+              "Got visa validation response: {}",
+              Map.of(
+                  "linkedAccountId", pd.getLinkedAccountId(),
+                  "providerId", pd.getProviderId(),
+                  "validationResponse", responseBody));
         });
     return visaDetailsList.size();
   }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAOTest.java
@@ -9,12 +9,8 @@ import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.models.GA4GHVisa;
-import bio.terra.externalcreds.models.PassportVerificationDetails;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import java.sql.Timestamp;
-import java.time.Duration;
-import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -34,129 +30,6 @@ public class GA4GHPassportDAOTest extends BaseTest {
   void testGetMissingPassport() {
     var shouldBeEmpty = passportDAO.getPassport("nonexistent_user_id", "nonexistent_provider_id");
     assertEmpty(shouldBeEmpty);
-  }
-
-  @Nested
-  class GetPassportsWithUnvalidatedAccessTokenVisas {
-
-    private final Timestamp validationCutoff =
-        new Timestamp(Instant.now().plus(Duration.ofMinutes(60)).toEpochMilli());
-
-    @Test
-    void testGetPassportsWithUnvalidatedAccessTokenVisas() {
-      // create linked account with passport and visa that does not need validation
-      var savedLinkedAccount =
-          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
-      var savedPassport =
-          passportDAO.insertPassport(
-              TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId()));
-      var savedValidatedVisa =
-          visaDAO.insertVisa(
-              TestUtils.createRandomVisa()
-                  .withLastValidated(
-                      new Timestamp(Instant.now().plus(Duration.ofMinutes(60)).toEpochMilli()))
-                  .withPassportId(savedPassport.getId()));
-
-      // create linked account with passport and one visa that was NOT validated in the validation
-      // window
-      var savedLinkedAccountUnvalidatedVisa =
-          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
-      var savedPassportUnvalidatedVisa =
-          passportDAO.insertPassport(
-              TestUtils.createRandomPassport()
-                  .withLinkedAccountId(savedLinkedAccountUnvalidatedVisa.getId()));
-      var savedUnvalidatedVisa =
-          visaDAO.insertVisa(
-              TestUtils.createRandomVisa()
-                  .withLastValidated(
-                      new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()))
-                  .withPassportId(savedPassportUnvalidatedVisa.getId()));
-
-      // create linked account with passport and one visa that was NOT validated in the validation
-      // window and one that was to make sure it still returns the account
-      var savedLinkedAccountUnvalidatedVisa2 =
-          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
-      var savedPassportUnvalidatedVisa2 =
-          passportDAO.insertPassport(
-              TestUtils.createRandomPassport()
-                  .withLinkedAccountId(savedLinkedAccountUnvalidatedVisa2.getId()));
-      var savedUnvalidatedVisa2 =
-          visaDAO.insertVisa(
-              TestUtils.createRandomVisa()
-                  .withLastValidated(
-                      new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()))
-                  .withPassportId(savedPassportUnvalidatedVisa2.getId()));
-      var savedValidatedVisa2 =
-          visaDAO.insertVisa(
-              TestUtils.createRandomVisa()
-                  .withLastValidated(new Timestamp(Instant.now().toEpochMilli()))
-                  .withPassportId(savedPassportUnvalidatedVisa2.getId()));
-
-      // create verified visa passport details to check unvalidated visa details against
-      var passportWithUnvalidatedVisaDetails =
-          new PassportVerificationDetails.Builder()
-              .linkedAccountId(savedLinkedAccountUnvalidatedVisa.getId().get())
-              .providerId(savedLinkedAccountUnvalidatedVisa.getProviderId())
-              .passportJwt(savedPassportUnvalidatedVisa.getJwt())
-              .build();
-
-      var passportWithUnvalidatedVisaDetails2 =
-          new PassportVerificationDetails.Builder()
-              .linkedAccountId(savedLinkedAccountUnvalidatedVisa2.getId().get())
-              .providerId(savedLinkedAccountUnvalidatedVisa2.getProviderId())
-              .passportJwt(savedPassportUnvalidatedVisa2.getJwt())
-              .build();
-
-      assertEquals(
-          List.of(passportWithUnvalidatedVisaDetails, passportWithUnvalidatedVisaDetails2),
-          passportDAO.getPassportsWithUnvalidatedAccessTokenVisas(validationCutoff));
-    }
-
-    @Test
-    void testGetsOnlyTokenTypeVisas() {
-      // create linked account with passport and one token type visa NOT validated in the validation
-      // window
-      var savedLinkedAccountUnvalidatedVisa =
-          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
-      var savedPassportUnvalidatedVisa =
-          passportDAO.insertPassport(
-              TestUtils.createRandomPassport()
-                  .withLinkedAccountId(savedLinkedAccountUnvalidatedVisa.getId()));
-      var savedUnvalidatedVisa =
-          visaDAO.insertVisa(
-              TestUtils.createRandomVisa()
-                  .withLastValidated(
-                      new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()))
-                  .withPassportId(savedPassportUnvalidatedVisa.getId()));
-
-      // create linked account with passport and one document type visa NOT validated in the
-      // validation window
-      var savedLinkedAccountUnvalidatedDocumentVisa =
-          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
-      var savedPassportUnvalidatedDocumentVisa =
-          passportDAO.insertPassport(
-              TestUtils.createRandomPassport()
-                  .withLinkedAccountId(savedLinkedAccountUnvalidatedDocumentVisa.getId()));
-      var savedUnvalidatedDocumentVisa =
-          visaDAO.insertVisa(
-              TestUtils.createRandomVisa()
-                  .withLastValidated(
-                      new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()))
-                  .withPassportId(savedPassportUnvalidatedDocumentVisa.getId())
-                  .withTokenType(TokenTypeEnum.document_token));
-
-      // create verified visa passport details to check unvalidated visa details against
-      var passportWithUnvalidatedVisaDetails =
-          new PassportVerificationDetails.Builder()
-              .linkedAccountId(savedLinkedAccountUnvalidatedVisa.getId().get())
-              .providerId(savedLinkedAccountUnvalidatedVisa.getProviderId())
-              .passportJwt(savedPassportUnvalidatedVisa.getJwt())
-              .build();
-
-      assertEquals(
-          List.of(passportWithUnvalidatedVisaDetails),
-          passportDAO.getPassportsWithUnvalidatedAccessTokenVisas(validationCutoff));
-    }
   }
 
   @Nested

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
@@ -7,9 +7,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.models.TokenTypeEnum;
+import bio.terra.externalcreds.models.VisaVerificationDetails;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
@@ -19,6 +25,129 @@ public class GA4GHVisaDAOTest extends BaseTest {
   @Autowired private LinkedAccountDAO linkedAccountDAO;
   @Autowired private GA4GHPassportDAO passportDAO;
   @Autowired private GA4GHVisaDAO visaDAO;
+
+  @Nested
+  class GetUnvalidatedAccessTokenVisaDetails {
+
+    private final Timestamp validationCutoff =
+        new Timestamp(Instant.now().minus(Duration.ofMinutes(60)).toEpochMilli());
+
+    @Test
+    void testGetUnvalidatedAccessTokenVisaDetails() {
+      var recentlyValidatedTimestamp = new Timestamp(Instant.now().toEpochMilli());
+      var expiredValidationTimestamp =
+          new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli());
+
+      // create linked account with passport and visa that does not need validation
+      var savedLinkedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassport =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId()));
+      var savedValidatedVisa =
+          visaDAO.insertVisa(
+              TestUtils.createRandomVisa()
+                  .withLastValidated(recentlyValidatedTimestamp)
+                  .withPassportId(savedPassport.getId()));
+
+      // create linked account with passport and one visa that was NOT validated in the validation
+      // window
+      var savedLinkedAccountUnvalidatedVisa =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassportUnvalidatedVisa =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport()
+                  .withLinkedAccountId(savedLinkedAccountUnvalidatedVisa.getId()));
+      var savedUnvalidatedVisa =
+          visaDAO.insertVisa(
+              TestUtils.createRandomVisa()
+                  .withLastValidated(expiredValidationTimestamp)
+                  .withPassportId(savedPassportUnvalidatedVisa.getId()));
+
+      // create linked account with passport and one visa that was NOT validated in the validation
+      // window and one that was to make sure it still returns the account info
+      var savedLinkedAccountUnvalidatedVisa2 =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassportUnvalidatedVisa2 =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport()
+                  .withLinkedAccountId(savedLinkedAccountUnvalidatedVisa2.getId()));
+      var savedUnvalidatedVisa2 =
+          visaDAO.insertVisa(
+              TestUtils.createRandomVisa()
+                  .withLastValidated(expiredValidationTimestamp)
+                  .withPassportId(savedPassportUnvalidatedVisa2.getId()));
+      var savedValidatedVisa2 =
+          visaDAO.insertVisa(
+              TestUtils.createRandomVisa()
+                  .withLastValidated(recentlyValidatedTimestamp)
+                  .withPassportId(savedPassportUnvalidatedVisa2.getId()));
+
+      // create verified visa passport details to check unvalidated visa details against
+      var passportWithUnvalidatedVisaDetails =
+          new VisaVerificationDetails.Builder()
+              .linkedAccountId(savedLinkedAccountUnvalidatedVisa.getId().get())
+              .providerId(savedLinkedAccountUnvalidatedVisa.getProviderId())
+              .visaJwt(savedUnvalidatedVisa.getJwt())
+              .build();
+
+      var passportWithUnvalidatedVisaDetails2 =
+          new VisaVerificationDetails.Builder()
+              .linkedAccountId(savedLinkedAccountUnvalidatedVisa2.getId().get())
+              .providerId(savedLinkedAccountUnvalidatedVisa2.getProviderId())
+              .visaJwt(savedUnvalidatedVisa2.getJwt())
+              .build();
+
+      assertEquals(
+          List.of(passportWithUnvalidatedVisaDetails, passportWithUnvalidatedVisaDetails2),
+          visaDAO.getUnvalidatedAccessTokenVisaDetails(validationCutoff));
+    }
+
+    @Test
+    void testGetsOnlyTokenTypeVisas() {
+      // create linked account with passport and one token type visa NOT validated in the validation
+      // window
+      var savedLinkedAccountUnvalidatedVisa =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassportUnvalidatedVisa =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport()
+                  .withLinkedAccountId(savedLinkedAccountUnvalidatedVisa.getId()));
+      var savedUnvalidatedVisa =
+          visaDAO.insertVisa(
+              TestUtils.createRandomVisa()
+                  .withLastValidated(
+                      new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()))
+                  .withPassportId(savedPassportUnvalidatedVisa.getId()));
+
+      // create linked account with passport and one document type visa NOT validated in the
+      // validation window
+      var savedLinkedAccountUnvalidatedDocumentVisa =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassportUnvalidatedDocumentVisa =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport()
+                  .withLinkedAccountId(savedLinkedAccountUnvalidatedDocumentVisa.getId()));
+      visaDAO.insertVisa(
+          TestUtils.createRandomVisa()
+              .withLastValidated(
+                  new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli()))
+              .withPassportId(savedPassportUnvalidatedDocumentVisa.getId())
+              .withTokenType(TokenTypeEnum.document_token));
+
+      // create verified visa passport details to check unvalidated visa details against
+      var passportWithUnvalidatedVisaDetails =
+          new VisaVerificationDetails.Builder()
+              .linkedAccountId(savedLinkedAccountUnvalidatedVisa.getId().get())
+              .providerId(savedLinkedAccountUnvalidatedVisa.getProviderId())
+              .visaJwt(savedUnvalidatedVisa.getJwt())
+              .build();
+
+      assertEquals(
+          List.of(passportWithUnvalidatedVisaDetails),
+          visaDAO.getUnvalidatedAccessTokenVisaDetails(validationCutoff));
+    }
+  }
 
   @Test
   void testInsertAndListVisa() {

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -19,9 +19,11 @@ import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.GA4GHPassportDAO;
 import bio.terra.externalcreds.dataAccess.GA4GHVisaDAO;
 import bio.terra.externalcreds.dataAccess.LinkedAccountDAO;
+import bio.terra.externalcreds.models.GA4GHVisa;
+import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
-import bio.terra.externalcreds.models.PassportVerificationDetails;
 import bio.terra.externalcreds.models.TokenTypeEnum;
+import bio.terra.externalcreds.models.VisaVerificationDetails;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
@@ -413,7 +415,7 @@ public class ProviderServiceTest extends BaseTest {
 
   @Nested
   @TestComponent
-  class ValidatePassportWithProvider {
+  class ValidateVisaWithProvider {
     @Autowired private ProviderService providerService;
     @Autowired private LinkedAccountDAO linkedAccountDAO;
 
@@ -427,17 +429,17 @@ public class ProviderServiceTest extends BaseTest {
       var passport =
           TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId());
       var passportVerificationDetails =
-          new PassportVerificationDetails.Builder()
+          new VisaVerificationDetails.Builder()
               .linkedAccountId(passport.getLinkedAccountId().get())
               .providerId(savedLinkedAccount.getProviderId())
-              .passportJwt(passport.getJwt())
+              .visaJwt(passport.getJwt())
               .build();
 
       var mockServer =
           mockValidationEndpointConfigsAndResponse(
               passportVerificationDetails, HttpStatus.OK, "Valid");
 
-      var responseBody = providerService.validatePassportWithProvider(passportVerificationDetails);
+      var responseBody = providerService.validateVisaWithProvider(passportVerificationDetails);
       assertEquals("Valid", responseBody);
 
       mockServer.stop();
@@ -451,24 +453,24 @@ public class ProviderServiceTest extends BaseTest {
       var passport =
           TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId());
       var passportVerificationDetails =
-          new PassportVerificationDetails.Builder()
+          new VisaVerificationDetails.Builder()
               .linkedAccountId(passport.getLinkedAccountId().get())
               .providerId(savedLinkedAccount.getProviderId())
-              .passportJwt(passport.getJwt())
+              .visaJwt(passport.getJwt())
               .build();
 
       var mockServer =
           mockValidationEndpointConfigsAndResponse(
               passportVerificationDetails, HttpStatus.BAD_REQUEST, "Invalid Passport");
 
-      var responseBody = providerService.validatePassportWithProvider(passportVerificationDetails);
+      var responseBody = providerService.validateVisaWithProvider(passportVerificationDetails);
       assertEquals("Invalid Passport", responseBody);
 
       mockServer.stop();
     }
 
     private ClientAndServer mockValidationEndpointConfigsAndResponse(
-        PassportVerificationDetails passportVerificationDetails,
+        VisaVerificationDetails visaVerificationDetails,
         HttpStatus mockedStatusCode,
         String mockedResponseBody) {
       var mockServerPort = 50555;
@@ -477,18 +479,20 @@ public class ProviderServiceTest extends BaseTest {
       when(externalCredsConfigMock.getProviders())
           .thenReturn(
               Map.of(
-                  passportVerificationDetails.getProviderId(),
+                  visaVerificationDetails.getProviderId(),
                   TestUtils.createRandomProvider()
                       .setValidationEndpoint(
                           "http://localhost:" + mockServerPort + validationEndpoint)));
 
       //  Mock the server response with 400 response code for invalid passport format
       var mockServer = ClientAndServer.startClientAndServer(mockServerPort);
+      var expectedQueryStringParameters =
+          List.of(new Parameter("visa", visaVerificationDetails.getVisaJwt()));
       mockServer
           .when(
               HttpRequest.request(validationEndpoint)
-                  .withMethod("POST")
-                  .withBody(passportVerificationDetails.getPassportJwt()))
+                  .withMethod("GET")
+                  .withQueryStringParameters(expectedQueryStringParameters))
           .respond(
               HttpResponse.response()
                   .withStatusCode(mockedStatusCode.value())
@@ -521,16 +525,15 @@ public class ProviderServiceTest extends BaseTest {
                   .visas(List.of(visaNeedingVerification))
                   .build());
 
-      var expectedPassportDetails =
-          getExpectedPassportVerificationDetails(savedLinkedAccountWithPassportAndVisa);
-      doReturn("Valid")
-          .when(providerServiceSpy)
-          .validatePassportWithProvider(expectedPassportDetails);
+      var expectedVisaDetails =
+          getExpectedVisaVerificationDetails(
+              savedLinkedAccountWithPassportAndVisa.getLinkedAccount(), visaNeedingVerification);
+      doReturn("Valid").when(providerServiceSpy).validateVisaWithProvider(expectedVisaDetails);
 
       // check that validatePassportWithProvider is called once and no exceptions are thrown
-      providerServiceSpy.validatePassportsWithAccessTokenVisas();
-      verify(providerServiceSpy).validatePassportWithProvider(any());
-      verify(providerServiceSpy).validatePassportWithProvider(expectedPassportDetails);
+      providerServiceSpy.validateAccessTokenVisas();
+      verify(providerServiceSpy).validateVisaWithProvider(any());
+      verify(providerServiceSpy).validateVisaWithProvider(expectedVisaDetails);
     }
 
     @Test
@@ -552,30 +555,31 @@ public class ProviderServiceTest extends BaseTest {
 
       // mock the behavior of helper functions which already have their own tests
       var expectedPassportDetails =
-          getExpectedPassportVerificationDetails(savedLinkedAccountWithPassportAndVisa);
+          getExpectedVisaVerificationDetails(
+              savedLinkedAccountWithPassportAndVisa.getLinkedAccount(), visaNeedingVerification);
       doReturn("Invalid")
           .when(providerServiceSpy)
-          .validatePassportWithProvider(expectedPassportDetails);
+          .validateVisaWithProvider(expectedPassportDetails);
       doNothing()
           .when(providerServiceSpy)
           .authAndRefreshPassport(savedLinkedAccountWithPassportAndVisa.getLinkedAccount());
 
       // check that validatePassportWithProvider is called once and no exceptions are thrown
-      providerServiceSpy.validatePassportsWithAccessTokenVisas();
-      verify(providerServiceSpy).validatePassportWithProvider(any());
-      verify(providerServiceSpy).validatePassportWithProvider(expectedPassportDetails);
+      providerServiceSpy.validateAccessTokenVisas();
+      verify(providerServiceSpy).validateVisaWithProvider(any());
+      verify(providerServiceSpy).validateVisaWithProvider(expectedPassportDetails);
 
       // check that authAndRefreshPassport was also called once
       verify(providerServiceSpy)
           .authAndRefreshPassport(savedLinkedAccountWithPassportAndVisa.getLinkedAccount());
     }
 
-    private PassportVerificationDetails getExpectedPassportVerificationDetails(
-        LinkedAccountWithPassportAndVisas linkedAccountWithPassportAndVisa) {
-      return new PassportVerificationDetails.Builder()
-          .linkedAccountId(linkedAccountWithPassportAndVisa.getLinkedAccount().getId().get())
-          .passportJwt(linkedAccountWithPassportAndVisa.getPassport().get().getJwt())
-          .providerId(linkedAccountWithPassportAndVisa.getLinkedAccount().getProviderId())
+    private VisaVerificationDetails getExpectedVisaVerificationDetails(
+        LinkedAccount linkedAccount, GA4GHVisa visa) {
+      return new VisaVerificationDetails.Builder()
+          .linkedAccountId(linkedAccount.getId().get())
+          .visaJwt(visa.getJwt())
+          .providerId(linkedAccount.getProviderId())
           .build();
     }
   }


### PR DESCRIPTION
We had been making a POST request with the entire passport in the request body, but realized this approach doesn't actually work with the RAS endpoint. Instead, we need to make a GET request with only the visa as a query parameter. 

This PR is mostly renaming things from "passport" to "visa", including:
- `validatePassportsWithAccessTokenVisas` -> `validateAccessTokenVisas`
- `getPassportsWithUnvalidatedAccessTokenVisas` -> `getUnvalidatedAccessTokenVisaDetails` (also moving this and its tests from the PassportDAO to the VisaDAO).
- `validatePassportWithProvider` -> `validateVisaWithProvider`


The only non-naming changes are:
- updating the database query to return the visa JWT instead of the passport JWT
- updating the structure of the structure of the request we make to the RAS validation endpoint