### PR TITLE
fix npe in log message

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -306,7 +307,7 @@ public class ProviderService {
         Map.of(
             "linkedAccountId", visaDetails.getLinkedAccountId(),
             "providerName", visaDetails.getProviderName(),
-            "validationResponse", responseBody));
+            "validationResponse", Objects.requireNonNullElse(responseBody, "[null]")));
 
     var visaValid = "valid".equalsIgnoreCase(responseBody);
 


### PR DESCRIPTION
`Map.of` does not allow null values and `responseBody` in the changed code is nullable. Most likely this is the cause of [this error](https://console.cloud.google.com/logs/query;cursorTimestamp=2022-01-04T14:26:05.711Z;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22broad-dsde-dev%22%0Aresource.labels.location%3D%22us-central1-a%22%0Aresource.labels.cluster_name%3D%22terra-dev%22%0Aresource.labels.namespace_name%3D%22terra-dev%22%0Aresource.labels.container_name%3D%22externalcreds%22%0A-httpRequest.userAgent%3D%22kube-probe%2F1.20%2B%22%0A-httpRequest.userAgent%3D%22GoogleHC%2F1.0%22%0A-httpRequest.userAgent%3D%22GoogleStackdriverMonitoring-UptimeChecks%2528https:%2F%2Fcloud.google.com%2Fmonitoring%2529%22%0Atimestamp%3D%222022-01-04T14:21:05.881Z%22%0AinsertId%3D%228r7efhnb2o2l7exl%22;summaryFields=:false:32:beginning?project=broad-dsde-dev).