### PR TITLE
choose any free port

### DIFF
--- a/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
@@ -38,7 +38,7 @@ public class JwtSigningTestUtils {
     accessTokenSigner = new RSASSASigner(accessTokenRsaJWK);
     documentTokenSigner = new RSASSASigner(documentTokenRsaJWK);
 
-    mockServer = ClientAndServer.startClientAndServer(50555);
+    mockServer = ClientAndServer.startClientAndServer();
 
     issuer = "http://localhost:" + mockServer.getPort();
     var wellKnownConfigMap = Map.of("issuer", issuer, "jwks_uri", issuer + JWKS_PATH);


### PR DESCRIPTION
I suspect an intermittent failure stems from reusing the same port in each test for a mock server. This change lets the mock server choose any free port.

suggest ignoring whitespace