### PR TITLE
Mock test configs [POL-91]

### DIFF
--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -403,10 +403,6 @@ public class ProviderServiceTest extends BaseTest {
       passportDAO.insertPassport(expiringPassport);
       passportDAO.insertPassport(notExpiringPassport);
 
-      // mock the configs
-      when(externalCredsConfigMock.getVisaAndPassportRefreshDuration())
-          .thenReturn(Duration.ofMinutes(30));
-
       // check that authAndRefreshPassport is called exactly once with the expiring linked account
       var providerServiceSpy = Mockito.spy(providerService);
       providerServiceSpy.refreshExpiringPassports();

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,5 +1,5 @@
+# Override the ECM config values for tests so unit tests won't be impacted by config changes
 externalcreds:
-  # 
   sam-base-path: http://localhost:1000/
   background-job-interval-mins: 5
   token-validation-duration: 1h

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+externalcreds:
+  sam-base-path: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
+  background-job-interval-mins: 5
+  token-validation-duration: 1h
+  visa-and-passport-refresh-duration: 30m
+  authorization-change-events-enabled: ${AUTHORIZATION_CHANGE_EVENTS_ENABLED:false}
+  authorization-change-event-topic-name: projects/${SERVICE_GOOGLE_PROJECT:broad-dsde-dev}/topics/ecm-events
+
+spring:
+  datasource:
+    password: ${DATABASE_USER_PASSWORD:ecmpwd}
+    url: jdbc:postgresql://${DATABASE_HOSTNAME:localhost}:5432/${DATABASE_NAME:ecm}
+    username: ${DATABASE_USER:ecmuser}
+
+terra.common:
+  tracing:
+    stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,10 +1,10 @@
 externalcreds:
-  sam-base-path: ${SAM_ADDRESS:https://sam.dsde-dev.broadinstitute.org}
+  # 
+  sam-base-path: http://localhost:1000/
   background-job-interval-mins: 5
   token-validation-duration: 1h
   visa-and-passport-refresh-duration: 30m
-  authorization-change-events-enabled: ${AUTHORIZATION_CHANGE_EVENTS_ENABLED:false}
-  authorization-change-event-topic-name: projects/${SERVICE_GOOGLE_PROJECT:broad-dsde-dev}/topics/ecm-events
+  authorization-change-events-enabled: false
 
 spring:
   datasource:
@@ -14,4 +14,4 @@ spring:
 
 terra.common:
   tracing:
-    stackdriverExportEnabled: ${CLOUD_TRACE_ENABLED:false}
+    stackdriverExportEnabled: false


### PR DESCRIPTION
I've been looking into test config mocking and came to a few conclusions:
1. It's not worth creating test utils for this because the config mocking is pretty simple to begin with. 
2. We often forget to mock the non-provider configs, so our unit tests often use the actual config values. To me, that seems like a weird dependency which could cause our tests could break when the config values are updated. 

The changes below create a separate set of configs which can be used by the tests. That way we don't need to remember to mock them every time they're relevant to a test.