### PR TITLE
[POL-98] Part 1: Perf Test Suite Setup

### DIFF
--- a/integration/README.md
+++ b/integration/README.md
@@ -1,26 +1,26 @@
 # `integration` Project
 
-This Gradle project contains Test Runner integration tests for the External Credentials Manager. 
-    
+This Gradle project contains Test Runner integration tests for the External Credentials Manager.
+
 
 ### Adding New Tests
 
-1. Create a new script in the [test scripts directory](src/main/java/scripts/testscripts). 
+1. Create a new script in the [test scripts directory](src/main/java/scripts/testscripts).
 2. Add a reference to the test script in our FullIntegration test suite [here](src/main/resources/suites/FullIntegration.json).
-3. Debug the test locally using the instructions below. 
+3. Debug the test locally using the instructions below.
 
 
-### Running Integration Tests
+### Running Tests
 
-The test runner task `runTest` can be used to launch individual tests or entire test suites. 
+The test runner task `runTest` can be used to launch individual tests or entire test suites.
 
 To run the tests locally:
 
-1. Follow the initial setup instructions described in the [DEVELOPMENT.md](../DEVELOPMENT.md). 
+1. Follow the initial setup instructions described in the [DEVELOPMENT.md](../DEVELOPMENT.md).
 2. Run the `ExternalCredsApplication` (in IntelliJ).
 3. Then, run the integration tests in IntelliJ using the "Run local Integration" run configuration, or on the command line using the `runTest` command:
    - To run a test suite (ex. Full Integration suite):
-     `./gradlew runTest --args="suites/dev/FullIntegration.json /tmp/TR`
+     `./gradlew runTest --args="suites/FullIntegration.json /tmp/test-results"`
    - To run a single test (ex. Service Status test)
-     `./gradlew runTest --args="configs/integration/GetStatus.json /tmp/TR"`
+     `./gradlew runTest --args="suites/FullIntegration.json /tmp/test-results"`
    - To debug, add `--stacktrace`.

--- a/integration/README.md
+++ b/integration/README.md
@@ -22,5 +22,5 @@ To run the tests locally:
    - To run a test suite (ex. Full Integration suite):
      `./gradlew runTest --args="suites/FullIntegration.json /tmp/test-results"`
    - To run a single test (ex. Service Status test)
-     `./gradlew runTest --args="suites/FullIntegration.json /tmp/test-results"`
+     `./gradlew runTest --args="configs/integration/GetStatus.json /tmp/test-results"`
    - To debug, add `--stacktrace`.

--- a/integration/src/main/java/scripts/testscripts/ListProviders.java
+++ b/integration/src/main/java/scripts/testscripts/ListProviders.java
@@ -2,7 +2,6 @@ package scripts.testscripts;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.api.OidcApi;
 import bio.terra.testrunner.runner.TestScript;
@@ -29,6 +28,5 @@ public class ListProviders extends TestScript {
 
     // check the response body
     assertNotNull(providers);
-    assertTrue(providers.size() > 0);
   }
 }

