### PR TITLE
[POL-156] Generate data for performance tests

### DIFF
--- a/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
@@ -1,16 +1,35 @@
+-- This function inserts a semi-random linked account and passport with
+-- the given user_id and external_user_id
+CREATE PROCEDURE insert_test_record(user_id text, external_user_id text)  
+LANGUAGE SQL 
+AS $$ 
+    -- Insert a linked account with the given values
+    INSERT INTO linked_account 
+    (id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
+    VALUES (
+        nextval('linked_account_id_seq'), 
+        user_id, 
+        'ras', 
+        'testToken', 
+        current_timestamp + interval '3000 year', 
+        external_user_id, 
+        true
+    );
+    -- Insert a corresponding passport
+        INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
+        VALUES (
+            currval('linked_account_id_seq'), 
+            'testJwt', 
+            current_timestamp + interval '3000 year'
+        );
+$$;  
+
 
 -- delete all of the existing data
 TRUNCATE linked_account, ga4gh_passport, ga4gh_visa;
 
 -- Insert Linked Accounts and Passports for specific users that already exist in SAM
-INSERT INTO linked_account 
-(id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
-VALUES
-(nextval(pg_get_serial_sequence('linked_account','id')), '114925642006220098835', 'ras', 'testToken', current_timestamp + interval '3000 year', 'Scarlett.Flowerpicker@test.firecloud.org', true);
-
-INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
-VALUES 
-(currval(pg_get_serial_sequence('linked_account','id')), 'testJwt', current_timestamp + interval '3000 year');
+CALL insert_test_record('114925642006220098835', 'Scarlett.Flowerpicker@test.firecloud.org');
 
 -- Insert semi-randomized records
 do $$
@@ -18,32 +37,15 @@ declare
     counter integer := 0;
 begin
     while counter < 10000 loop
-        -- Insert a linked account with a random user_id
-        INSERT INTO linked_account 
-        (id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
-        VALUES (
-            nextval(pg_get_serial_sequence('linked_account','id')), 
-            substr(md5(random()::text), 0, 25), 
-            'ras', 
-            'testToken', 
-            current_timestamp + interval '3000 year', 
-            'testExternalUserId', 
-            true
-            );
-
-        -- Insert a corresponding passport
-        INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
-        VALUES (
-            currval(pg_get_serial_sequence('linked_account','id')), 
-            'testJwt', 
-            current_timestamp + interval '3000 year'
-        );
-	  
+        -- Insert a record with a random user id 
+        CALL insert_test_record(substr(md5(random()::text), 0, 25), 'testExternalUserId');
         counter := counter + 1;
    end loop;
 end$$;
 
--- TODO: decide if visas should be generated as well
+
+DROP PROCEDURE insert_test_record(text, text);
+
 -- TODO: determine how the db is indexed - does the order of insertion matter here?
--- TODO: try making a function which inserts a LA & Passport given a user_id and external_user_id (so there's less duplicate code)
--- TODO: make sure while loop actually works
+-- TODO: see if there's a way to improve the readibility of the function or select * syntax
+-- TODO: decide if we want to have more than one authed user

--- a/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
@@ -28,9 +28,6 @@ $$;
 -- delete all of the existing data
 TRUNCATE linked_account, ga4gh_passport, ga4gh_visa;
 
--- Insert Linked Accounts and Passports for specific users that already exist in SAM
-CALL insert_test_record('114925642006220098835', 'Scarlett.Flowerpicker@test.firecloud.org');
-
 -- Insert semi-randomized records
 do $$
 declare 
@@ -43,9 +40,8 @@ begin
    end loop;
 end$$;
 
+-- Insert Linked Accounts and Passports for specific users that already exist in SAM
+CALL insert_test_record('114925642006220098835', 'Scarlett.Flowerpicker@test.firecloud.org');
+
 
 DROP PROCEDURE insert_test_record(text, text);
-
--- TODO: determine how the db is indexed - does the order of insertion matter here?
--- TODO: see if there's a way to improve the readibility of the function or select * syntax
--- TODO: decide if we want to have more than one authed user

--- a/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
@@ -1,0 +1,49 @@
+
+-- delete all of the existing data
+TRUNCATE linked_account, ga4gh_passport, ga4gh_visa;
+
+-- Insert Linked Accounts and Passports for specific users that already exist in SAM
+INSERT INTO linked_account 
+(id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
+VALUES
+(nextval(pg_get_serial_sequence('linked_account','id')), '114925642006220098835', 'ras', 'testToken', current_timestamp + interval '3000 year', 'Scarlett.Flowerpicker@test.firecloud.org', true);
+
+INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
+VALUES 
+(currval(pg_get_serial_sequence('linked_account','id')), 'testJwt', current_timestamp + interval '3000 year');
+
+-- Insert semi-randomized records
+do $$
+declare 
+    counter integer := 0;
+begin
+    while counter < 10000 loop
+        -- Insert a linked account with a random user_id
+        INSERT INTO linked_account 
+        (id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
+        VALUES (
+            nextval(pg_get_serial_sequence('linked_account','id')), 
+            substr(md5(random()::text), 0, 25), 
+            'ras', 
+            'testToken', 
+            current_timestamp + interval '3000 year', 
+            'testExternalUserId', 
+            true
+            );
+
+        -- Insert a corresponding passport
+        INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
+        VALUES (
+            currval(pg_get_serial_sequence('linked_account','id')), 
+            'testJwt', 
+            current_timestamp + interval '3000 year'
+        );
+	  
+        counter := counter + 1;
+   end loop;
+end$$;
+
+-- TODO: decide if visas should be generated as well
+-- TODO: determine how the db is indexed - does the order of insertion matter here?
+-- TODO: try making a function which inserts a LA & Passport given a user_id and external_user_id (so there's less duplicate code)
+-- TODO: make sure while loop actually works

--- a/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
@@ -1,5 +1,3 @@
--- TODO: test out and debug again
-
 -- Generate a random string of the correct length (to stand in for the JWTs)
 CREATE FUNCTION generate_random_string(approximate_length int) RETURNS text 
 LANGUAGE SQL AS $$

--- a/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/java/scripts/datageneration/regenerate_perf_data.sql
@@ -1,28 +1,28 @@
 -- This function inserts a semi-random linked account and passport with
 -- the given user_id and external_user_id
-CREATE PROCEDURE insert_test_record(user_id text, external_user_id text)  
-LANGUAGE SQL 
-AS $$ 
-    -- Insert a linked account with the given values
-    INSERT INTO linked_account 
-    (id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
-    VALUES (
-        nextval('linked_account_id_seq'), 
-        user_id, 
-        'ras', 
-        'testToken', 
-        current_timestamp + interval '3000 year', 
-        external_user_id, 
-        true
-    );
-    -- Insert a corresponding passport
-        INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
-        VALUES (
-            currval('linked_account_id_seq'), 
-            'testJwt', 
-            current_timestamp + interval '3000 year'
-        );
-$$;  
+CREATE PROCEDURE insert_test_record(user_id text, external_user_id text)
+LANGUAGE SQL
+AS $$
+  -- Insert a linked account with the given values
+  INSERT INTO linked_account
+  (id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
+  VALUES (
+    nextval('linked_account_id_seq'),
+    user_id,
+    'ras',
+    'testToken',
+    current_timestamp + interval '3000 year',
+    external_user_id,
+    true
+  );
+  -- Insert a corresponding passport
+  INSERT INTO ga4gh_passport (linked_account_id, jwt, expires)
+  VALUES (
+    currval('linked_account_id_seq'),
+    'testJwt',
+    current_timestamp + interval '3000 year'
+  );
+$$;
 
 
 -- delete all of the existing data
@@ -30,14 +30,14 @@ TRUNCATE linked_account, ga4gh_passport, ga4gh_visa;
 
 -- Insert semi-randomized records
 do $$
-declare 
-    counter integer := 0;
+declare
+  counter integer := 0;
 begin
-    while counter < 10000 loop
-        -- Insert a record with a random user id 
-        CALL insert_test_record(substr(md5(random()::text), 0, 25), 'testExternalUserId');
-        counter := counter + 1;
-   end loop;
+  while counter < 10000 loop
+    -- Insert a record with a random user id
+    CALL insert_test_record(substr(md5(random()::text), 0, 25), 'testExternalUserId');
+    counter := counter + 1;
+  end loop;
 end$$;
 
 -- Insert Linked Accounts and Passports for specific users that already exist in SAM


### PR DESCRIPTION
This script does the following:
- Deletes all of the existing rows from the database
- Inserts 10,000 linked accounts and passports, each with a random user id
- Inserts a linked account and passport for the `Scarlett.Flowerpicker@test.firecloud.org` testUser (which is already set up in Sam).


It can be run on the perf db by using the existing psql-connect script ([link here](https://github.com/broadinstitute/dsp-scripts/blob/master/firecloud/psql-connect.sh)).