### PR TITLE
sync pubsub channel name [POL-83]

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -30,5 +30,7 @@ public interface ExternalCredsConfigInterface {
   /** List of URIs that are allowable in jku headers of JWTs */
   Collection<URI> getAllowedJwksUris();
 
+  boolean getAuthorizationChangeEventsEnabled();
+
   Optional<String> getAuthorizationChangeEventTopicName();
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/EventPublisher.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/EventPublisher.java
@@ -29,17 +29,22 @@ public class EventPublisher {
     this.objectMapper = objectMapper;
 
     // note that Publisher authenticates to Google using the env var GOOGLE_APPLICATION_CREDENTIALS
-    this.authorizationChangeEventPublisher =
-        externalCredsConfig
-            .getAuthorizationChangeEventTopicName()
-            .map(
-                topicName -> {
-                  try {
-                    return Publisher.newBuilder(topicName).build();
-                  } catch (IOException e) {
-                    throw new ExternalCredsException("exception building event publisher", e);
-                  }
-                });
+    // the Publisher will be disabled when running locally, to prevent tests from using it
+    if (externalCredsConfig.getAuthorizationChangeEventsEnabled()) {
+      this.authorizationChangeEventPublisher =
+          externalCredsConfig
+              .getAuthorizationChangeEventTopicName()
+              .map(
+                  topicName -> {
+                    try {
+                      return Publisher.newBuilder(topicName).build();
+                    } catch (IOException e) {
+                      throw new ExternalCredsException("exception building event publisher", e);
+                    }
+                  });
+    } else {
+      this.authorizationChangeEventPublisher = Optional.empty();
+    }
   }
 
   public void publishAuthorizationChangeEvent(AuthorizationChangeEvent event) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -3,6 +3,7 @@ externalcreds:
   background-job-interval-mins: 5
   token-validation-duration: 1h
   visa-and-passport-refresh-duration: 30m
+  authorization-change-event-topic-name: projects/${SERVICE_GOOGLE_PROJECT:broad-dsde-dev}/topics/ecm-events
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ externalcreds:
   background-job-interval-mins: 5
   token-validation-duration: 1h
   visa-and-passport-refresh-duration: 30m
+  # TODO: add the code to actually check and apply this
+  # TODO: May need to use profiles to get the pubsub topic conditionally
   # only enable google pubsub topic in live envs
   authorization-change-events-enabled: ${AUTHORIZATION_CHANGE_EVENTS_ENABLED:false}
   # name from: https://github.com/broadinstitute/terraform-ap-modules/blob/master/externalcreds/pubsub.tf

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -3,6 +3,7 @@ externalcreds:
   background-job-interval-mins: 5
   token-validation-duration: 1h
   visa-and-passport-refresh-duration: 30m
+  # name from: https://github.com/broadinstitute/terraform-ap-modules/blob/master/externalcreds/pubsub.tf
   authorization-change-event-topic-name: projects/${SERVICE_GOOGLE_PROJECT:broad-dsde-dev}/topics/ecm-events
 
 logging:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -3,8 +3,6 @@ externalcreds:
   background-job-interval-mins: 5
   token-validation-duration: 1h
   visa-and-passport-refresh-duration: 30m
-  # TODO: add the code to actually check and apply this
-  # TODO: May need to use profiles to get the pubsub topic conditionally
   # only enable google pubsub topic in live envs
   authorization-change-events-enabled: ${AUTHORIZATION_CHANGE_EVENTS_ENABLED:false}
   # name from: https://github.com/broadinstitute/terraform-ap-modules/blob/master/externalcreds/pubsub.tf

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -3,6 +3,8 @@ externalcreds:
   background-job-interval-mins: 5
   token-validation-duration: 1h
   visa-and-passport-refresh-duration: 30m
+  # only enable google pubsub topic in live envs
+  authorization-change-events-enabled: ${AUTHORIZATION_CHANGE_EVENTS_ENABLED:false}
   # name from: https://github.com/broadinstitute/terraform-ap-modules/blob/master/externalcreds/pubsub.tf
   authorization-change-event-topic-name: projects/${SERVICE_GOOGLE_PROJECT:broad-dsde-dev}/topics/ecm-events
 

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAOTest.java
@@ -9,7 +9,6 @@ import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.models.GA4GHVisa;
-import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.PassportVerificationDetails;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import java.sql.Timestamp;


### PR DESCRIPTION
This will conditionally pull the channel name into the event publisher unless you're running locally, which will set the publisher to `Optional.empty` so it doesn't break tests

related helm PR: https://github.com/broadinstitute/terra-helm/pull/505