### PR TITLE
POL-151 don't return expired passports

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -100,7 +100,7 @@ paths:
       summary: Get the original passport from this provider
       tags: [ oidc ]
       operationId: getProviderPassport
-      description: Gets passport signed by provider, not Terra, containing only visas from provider
+      description: Gets passport signed by provider, not Terra, containing only visas from provider. Passport and visas should be valid.
       responses:
         '200':
           description: A JSON object


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/POL-151

This check could have been done in the DAO (i.e. sql where clause) but the DAO should be general purpose, without business logic.

This check could also have been done in the `PassportService` but that seemed like it would be unexpected. I can certainly envision other code in ECM that needs to get the passport, expired or not, that would be surprised by this condition.

So controller logic seemed most appropriate.