### PR TITLE
POL-137 add version to logging service context

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -19,7 +19,10 @@ server:
   port: 8080
 
 spring:
+  # application name and version are used to populate the logging serviceContext
+  # https://github.com/DataBiosphere/terra-common-lib/blob/480ab3daae282ddff0fef8dc329494a4422e32f1/src/main/java/bio/terra/common/logging/GoogleJsonLayout.java#L118
   application.name: externalcreds
+  application.version: ${externalcreds.version.gitHash:unknown}
 
   config.import: optional:classpath:rendered/providers.yaml;classpath:rendered/version.properties;classpath:rendered/allowed_jwks.yaml
 


### PR DESCRIPTION
Here is a log message from a recent error:
```
{
  "insertId": "sm2kx601s51e445x",
  "jsonPayload": {
    "thread": "scheduling-1",
    "context": "default",
    "serviceContext": {
      "version": null,
      "service": "externalcreds"
    },
    "logger": "org.springframework.scheduling.support.TaskUtils$LoggingErrorHandler",
    "message": "Unexpected error occurred in scheduled task\njava.lang.NullPointerException: null\n\tat java.base/java.util.Objects.requireNonNull(Unknown Source)\n\tat java.base/java.util.ImmutableCollections$MapN.<init>(Unknown Source)\n\tat java.base/java.util.Map.of(Unknown Source)\n\tat bio.terra.externalcreds.services.ProviderService.validateVisaWithProvider(ProviderService.java:306)\n\tat bio.terra.externalcreds.services.ProviderService.lambda$validateAccessTokenVisas$3(ProviderService.java:196)\n\tat java.base/java.util.stream.ReferencePipeline$7$1.accept(Unknown Source)\n\tat java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(Unknown Source)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(Unknown Source)\n\tat java.base/java.util.stream.ReferencePipeline.forEach(Unknown Source)\n\tat bio.terra.externalcreds.services.ProviderService.validateAccessTokenVisas(ProviderService.java:201)\n\tat bio.terra.externalcreds.ExternalCredsCronApplication.checkForExpiringCredentials(ExternalCredsCronApplication.java:53)\n\tat jdk.internal.reflect.GeneratedMethodAccessor191.invoke(Unknown Source)\n\tat java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)\n\tat java.base/java.lang.reflect.Method.invoke(Unknown Source)\n\tat org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:84)\n\tat org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)\n\tat java.base/java.util.concurrent.FutureTask.runAndReset(Unknown Source)\n\tat java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)\n\tat java.base/java.lang.Thread.run(Unknown Source)\n"
  },
  "resource": {
    "type": "k8s_container",
    "labels": {
      "container_name": "externalcreds",
      "pod_name": "externalcreds-backend-deployment-7c6548c677-82fmk",
      "namespace_name": "terra-dev",
      "cluster_name": "terra-dev",
      "location": "us-central1-a",
      "project_id": "broad-dsde-dev"
    }
  },
  "timestamp": "2022-01-04T16:51:05.773Z",
  "severity": "ERROR",
  "labels": {
    "k8s-pod/app_kubernetes_io/part-of": "terra",
    "k8s-pod/app_kubernetes_io/component": "externalcreds",
    "compute.googleapis.com/resource_name": "gke-terra-dev-default-v3-97df8767-lfmw",
    "k8s-pod/app_kubernetes_io/instance": "externalcreds",
    "k8s-pod/helm_sh/chart": "externalcreds-0.62.0",
    "k8s-pod/deployment": "externalcreds-backend-deployment",
    "k8s-pod/pod-template-hash": "7c6548c677",
    "k8s-pod/app_kubernetes_io/managed-by": "Helm",
    "k8s-pod/app_kubernetes_io/name": "externalcreds"
  },
  "logName": "projects/broad-dsde-dev/logs/stdout",
  "sourceLocation": {
    "file": "org/springframework/scheduling/support/TaskUtils.java",
    "line": "95",
    "function": "org.springframework.scheduling.support.TaskUtils$LoggingErrorHandler.handleError"
  },
  "receiveTimestamp": "2022-01-04T16:51:12.293036706Z"
}
```
Notice that `serviceContext.version` is null. This PR populates that with the git hash.