--- a/integration/src/main/java/scripts/testscripts/ListProviders.java
+++ b/integration/src/main/java/scripts/testscripts/ListProviders.java
@@ -15,7 +15,7 @@ public class ListProviders extends TestScript {
 
   @Override
   public void userJourney(TestUserSpecification testUser) throws Exception {
-    log.info("Checking the version endpoint.");
+    log.info("Checking the list providers endpoint.");
     var apiClient = ClientTestUtils.getClientWithoutAccessToken(server);
     var oidcApi = new OidcApi(apiClient);
 
@@ -24,7 +24,7 @@ public class ListProviders extends TestScript {
     // check the response code
     var httpCode = oidcApi.getApiClient().getStatusCode();
     assertEquals(HttpStatusCodes.STATUS_CODE_OK, httpCode);
-    log.info("Service status return code: {}", httpCode);
+    log.info("List providers return code: {}", httpCode);
 
     // check the response body
     assertNotNull(providers);

--- a/integration/src/main/java/scripts/testscripts/ListProviders.java
+++ b/integration/src/main/java/scripts/testscripts/ListProviders.java
@@ -17,7 +17,6 @@ public class ListProviders extends TestScript {
   @Override
   public void userJourney(TestUserSpecification testUser) throws Exception {
     log.info("Checking the version endpoint.");
-    // TODO: figure out why this passes without authentication
     var apiClient = ClientTestUtils.getClientWithoutAccessToken(server);
     var oidcApi = new OidcApi(apiClient);
 

--- a/integration/src/main/java/scripts/testscripts/ListProviders.java
+++ b/integration/src/main/java/scripts/testscripts/ListProviders.java
@@ -1,0 +1,35 @@
+package scripts.testscripts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.externalcreds.api.OidcApi;
+import bio.terra.testrunner.runner.TestScript;
+import bio.terra.testrunner.runner.config.TestUserSpecification;
+import com.google.api.client.http.HttpStatusCodes;
+import lombok.extern.slf4j.Slf4j;
+import scripts.utils.ClientTestUtils;
+
+@Slf4j
+public class ListProviders extends TestScript {
+
+  @Override
+  public void userJourney(TestUserSpecification testUser) throws Exception {
+    log.info("Checking the version endpoint.");
+    // TODO: figure out why this passes without authentication
+    var apiClient = ClientTestUtils.getClientWithoutAccessToken(server);
+    var oidcApi = new OidcApi(apiClient);
+
+    var providers = oidcApi.listProviders();
+
+    // check the response code
+    var httpCode = oidcApi.getApiClient().getStatusCode();
+    assertEquals(HttpStatusCodes.STATUS_CODE_OK, httpCode);
+    log.info("Service status return code: {}", httpCode);
+
+    // check the response body
+    assertNotNull(providers);
+    assertTrue(providers.size() > 0);
+  }
+}

--- a/integration/src/main/resources/configs/integration/ListProviders.json
+++ b/integration/src/main/resources/configs/integration/ListProviders.json
@@ -1,0 +1,17 @@
+{
+  "name": "ListProviders",
+  "description": "Lists the available OIDC providers. Authentication required.",
+  "serverSpecificationFile": "ecm-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ListProviders",
+      "numberOfUserJourneyThreadsToRun": 1,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": []
+}

--- a/integration/src/main/resources/configs/perf/GetStatus.json
+++ b/integration/src/main/resources/configs/perf/GetStatus.json
@@ -1,0 +1,17 @@
+{
+  "name": "GetStatus",
+  "description": "Check the service status once. No authentication required.",
+  "serverSpecificationFile": "ecm-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "GetStatus",
+      "numberOfUserJourneyThreadsToRun": 10,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": []
+}

--- a/integration/src/main/resources/configs/perf/GetVersion.json
+++ b/integration/src/main/resources/configs/perf/GetVersion.json
@@ -1,0 +1,17 @@
+{
+  "name": "GetVersion",
+  "description": "Check the version endpoint once. No authentication required.",
+  "serverSpecificationFile": "ecm-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "GetVersion",
+      "numberOfUserJourneyThreadsToRun": 10,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": []
+}

--- a/integration/src/main/resources/configs/perf/ListProviders.json
+++ b/integration/src/main/resources/configs/perf/ListProviders.json
@@ -1,6 +1,6 @@
 {
   "name": "ListProviders",
-  "description": "Lists the available OIDC providers. Authentication required.",
+  "description": "Lists the available OIDC providers.",
   "serverSpecificationFile": "ecm-local.json",
   "kubernetes": {},
   "application": {},

--- a/integration/src/main/resources/configs/perf/ListProviders.json
+++ b/integration/src/main/resources/configs/perf/ListProviders.json
@@ -1,0 +1,17 @@
+{
+  "name": "ListProviders",
+  "description": "Lists the available OIDC providers. Authentication required.",
+  "serverSpecificationFile": "ecm-local.json",
+  "kubernetes": {},
+  "application": {},
+  "testScripts": [
+    {
+      "name": "ListProviders",
+      "numberOfUserJourneyThreadsToRun": 10,
+      "userJourneyThreadPoolSize": 2,
+      "expectedTimeForEach": 5,
+      "expectedTimeForEachUnit": "SECONDS"
+    }
+  ],
+  "testUserFiles": []
+}

--- a/integration/src/main/resources/suites/FullIntegration.json
+++ b/integration/src/main/resources/suites/FullIntegration.json
@@ -4,7 +4,8 @@
   "serverSpecificationFile": "ecm-local.json",
   "testConfigurationFiles": [
     "integration/GetStatus.json",
-    "integration/GetVersion.json"
+    "integration/GetVersion.json",
+    "integration/ListProviders.json"
   ]
 }
 

--- a/integration/src/main/resources/suites/FullPerf.json
+++ b/integration/src/main/resources/suites/FullPerf.json
@@ -1,0 +1,10 @@
+{
+  "name": "FullPerf",
+  "description": "All perf tests",
+  "serverSpecificationFile": "ecm-local.json",
+  "testConfigurationFiles": [
+    "perf/GetStatus.json",
+    "perf/GetVersion.json",
+    "perf/ListProviders.json"
+  ]
+}


### PR DESCRIPTION
Setting up a performance test suite that runs locally, which includes the following changes:
- Adding a `ListProviders` test. This is the only other endpoint that's straightforward to test so I figured it might as well be included.
- Adding a config for each individual perf test. These are identical to the integration test configs, except that they run the test 10 times instead of once (yes it's a lot of copy and pasting, but that seems to be what test runner requires).
- Adding a `FullPerf` test suite, which just lists all of the configs we consider part of the full perf test