### PR TITLE
PF-1382: Define API for ssh key storing

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -161,7 +161,7 @@ paths:
           $ref: '#/components/responses/ServerError'
     put:
       summary: Store an ssh key pair to the given provider.
-      tags: [ssh key pair]
+      tags: [ ssh key pair ]
       operationId: putSshKeyPair
       requestBody:
         content:
@@ -282,12 +282,12 @@ components:
       description: Enum containing valid ssh key types.
       type: string
       enum:
-        - GITHUB
-        - GITLAB
-        - AZURE
+        - github
+        - gitlab
+        - azure
     SshKeyPair:
       type: object
-      required: [privateKey, publicKey, externalUserEmail]
+      required: [ privateKey, publicKey, externalUserEmail ]
       properties:
         privateKey:
           type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -145,9 +145,9 @@ paths:
           description: "Version not configured"
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/secrets/sshkeys/v1/{provider}:
+  /api/sshkey/v1/{sshkey_type}:
     parameters:
-      - $ref: '#/components/parameters/sshkeyProviderParam'
+      - $ref: '#/components/parameters/sshKeyProviderParam'
     get:
       summary: Get the ssh key of the given provider.
       tags: [ ssh_key ]
@@ -155,13 +155,11 @@ paths:
       responses:
         '200':
           $ref: '#/components/responses/SshKeyResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-    post:
+    put:
       summary: Store an ssh key to the given provider.
       tags: [ssh_key]
       operationId: storeSshKey
@@ -175,8 +173,6 @@ paths:
           description: Successfully stored the ssh key.
         '400':
           $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
         '409':
           $ref: '#/components/responses/Conflict'
         '500':
@@ -188,27 +184,6 @@ paths:
       responses:
         '204':
           description: Deletes the ssh key.
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
-        '404':
-          $ref: '#/components/responses/NotFound'
-        '500':
-          $ref: '#/components/responses/ServerError'
-    patch:
-      summary: update the ssh key of the given provider
-      tags: [ ssh_key ]
-      operationId: updateSshKey
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/UpdateSshKeyRequestBody'
-      responses:
-        '200':
-          $ref: '#/components/responses/SshKeyResponse'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -216,12 +191,11 @@ paths:
 
 components:
   parameters:
-    sshkeyProviderParam:
-      name: provider
+    sshKeyProviderParam:
+      name: sshkey_type
       in: path
       schema:
         $ref: '#/components/schemas/SshKeyType'
-      example: ["GITHUB", "GITLAB", "AZURE"]
       required: true
     providerParam:
       name: provider
@@ -281,7 +255,7 @@ components:
     SshKeyResponse:
       description: A JSON object of the ssh key.
       content:
-        multipart/form-data:
+        application/json:
           schema:
             $ref: '#/components/schemas/SshKeyInfo'
 
@@ -327,37 +301,16 @@ components:
         - AZURE
     SshKeyInfo:
       type: object
-      required: [key]
+      required: [key, externalUserEmail]
       properties:
-        name:
-          type: string
-        description:
-          type: string
         key:
           type: string
           format: byte
           description: Base64-encoded contents of the key
-        externalUserName:
-          description: account name
-          type: string
         externalUserEmail:
           description: account email.
           type: string
 
-    UpdateSshKeyRequestBody:
-      type: object
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        externalUserName:
-          type: string
-        externalUserEmail:
-          type: string
-        key:
-          description: ssh private key
-          type: string
     LinkInfo:
       type: object
       required: [ externalUserId, expirationTimestamp ]

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -165,7 +165,7 @@ paths:
       operationId: putSshKeyPair
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
               $ref: '#/components/schemas/SshKeyPair'
       responses:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -165,7 +165,7 @@ paths:
       operationId: putSshKeyPair
       requestBody:
         content:
-          application/json:
+          multipart/form-data:
             schema:
               $ref: '#/components/schemas/SshKeyPair'
       responses:
@@ -291,12 +291,10 @@ components:
       properties:
         privateKey:
           type: string
-          format: byte
-          description: Base64-encoded contents of the private ssh key
+          description: private ssh key
         publicKey:
           type: string
-          format: byte
-          description: Base64-encoded contents of the public ssh key
+          description: public ssh key
         externalUserEmail:
           description: account email.
           type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -145,6 +145,89 @@ paths:
           description: "Version not configured"
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/secrets/sshkeys:
+    get:
+      summary: Enumerate all the ssh keys stored for the user.
+      tags: [ ssh_key ]
+      operationId: enumerateSshKeys
+      responses:
+        '200':
+          description: A JSON array of ssh keys providers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GitHubSshKey'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/secrets/sshkeys/github:
+    get:
+      summary: Get the ssh key of the linked github account.
+      tags: [ ssh_key ]
+      operationId: getGitHubSshKey
+      responses:
+        '200':
+          $ref: '#components/responses/GitHubSshKeyResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      summary: Store an ssh key to link a github account
+      tags: [ssh_key]
+      operationId: storeGitHubSshKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddGitHubSshKeyRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/GitHubSshKeyResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '409':
+          $ref: '#/components/responses/Conflict'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      summary: delete the github ssh key
+      tags: [ ssh_key ]
+      operationId: deleteGitHubSshKey
+      responses:
+        '204':
+          description: Deletes the GitHub ssh key.
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    patch:
+      summary: update the github ssh key
+      tags: [ ssh_key ]
+      operationId: updateGitHubSshKey
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGitHubSshKeyRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/GitHubSshKeyResponse'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
 
 components:
   parameters:
@@ -203,6 +286,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SystemStatus'
+    GitHubSshKeyResponse:
+      description: A JSON object of the github ssh key.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/GitHubSshKey'
 
     # Error Responses
     BadRequest:
@@ -229,8 +318,81 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorReport'
+    Conflict:
+      description: Conflict
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorReport'
 
   schemas:
+    GitHubSshKeyAttributes:
+      type: object
+      required: [key]
+      properties:
+        key:
+          description: private ssh key for the gitHub account.
+          type: string
+        accountName:
+          description: GitHub account name
+          type: string
+        accountEmail:
+          description: GitHub account email.
+          type: string
+
+    SshKeyType:
+      description: Enum containing valid secret types.
+      type: string
+      enum:
+        - GitHub
+        - GitLab
+        - AzureDevOp
+    SshKeyMetadata:
+      type: object
+      required: [name, keyType]
+      properties:
+        name:
+          type:  string
+        description:
+          type: string
+        keyType:
+          $ref: '#/components/schemas/SshKeyType'
+        id:
+          type: string
+          format: uuid
+    SecretAddRequestCommonFields:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+    GitHubSshKey:
+      type: object
+      required: [metadata, attributes]
+      properties:
+        metadata:
+          $ref: '#/components/schemas/SshKeyMetadata'
+        attributes:
+          $ref: '#/components/schemas/GitHubSshKeyAttributes'
+    AddGitHubSshKeyRequestBody:
+      type: object
+      required: [metadata, attributes]
+      properties:
+        metadata:
+          $ref: '#/components/schemas/SecretAddRequestCommonFields'
+        attributes:
+          $ref: '#/components/schemas/GitHubSshKeyAttributes'
+    UpdateGitHubSshKeyRequestBody:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        attributes:
+          $ref: '#/components/schemas/GitHubSshKeyAttributes'
     LinkInfo:
       type: object
       required: [ externalUserId, expirationTimestamp ]

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -169,24 +169,7 @@ paths:
         content:
           multipart/form-data:
             schema:
-              title: storeSshKeyRequest
-              type: object
-              required: [ key, type ]
-              properties:
-                name:
-                  type: string
-                description:
-                  type: string
-                key:
-                  type: string
-                  format: byte
-                  description: Base64-encoded contents of the key
-                externalUserName:
-                  description: account name
-                  type: string
-                externalUserEmail:
-                  description: account email.
-                  type: string
+              $ref: '#/components/schemas/SshKeyInfo'
       responses:
         '204':
           description: Successfully stored the ssh key.
@@ -344,7 +327,7 @@ components:
         - AZURE
     SshKeyInfo:
       type: object
-      required: [key, type]
+      required: [key]
       properties:
         name:
           type: string
@@ -354,8 +337,6 @@ components:
           type: string
           format: byte
           description: Base64-encoded contents of the key
-        type:
-          $ref: '#/components/schemas/SshKeyType'
         externalUserName:
           description: account name
           type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -154,7 +154,7 @@ paths:
       operationId: getSshKey
       responses:
         '200':
-          $ref: '#components/responses/SshKeyResponse'
+          $ref: '#/components/responses/SshKeyResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -172,21 +172,14 @@ paths:
               required: [key]
               type: object
               properties:
-                name:
-                  type: string
-                description:
-                  type: string
                 key:
                   type: string
-                  format: base64
-                externalAccountName:
-                  type: string
-                externalAccountEmail:
-                  type: string
-
+                  format: byte
+                keyInfo:
+                  $ref: '#/components/schemas/SshKeyCommonFields'
       responses:
-        '200':
-          $ref: '#/components/responses/SshKeyResponse'
+        '204':
+          description: Successfully stored the ssh key.
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -295,9 +288,17 @@ components:
     SshKeyResponse:
       description: A JSON object of the ssh key.
       content:
-        application/json:
+        multipart/form-data:
           schema:
-            $ref: '#/components/schemas/SshKeyInfo'
+            type: object
+            title: sshkey
+            properties:
+              keyInfo:
+                $ref: '#/components/schemas/SshKeyCommonFields'
+              key:
+                type: string
+                format: byte
+                description: Base64-encoded contents of the key
 
     # Error Responses
     BadRequest:
@@ -339,9 +340,9 @@ components:
         - GITHUB
         - GITLAB
         - AZURE
-    SshKeyInfo:
+    SshKeyCommonFields:
       type: object
-      required: [type, key]
+      required: [type]
       properties:
         name:
           type: string
@@ -349,9 +350,6 @@ components:
           type: string
         type:
           $ref: '#/components/schemas/SshKeyType'
-        key:
-          type: string
-          format: byte
         externalUserName:
           description: account name
           type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -169,14 +169,24 @@ paths:
         content:
           multipart/form-data:
             schema:
-              required: [key]
+              title: storeSshKeyRequest
               type: object
+              required: [ key, type ]
               properties:
+                name:
+                  type: string
+                description:
+                  type: string
                 key:
                   type: string
                   format: byte
-                keyInfo:
-                  $ref: '#/components/schemas/SshKeyCommonFields'
+                  description: Base64-encoded contents of the key
+                externalUserName:
+                  description: account name
+                  type: string
+                externalUserEmail:
+                  description: account email.
+                  type: string
       responses:
         '204':
           description: Successfully stored the ssh key.
@@ -290,15 +300,7 @@ components:
       content:
         multipart/form-data:
           schema:
-            type: object
-            title: sshkey
-            properties:
-              keyInfo:
-                $ref: '#/components/schemas/SshKeyCommonFields'
-              key:
-                type: string
-                format: byte
-                description: Base64-encoded contents of the key
+            $ref: '#/components/schemas/SshKeyInfo'
 
     # Error Responses
     BadRequest:
@@ -340,14 +342,18 @@ components:
         - GITHUB
         - GITLAB
         - AZURE
-    SshKeyCommonFields:
+    SshKeyInfo:
       type: object
-      required: [type]
+      required: [key, type]
       properties:
         name:
           type: string
         description:
           type: string
+        key:
+          type: string
+          format: byte
+          description: Base64-encoded contents of the key
         type:
           $ref: '#/components/schemas/SshKeyType'
         externalUserName:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -145,32 +145,32 @@ paths:
           description: "Version not configured"
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/sshkey/v1/{sshkey_type}:
+  /api/sshkeypair/v1/{sshkey_type}:
     parameters:
       - $ref: '#/components/parameters/sshKeyProviderParam'
     get:
-      summary: Get the ssh key of the given provider.
+      summary: Get the ssh key pair of the given provider.
       tags: [ ssh_key ]
-      operationId: getSshKey
+      operationId: getSshKeyPair
       responses:
         '200':
-          $ref: '#/components/responses/SshKeyResponse'
+          $ref: '#/components/responses/SshKeyPairResponse'
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
     put:
-      summary: Store an ssh key to the given provider.
+      summary: Store an ssh key pair to the given provider.
       tags: [ssh_key]
-      operationId: storeSshKey
+      operationId: storeSshKeyPair
       requestBody:
         content:
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/SshKeyInfo'
+              $ref: '#/components/schemas/SshKeyPairInfo'
       responses:
         '204':
-          description: Successfully stored the ssh key.
+          description: Successfully stored the ssh key pair.
         '400':
           $ref: '#/components/responses/BadRequest'
         '409':
@@ -178,12 +178,12 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
-      summary: delete the ssh key of the given provider
+      summary: delete the ssh key pair of the given provider
       tags: [ ssh_key ]
-      operationId: deleteSshKey
+      operationId: deleteSshKeyPair
       responses:
         '204':
-          description: Deletes the ssh key.
+          description: Deletes the ssh key pair.
         '404':
           $ref: '#/components/responses/NotFound'
         '500':
@@ -252,12 +252,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SystemStatus'
-    SshKeyResponse:
+    SshKeyPairResponse:
       description: A JSON object of the ssh key.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/SshKeyInfo'
+            $ref: '#/components/schemas/SshKeyPairInfo'
 
     # Error Responses
     BadRequest:
@@ -299,14 +299,18 @@ components:
         - GITHUB
         - GITLAB
         - AZURE
-    SshKeyInfo:
+    SshKeyPairInfo:
       type: object
-      required: [key, externalUserEmail]
+      required: [privateKey, publicKey, externalUserEmail]
       properties:
-        key:
+        privateKey:
           type: string
           format: byte
-          description: Base64-encoded contents of the key
+          description: Base64-encoded contents of the private ssh key
+        publicKey:
+          type: string
+          format: byte
+          description: Base64-encoded contents of the public ssh key
         externalUserEmail:
           description: account email.
           type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -145,30 +145,16 @@ paths:
           description: "Version not configured"
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/secrets/sshkeys:
+  /api/secrets/sshkeys/v1/{provider}:
+    parameters:
+      - $ref: '#/components/parameters/sshkeyProviderParam'
     get:
-      summary: Enumerate all the ssh keys stored for the user.
+      summary: Get the ssh key of the given provider.
       tags: [ ssh_key ]
-      operationId: enumerateSshKeys
+      operationId: getSshKey
       responses:
         '200':
-          description: A JSON array of ssh keys providers
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/GitHubSshKey'
-        '500':
-          $ref: '#/components/responses/ServerError'
-  /api/secrets/sshkeys/github:
-    get:
-      summary: Get the ssh key of the linked github account.
-      tags: [ ssh_key ]
-      operationId: getGitHubSshKey
-      responses:
-        '200':
-          $ref: '#components/responses/GitHubSshKeyResponse'
+          $ref: '#components/responses/SshKeyResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -176,18 +162,31 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     post:
-      summary: Store an ssh key to link a github account
+      summary: Store an ssh key to the given provider.
       tags: [ssh_key]
-      operationId: storeGitHubSshKey
+      operationId: storeSshKey
       requestBody:
-        required: true
         content:
-          application/json:
+          multipart/form-data:
             schema:
-              $ref: '#/components/schemas/AddGitHubSshKeyRequestBody'
+              required: [key]
+              type: object
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                key:
+                  type: string
+                  format: base64
+                externalAccountName:
+                  type: string
+                externalAccountEmail:
+                  type: string
+
       responses:
         '200':
-          $ref: '#/components/responses/GitHubSshKeyResponse'
+          $ref: '#/components/responses/SshKeyResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -197,12 +196,12 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
-      summary: delete the github ssh key
+      summary: delete the ssh key of the given provider
       tags: [ ssh_key ]
-      operationId: deleteGitHubSshKey
+      operationId: deleteSshKey
       responses:
         '204':
-          description: Deletes the GitHub ssh key.
+          description: Deletes the ssh key.
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -210,18 +209,18 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     patch:
-      summary: update the github ssh key
+      summary: update the ssh key of the given provider
       tags: [ ssh_key ]
-      operationId: updateGitHubSshKey
+      operationId: updateSshKey
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/UpdateGitHubSshKeyRequestBody'
+              $ref: '#/components/schemas/UpdateSshKeyRequestBody'
       responses:
         '200':
-          $ref: '#/components/responses/GitHubSshKeyResponse'
+          $ref: '#/components/responses/SshKeyResponse'
         '403':
           $ref: '#/components/responses/PermissionDenied'
         '404':
@@ -231,6 +230,13 @@ paths:
 
 components:
   parameters:
+    sshkeyProviderParam:
+      name: provider
+      in: path
+      schema:
+        $ref: '#/components/schemas/SshKeyType'
+      example: ["GITHUB", "GITLAB", "AZURE"]
+      required: true
     providerParam:
       name: provider
       in: path
@@ -286,12 +292,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/SystemStatus'
-    GitHubSshKeyResponse:
-      description: A JSON object of the github ssh key.
+    SshKeyResponse:
+      description: A JSON object of the ssh key.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GitHubSshKey'
+            $ref: '#/components/schemas/SshKeyInfo'
 
     # Error Responses
     BadRequest:
@@ -326,73 +332,47 @@ components:
             $ref: '#/components/schemas/ErrorReport'
 
   schemas:
-    GitHubSshKeyAttributes:
-      type: object
-      required: [key]
-      properties:
-        key:
-          description: private ssh key for the gitHub account.
-          type: string
-        accountName:
-          description: GitHub account name
-          type: string
-        accountEmail:
-          description: GitHub account email.
-          type: string
-
     SshKeyType:
-      description: Enum containing valid secret types.
+      description: Enum containing valid ssh key types.
       type: string
       enum:
-        - GitHub
-        - GitLab
-        - AzureDevOp
-    SshKeyMetadata:
+        - GITHUB
+        - GITLAB
+        - AZURE
+    SshKeyInfo:
       type: object
-      required: [name, keyType]
+      required: [type, key]
       properties:
         name:
-          type:  string
+          type: string
         description:
           type: string
-        keyType:
+        type:
           $ref: '#/components/schemas/SshKeyType'
-        id:
+        key:
           type: string
-          format: uuid
-    SecretAddRequestCommonFields:
-      type: object
-      required: [name]
-      properties:
-        name:
+          format: byte
+        externalUserName:
+          description: account name
           type: string
-        description:
+        externalUserEmail:
+          description: account email.
           type: string
-    GitHubSshKey:
-      type: object
-      required: [metadata, attributes]
-      properties:
-        metadata:
-          $ref: '#/components/schemas/SshKeyMetadata'
-        attributes:
-          $ref: '#/components/schemas/GitHubSshKeyAttributes'
-    AddGitHubSshKeyRequestBody:
-      type: object
-      required: [metadata, attributes]
-      properties:
-        metadata:
-          $ref: '#/components/schemas/SecretAddRequestCommonFields'
-        attributes:
-          $ref: '#/components/schemas/GitHubSshKeyAttributes'
-    UpdateGitHubSshKeyRequestBody:
+
+    UpdateSshKeyRequestBody:
       type: object
       properties:
         name:
           type: string
         description:
           type: string
-        attributes:
-          $ref: '#/components/schemas/GitHubSshKeyAttributes'
+        externalUserName:
+          type: string
+        externalUserEmail:
+          type: string
+        key:
+          description: ssh private key
+          type: string
     LinkInfo:
       type: object
       required: [ externalUserId, expirationTimestamp ]

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -145,12 +145,12 @@ paths:
           description: "Version not configured"
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/sshkeypair/v1/{sshkey_type}:
+  /api/sshkeypair/v1/{type}:
     parameters:
-      - $ref: '#/components/parameters/sshKeyProviderParam'
+      - $ref: '#/components/parameters/sshKeyPairTypeParam'
     get:
       summary: Get the ssh key pair of the given provider.
-      tags: [ ssh_key ]
+      tags: [ ssh key pair ]
       operationId: getSshKeyPair
       responses:
         '200':
@@ -161,25 +161,23 @@ paths:
           $ref: '#/components/responses/ServerError'
     put:
       summary: Store an ssh key pair to the given provider.
-      tags: [ssh_key]
-      operationId: storeSshKeyPair
+      tags: [ssh key pair]
+      operationId: putSshKeyPair
       requestBody:
         content:
-          multipart/form-data:
+          application/json:
             schema:
-              $ref: '#/components/schemas/SshKeyPairInfo'
+              $ref: '#/components/schemas/SshKeyPair'
       responses:
         '204':
           description: Successfully stored the ssh key pair.
         '400':
           $ref: '#/components/responses/BadRequest'
-        '409':
-          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/ServerError'
     delete:
       summary: delete the ssh key pair of the given provider
-      tags: [ ssh_key ]
+      tags: [ ssh key pair ]
       operationId: deleteSshKeyPair
       responses:
         '204':
@@ -191,11 +189,11 @@ paths:
 
 components:
   parameters:
-    sshKeyProviderParam:
-      name: sshkey_type
+    sshKeyPairTypeParam:
+      name: type
       in: path
       schema:
-        $ref: '#/components/schemas/SshKeyType'
+        $ref: '#/components/schemas/SshKeyPairType'
       required: true
     providerParam:
       name: provider
@@ -203,12 +201,6 @@ components:
       schema:
         type: string
         default: ras
-      required: true
-    userIdParam:
-      name: user_id
-      in: path
-      schema:
-        type: string
       required: true
     scopesParam:
       name: scopes
@@ -257,7 +249,7 @@ components:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/SshKeyPairInfo'
+            $ref: '#/components/schemas/SshKeyPair'
 
     # Error Responses
     BadRequest:
@@ -284,22 +276,16 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorReport'
-    Conflict:
-      description: Conflict
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorReport'
 
   schemas:
-    SshKeyType:
+    SshKeyPairType:
       description: Enum containing valid ssh key types.
       type: string
       enum:
         - GITHUB
         - GITLAB
         - AZURE
-    SshKeyPairInfo:
+    SshKeyPair:
       type: object
       required: [privateKey, publicKey, externalUserEmail]
       properties:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -169,8 +169,8 @@ paths:
             schema:
               $ref: '#/components/schemas/SshKeyPair'
       responses:
-        '204':
-          description: Successfully stored the ssh key pair.
+        '200':
+          $ref: '#/components/responses/SshKeyPairResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '500':

--- a/service/src/main/java/bio/terra/externalcreds/ExternalCredsSpringConfig.java
+++ b/service/src/main/java/bio/terra/externalcreds/ExternalCredsSpringConfig.java
@@ -1,22 +1,25 @@
 package bio.terra.externalcreds;
 
 import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.models.StringToSshKeyPairTypeConverter;
 import javax.sql.DataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.jdbc.support.JdbcTransactionManager;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /** Spring configuration class for loading application config and code defined beans. */
 @Configuration
 @EnableRetry
 @EnableTransactionManagement
 @EnableConfigurationProperties
-public class ExternalCredsSpringConfig {
+public class ExternalCredsSpringConfig implements WebMvcConfigurer {
   private final DataSource dataSource;
 
   public ExternalCredsSpringConfig(DataSource dataSource) {
@@ -34,5 +37,10 @@ public class ExternalCredsSpringConfig {
   @ConfigurationProperties(value = "externalcreds", ignoreUnknownFields = false)
   public ExternalCredsConfig getExternalCredsSpringConfig() {
     return ExternalCredsConfig.create();
+  }
+
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new StringToSshKeyPairTypeConverter());
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/GlobalExceptionHandler.java
@@ -4,6 +4,8 @@ import bio.terra.common.exception.ErrorReportException;
 import bio.terra.externalcreds.generated.model.ErrorReport;
 import javax.validation.constraints.NotNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.NestedRuntimeException;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -26,10 +28,14 @@ public class GlobalExceptionHandler {
     return buildErrorReport(ex, ex.getStatusCode());
   }
 
+  @ExceptionHandler({ConversionFailedException.class, MethodArgumentTypeMismatchException.class})
+  public ResponseEntity<ErrorReport> conversionFailedExceptionHandler(NestedRuntimeException ex) {
+    return buildErrorReport(ex.getMostSpecificCause(), HttpStatus.BAD_REQUEST);
+  }
+
   // -- validation exceptions - we don't control the exception raised
   @ExceptionHandler({
     MethodArgumentNotValidException.class,
-    MethodArgumentTypeMismatchException.class,
     HttpMessageNotReadableException.class,
     IllegalArgumentException.class,
     NoHandlerFoundException.class

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -23,8 +23,7 @@ public class SshKeyApiController implements SshKeyPairApi {
   }
 
   @Override
-  public ResponseEntity<SshKeyPair> putSshKeyPair(
-      SshKeyPairType type, String privateKey, String publicKey, String externalUserEmail) {
+  public ResponseEntity<SshKeyPair> putSshKeyPair(SshKeyPairType type, SshKeyPair body) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -1,7 +1,7 @@
 package bio.terra.externalcreds.controllers;
 
 import bio.terra.externalcreds.generated.api.SshKeyApi;
-import bio.terra.externalcreds.generated.model.SshKeyInfo;
+import bio.terra.externalcreds.generated.model.SshKeyPairInfo;
 import bio.terra.externalcreds.generated.model.SshKeyType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -13,18 +13,18 @@ public class SshKeyApiController implements SshKeyApi {
   public SshKeyApiController() {}
 
   @Override
-  public ResponseEntity<Void> deleteSshKey(SshKeyType provider) {
+  public ResponseEntity<Void> deleteSshKeyPair(SshKeyType provider) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResponseEntity<SshKeyInfo> getSshKey(SshKeyType provider) {
+  public ResponseEntity<SshKeyPairInfo> getSshKeyPair(SshKeyType provider) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResponseEntity<Void> storeSshKey(
-      SshKeyType sshkeyType, byte[] key, String externalUserEmail) {
+  public ResponseEntity<Void> storeSshKeyPair(
+      SshKeyType sshkeyType, byte[] privateKey, byte[] publicKey, String externalUserEmail) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -1,0 +1,41 @@
+package bio.terra.externalcreds.controllers;
+
+import bio.terra.externalcreds.generated.api.SshKeyApi;
+import bio.terra.externalcreds.generated.model.AddGitHubSshKeyRequestBody;
+import bio.terra.externalcreds.generated.model.GitHubSshKey;
+import bio.terra.externalcreds.generated.model.UpdateGitHubSshKeyRequestBody;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public class SshKeyApiController implements SshKeyApi {
+
+  public SshKeyApiController() {
+  }
+
+  @Override
+  public ResponseEntity<Void> getGitHubSshKey() {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<List<GitHubSshKey>> enumerateSshKeys() {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<GitHubSshKey> storeGitHubSshKey(AddGitHubSshKeyRequestBody body) {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<Void> deleteGitHubSshKey() {
+    return null;
+  }
+
+  @Override
+  public ResponseEntity<GitHubSshKey> updateGitHubSshKey(UpdateGitHubSshKeyRequestBody body) {
+    return null;
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -23,7 +23,8 @@ public class SshKeyApiController implements SshKeyPairApi {
   }
 
   @Override
-  public ResponseEntity<Void> putSshKeyPair(SshKeyPairType type, SshKeyPair sshKeyPair) {
+  public ResponseEntity<Void> putSshKeyPair(
+      SshKeyPairType type, String privateKey, String publicKey, String externalUserEmail) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -3,12 +3,11 @@ package bio.terra.externalcreds.controllers;
 import bio.terra.externalcreds.generated.api.SshKeyApi;
 import bio.terra.externalcreds.generated.model.SshKeyInfo;
 import bio.terra.externalcreds.generated.model.SshKeyType;
-import bio.terra.externalcreds.generated.model.UpdateSshKeyRequestBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-//TODO(PF-1354): implement the service.
+// TODO(PF-1354): implement the service.
 public class SshKeyApiController implements SshKeyApi {
 
   public SshKeyApiController() {}
@@ -25,18 +24,7 @@ public class SshKeyApiController implements SshKeyApi {
 
   @Override
   public ResponseEntity<Void> storeSshKey(
-      SshKeyType provider,
-      String name,
-      String description,
-      byte[] key,
-      String externalUserName,
-      String externalUserEmail) {
-    throw new UnsupportedOperationException("Not implemented");
-  }
-
-  @Override
-  public ResponseEntity<SshKeyInfo> updateSshKey(
-      SshKeyType provider, UpdateSshKeyRequestBody body) {
+      SshKeyType sshkeyType, byte[] key, String externalUserEmail) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -1,30 +1,29 @@
 package bio.terra.externalcreds.controllers;
 
-import bio.terra.externalcreds.generated.api.SshKeyApi;
-import bio.terra.externalcreds.generated.model.SshKeyPairInfo;
-import bio.terra.externalcreds.generated.model.SshKeyType;
+import bio.terra.externalcreds.generated.api.SshKeyPairApi;
+import bio.terra.externalcreds.generated.model.SshKeyPair;
+import bio.terra.externalcreds.generated.model.SshKeyPairType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 // TODO(PF-1354): implement the service.
-public class SshKeyApiController implements SshKeyApi {
+public class SshKeyApiController implements SshKeyPairApi {
 
   public SshKeyApiController() {}
 
   @Override
-  public ResponseEntity<Void> deleteSshKeyPair(SshKeyType provider) {
+  public ResponseEntity<Void> deleteSshKeyPair(SshKeyPairType type) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResponseEntity<SshKeyPairInfo> getSshKeyPair(SshKeyType provider) {
+  public ResponseEntity<SshKeyPair> getSshKeyPair(SshKeyPairType type) {
     throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResponseEntity<Void> storeSshKeyPair(
-      SshKeyType sshkeyType, byte[] privateKey, byte[] publicKey, String externalUserEmail) {
+  public ResponseEntity<Void> putSshKeyPair(SshKeyPairType type, SshKeyPair sshKeyPair) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -1,41 +1,41 @@
 package bio.terra.externalcreds.controllers;
 
 import bio.terra.externalcreds.generated.api.SshKeyApi;
-import bio.terra.externalcreds.generated.model.AddGitHubSshKeyRequestBody;
-import bio.terra.externalcreds.generated.model.GitHubSshKey;
-import bio.terra.externalcreds.generated.model.UpdateGitHubSshKeyRequestBody;
-import java.util.List;
+import bio.terra.externalcreds.generated.model.SshKeyInfo;
+import bio.terra.externalcreds.generated.model.SshKeyType;
+import bio.terra.externalcreds.generated.model.UpdateSshKeyRequestBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
 public class SshKeyApiController implements SshKeyApi {
 
-  public SshKeyApiController() {
+  public SshKeyApiController() {}
+
+  @Override
+  public ResponseEntity<Void> deleteSshKey(SshKeyType provider) {
+    throw new UnsupportedOperationException("not implemented");
   }
 
   @Override
-  public ResponseEntity<Void> getGitHubSshKey() {
-    return null;
+  public ResponseEntity<Void> getSshKey(SshKeyType provider) {
+    throw new UnsupportedOperationException("not implemented");
   }
 
   @Override
-  public ResponseEntity<List<GitHubSshKey>> enumerateSshKeys() {
-    return null;
+  public ResponseEntity<SshKeyInfo> storeSshKey(
+      SshKeyType provider,
+      String name,
+      String description,
+      byte[] key,
+      String externalUserName,
+      String externalUserEmail) {
+    throw new UnsupportedOperationException("not implemented");
   }
 
   @Override
-  public ResponseEntity<GitHubSshKey> storeGitHubSshKey(AddGitHubSshKeyRequestBody body) {
-    return null;
-  }
-
-  @Override
-  public ResponseEntity<Void> deleteGitHubSshKey() {
-    return null;
-  }
-
-  @Override
-  public ResponseEntity<GitHubSshKey> updateGitHubSshKey(UpdateGitHubSshKeyRequestBody body) {
-    return null;
+  public ResponseEntity<SshKeyInfo> updateSshKey(
+      SshKeyType provider, UpdateSshKeyRequestBody body) {
+    throw new UnsupportedOperationException("not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -1,8 +1,9 @@
 package bio.terra.externalcreds.controllers;
 
 import bio.terra.externalcreds.generated.api.SshKeyApi;
-import bio.terra.externalcreds.generated.model.SshKeyInfo;
+import bio.terra.externalcreds.generated.model.SshKeyCommonFields;
 import bio.terra.externalcreds.generated.model.SshKeyType;
+import bio.terra.externalcreds.generated.model.Sshkey;
 import bio.terra.externalcreds.generated.model.UpdateSshKeyRequestBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -18,24 +19,18 @@ public class SshKeyApiController implements SshKeyApi {
   }
 
   @Override
-  public ResponseEntity<Void> getSshKey(SshKeyType provider) {
+  public ResponseEntity<Sshkey> getSshKey(SshKeyType provider) {
     throw new UnsupportedOperationException("not implemented");
   }
 
   @Override
-  public ResponseEntity<SshKeyInfo> storeSshKey(
-      SshKeyType provider,
-      String name,
-      String description,
-      byte[] key,
-      String externalUserName,
-      String externalUserEmail) {
+  public ResponseEntity<Void> storeSshKey(
+      SshKeyType provider, byte[] key, SshKeyCommonFields keyInfo) {
     throw new UnsupportedOperationException("not implemented");
   }
 
   @Override
-  public ResponseEntity<SshKeyInfo> updateSshKey(
-      SshKeyType provider, UpdateSshKeyRequestBody body) {
+  public ResponseEntity<Sshkey> updateSshKey(SshKeyType provider, UpdateSshKeyRequestBody body) {
     throw new UnsupportedOperationException("not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
+//TODO(PF-1354): implement the service.
 public class SshKeyApiController implements SshKeyApi {
 
   public SshKeyApiController() {}

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -23,7 +23,7 @@ public class SshKeyApiController implements SshKeyPairApi {
   }
 
   @Override
-  public ResponseEntity<Void> putSshKeyPair(
+  public ResponseEntity<SshKeyPair> putSshKeyPair(
       SshKeyPairType type, String privateKey, String publicKey, String externalUserEmail) {
     throw new UnsupportedOperationException("Not implemented");
   }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -1,9 +1,8 @@
 package bio.terra.externalcreds.controllers;
 
 import bio.terra.externalcreds.generated.api.SshKeyApi;
-import bio.terra.externalcreds.generated.model.SshKeyCommonFields;
+import bio.terra.externalcreds.generated.model.SshKeyInfo;
 import bio.terra.externalcreds.generated.model.SshKeyType;
-import bio.terra.externalcreds.generated.model.Sshkey;
 import bio.terra.externalcreds.generated.model.UpdateSshKeyRequestBody;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -15,22 +14,28 @@ public class SshKeyApiController implements SshKeyApi {
 
   @Override
   public ResponseEntity<Void> deleteSshKey(SshKeyType provider) {
-    throw new UnsupportedOperationException("not implemented");
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResponseEntity<Sshkey> getSshKey(SshKeyType provider) {
-    throw new UnsupportedOperationException("not implemented");
+  public ResponseEntity<SshKeyInfo> getSshKey(SshKeyType provider) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
   public ResponseEntity<Void> storeSshKey(
-      SshKeyType provider, byte[] key, SshKeyCommonFields keyInfo) {
-    throw new UnsupportedOperationException("not implemented");
+      SshKeyType provider,
+      String name,
+      String description,
+      byte[] key,
+      String externalUserName,
+      String externalUserEmail) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 
   @Override
-  public ResponseEntity<Sshkey> updateSshKey(SshKeyType provider, UpdateSshKeyRequestBody body) {
-    throw new UnsupportedOperationException("not implemented");
+  public ResponseEntity<SshKeyInfo> updateSshKey(
+      SshKeyType provider, UpdateSshKeyRequestBody body) {
+    throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/models/StringToSshKeyPairTypeConverter.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/StringToSshKeyPairTypeConverter.java
@@ -1,0 +1,23 @@
+package bio.terra.externalcreds.models;
+
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.externalcreds.generated.model.SshKeyPairType;
+import java.util.Arrays;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StringToSshKeyPairTypeConverter implements Converter<String, SshKeyPairType> {
+  @Override
+  public SshKeyPairType convert(@NonNull String type) {
+    var result = SshKeyPairType.fromValue(type);
+    if (result == null) {
+      throw new BadRequestException(
+          String.format(
+              "Invalid SSH key pair type. Valid options are: %s",
+              Arrays.toString(SshKeyPairType.values())));
+    }
+    return result;
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -21,7 +21,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
 @AutoConfigureMockMvc
-public class SshKeyApiControllerTest extends BaseTest {
+class SshKeyApiControllerTest extends BaseTest {
 
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper objectMapper;

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -29,7 +29,7 @@ class SshKeyApiControllerTest extends BaseTest {
     var sshKeyType = "GITHUB";
     var failedResult =
         mvc.perform(get("/api/sshkeypair/v1/{type}", sshKeyType))
-            .andExpect(status().is(500))
+            .andExpect(status().is5xxServerError())
             .andReturn();
     var requestError =
         objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
@@ -46,17 +46,17 @@ class SshKeyApiControllerTest extends BaseTest {
     var sshPublicKey = "ssh-ed25519 AAABBBccc123 yuhuyoyo@google.com";
     var sshKeyPair =
         new SshKeyPair()
-            .privateKey(sshPrivateKey.getBytes())
-            .publicKey(sshPublicKey.getBytes())
+            .privateKey(sshPrivateKey)
+            .publicKey(sshPublicKey)
             .externalUserEmail("yuhuyoyo@google.com");
     var requestBody = objectMapper.writeValueAsString(sshKeyPair);
 
     var failedResult =
         mvc.perform(
                 put("/api/sshkeypair/v1/{type}", sshKeyPairType)
-                    .contentType(MediaType.APPLICATION_JSON)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
                     .content(requestBody))
-            .andExpect(status().is(500))
+            .andExpect(status().is5xxServerError())
             .andReturn();
 
     var requestError =
@@ -69,7 +69,7 @@ class SshKeyApiControllerTest extends BaseTest {
     var sshKeyType = "GITLAB";
     var failedResult =
         mvc.perform(delete("/api/sshkeypair/v1/{type}", sshKeyType))
-            .andExpect(status().is(500))
+            .andExpect(status().is5xxServerError())
             .andReturn();
 
     var requestError =

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -28,7 +28,7 @@ class SshKeyApiControllerTest extends BaseTest {
   void getSshKeyPair_throws500() throws Exception {
     var sshKeyType = "GITHUB";
     var failedResult =
-        mvc.perform(get("/api/sshkeypair/v1/{sshkey_type}", sshKeyType))
+        mvc.perform(get("/api/sshkeypair/v1/{type}", sshKeyType))
             .andExpect(status().is(500))
             .andReturn();
     var requestError =
@@ -68,7 +68,7 @@ class SshKeyApiControllerTest extends BaseTest {
   void deleteSshKeyPair_throws500() throws Exception {
     var sshKeyType = "GITLAB";
     var failedResult =
-        mvc.perform(delete("/api/sshkeypair/v1/{sshkey_type}", sshKeyType))
+        mvc.perform(delete("/api/sshkeypair/v1/{type}", sshKeyType))
             .andExpect(status().is(500))
             .andReturn();
 
@@ -81,7 +81,7 @@ class SshKeyApiControllerTest extends BaseTest {
   void updateSshKeyPair_invalidProvider_throwsBadRequest() throws Exception {
     var invalidSshKeyType = "AZURES";
     var failedResult =
-        mvc.perform(get("/api/sshkeypair/v1/{sshkey_type}", invalidSshKeyType))
+        mvc.perform(get("/api/sshkeypair/v1/{type}", invalidSshKeyType))
             .andExpect(status().isBadRequest())
             .andReturn();
 

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -78,7 +78,7 @@ class SshKeyApiControllerTest extends BaseTest {
   }
 
   @Test
-  void updateSshKeyPair_invalidProvider_throwsBadRequest() throws Exception {
+  void getSshKeyPair_invalidProvider_throwsBadRequest() throws Exception {
     var invalidSshKeyType = "AZURES";
     var failedResult =
         mvc.perform(get("/api/sshkeypair/v1/{type}", invalidSshKeyType))

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.generated.model.ErrorReport;
-import bio.terra.externalcreds.generated.model.StoreSshKeyRequest;
+import bio.terra.externalcreds.generated.model.SshKeyInfo;
 import bio.terra.externalcreds.generated.model.UpdateSshKeyRequestBody;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
@@ -41,14 +41,14 @@ public class SshKeyApiControllerTest extends BaseTest {
   @Test
   void storeSshKey_throws500() throws Exception {
     var providerName = "GITHUB";
-    StoreSshKeyRequest storeSshKeyRequest = new StoreSshKeyRequest();
+    SshKeyInfo sshkeyInfo = new SshKeyInfo();
 
     var sshKey =
         "-----BEGIN OPENSSH PRIVATE KEY-----\n"
             + "abcde12345/+xXXXYZ//890=\n"
             + "-----END OPENSSH PRIVATE KEY-----";
-    storeSshKeyRequest.key(sshKey.getBytes());
-    String requestBody = objectMapper.writeValueAsString(storeSshKeyRequest);
+    sshkeyInfo.key(sshKey.getBytes());
+    String requestBody = objectMapper.writeValueAsString(sshkeyInfo);
 
     MvcResult failedResult =
         mvc.perform(

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -8,7 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.generated.model.ErrorReport;
-import bio.terra.externalcreds.generated.model.SshKeyPairInfo;
+import bio.terra.externalcreds.generated.model.SshKeyPair;
+import bio.terra.externalcreds.generated.model.SshKeyPairType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -37,23 +38,24 @@ class SshKeyApiControllerTest extends BaseTest {
   }
 
   @Test
-  void storeSshKeyPair_throws500() throws Exception {
-    var sshKeyType = "GITHUB";
-    SshKeyPairInfo sshKeyPairInfo = new SshKeyPairInfo();
+  void putSshKeyPair_throws500() throws Exception {
+    var sshKeyPairType = SshKeyPairType.GITHUB;
     var sshPrivateKey =
         "-----BEGIN OPENSSH PRIVATE KEY-----\n"
             + "abcde12345/+xXXXYZ//890=\n"
             + "-----END OPENSSH PRIVATE KEY-----";
     var sshPublicKey = "ssh-ed25519 AAABBBccc123 yuhuyoyo@google.com";
-    sshKeyPairInfo.privateKey(sshPrivateKey.getBytes());
-    sshKeyPairInfo.publicKey(sshPublicKey.getBytes());
-    sshKeyPairInfo.externalUserEmail("yuhuyoyo@google.com");
-    String requestBody = objectMapper.writeValueAsString(sshKeyPairInfo);
+    var sshKeyPair =
+        new SshKeyPair()
+            .privateKey(sshPrivateKey.getBytes())
+            .publicKey(sshPublicKey.getBytes())
+            .externalUserEmail("yuhuyoyo@google.com");
+    String requestBody = objectMapper.writeValueAsString(sshKeyPair);
 
     MvcResult failedResult =
         mvc.perform(
-                put("/api/sshkeypair/v1/{sshkey_type}", sshKeyType)
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                put("/api/sshkeypair/v1/{type}", sshKeyPairType)
+                    .contentType(MediaType.APPLICATION_JSON)
                     .content(requestBody))
             .andExpect(status().is(500))
             .andReturn();

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -1,0 +1,118 @@
+package bio.terra.externalcreds.controllers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.generated.model.ErrorReport;
+import bio.terra.externalcreds.generated.model.StoreSshKeyRequest;
+import bio.terra.externalcreds.generated.model.UpdateSshKeyRequestBody;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@AutoConfigureMockMvc
+public class SshKeyApiControllerTest extends BaseTest {
+
+  @Autowired private MockMvc mvc;
+  @Autowired private ObjectMapper objectMapper;
+
+  @Test
+  void getSshKey_throws500() throws Exception {
+    var providerName = "GITHUB";
+    MvcResult failedResult =
+        mvc.perform(get("/api/secrets/sshkeys/v1/{provider}", providerName))
+            .andExpect(status().is(500))
+            .andReturn();
+    ErrorReport requestError =
+        objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+  }
+
+  @Test
+  void storeSshKey_throws500() throws Exception {
+    var providerName = "GITHUB";
+    StoreSshKeyRequest storeSshKeyRequest = new StoreSshKeyRequest();
+
+    var sshKey =
+        "-----BEGIN OPENSSH PRIVATE KEY-----\n"
+            + "abcde12345/+xXXXYZ//890=\n"
+            + "-----END OPENSSH PRIVATE KEY-----";
+    storeSshKeyRequest.key(sshKey.getBytes());
+    String requestBody = objectMapper.writeValueAsString(storeSshKeyRequest);
+
+    MvcResult failedResult =
+        mvc.perform(
+                post("/api/secrets/sshkeys/v1/{provider}", providerName)
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .content(requestBody))
+            .andExpect(status().is(500))
+            .andReturn();
+    ErrorReport requestError =
+        objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+  }
+
+  @Test
+  void deleteSshKey() throws Exception {
+    var providerName = "GITLAB";
+
+    MvcResult failedResult =
+        mvc.perform(delete("/api/secrets/sshkeys/v1/{provider}", providerName))
+            .andExpect(status().is(500))
+            .andReturn();
+    ErrorReport requestError =
+        objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+  }
+
+  @Test
+  void updateSshKey_throws500() throws Exception {
+    var providerName = "AZURE";
+    UpdateSshKeyRequestBody updateSshKeyRequestBody = new UpdateSshKeyRequestBody();
+    updateSshKeyRequestBody.name("new_name");
+    updateSshKeyRequestBody.description("new description");
+
+    MvcResult failedResult =
+        mvc.perform(
+                patch("/api/secrets/sshkeys/v1/{provider}", providerName)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateSshKeyRequestBody)))
+            .andExpect(status().is(500))
+            .andReturn();
+    ErrorReport requestError =
+        objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+  }
+
+  @Test
+  void updateSshKey_invalidProvider_throwsBadRequest() throws Exception {
+    var invalidProvider = "AZURES";
+    UpdateSshKeyRequestBody updateSshKeyRequestBody = new UpdateSshKeyRequestBody();
+    updateSshKeyRequestBody.name("new_name");
+    updateSshKeyRequestBody.description("new description");
+
+    MvcResult failedResult =
+        mvc.perform(
+                patch("/api/secrets/sshkeys/v1/{provider}", invalidProvider)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(updateSshKeyRequestBody)))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+    ErrorReport requestError =
+        objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
+    assertThat(
+        requestError.getMessage(),
+        Matchers.containsString(
+            "Request could not be parsed or was invalid: MethodArgumentTypeMismatchException. Ensure that all types are correct and that enums have valid values."));
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -1,9 +1,11 @@
 package bio.terra.externalcreds.controllers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.externalcreds.BaseTest;
@@ -11,7 +13,6 @@ import bio.terra.externalcreds.generated.model.ErrorReport;
 import bio.terra.externalcreds.generated.model.SshKeyPair;
 import bio.terra.externalcreds.generated.model.SshKeyPairType;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -26,14 +27,14 @@ class SshKeyApiControllerTest extends BaseTest {
 
   @Test
   void getSshKeyPair_throws500() throws Exception {
-    var sshKeyType = "GITHUB";
+    var sshKeyType = "github";
     var failedResult =
         mvc.perform(get("/api/sshkeypair/v1/{type}", sshKeyType))
             .andExpect(status().is5xxServerError())
             .andReturn();
     var requestError =
         objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
-    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+    assertThat(requestError.getMessage(), containsString("Not implemented"));
   }
 
   @Test
@@ -61,12 +62,12 @@ class SshKeyApiControllerTest extends BaseTest {
 
     var requestError =
         objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
-    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+    assertThat(requestError.getMessage(), containsString("Not implemented"));
   }
 
   @Test
   void deleteSshKeyPair_throws500() throws Exception {
-    var sshKeyType = "GITLAB";
+    var sshKeyType = "gitlab";
     var failedResult =
         mvc.perform(delete("/api/sshkeypair/v1/{type}", sshKeyType))
             .andExpect(status().is5xxServerError())
@@ -74,22 +75,14 @@ class SshKeyApiControllerTest extends BaseTest {
 
     var requestError =
         objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
-    assertThat(requestError.getMessage(), Matchers.containsString("Not implemented"));
+    assertThat(requestError.getMessage(), containsString("Not implemented"));
   }
 
   @Test
   void getSshKeyPair_invalidProvider_throwsBadRequest() throws Exception {
-    var invalidSshKeyType = "AZURES";
-    var failedResult =
-        mvc.perform(get("/api/sshkeypair/v1/{type}", invalidSshKeyType))
-            .andExpect(status().isBadRequest())
-            .andReturn();
-
-    var requestError =
-        objectMapper.readValue(failedResult.getResponse().getContentAsString(), ErrorReport.class);
-    assertThat(
-        requestError.getMessage(),
-        Matchers.containsString(
-            "Request could not be parsed or was invalid: MethodArgumentTypeMismatchException. Ensure that all types are correct and that enums have valid values."));
+    var invalidSshKeyType = "azures";
+    mvc.perform(get("/api/sshkeypair/v1/{type}", invalidSshKeyType))
+        .andExpect(status().isBadRequest())
+        .andExpect(content().string(containsString("Invalid SSH key pair type")));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -55,7 +55,7 @@ class SshKeyApiControllerTest extends BaseTest {
     var failedResult =
         mvc.perform(
                 put("/api/sshkeypair/v1/{type}", sshKeyPairType)
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .contentType(MediaType.APPLICATION_JSON)
                     .content(requestBody))
             .andExpect(status().is5xxServerError())
             .andReturn();


### PR DESCRIPTION
Add an endpoint for storing ssh key. There will be a pre-defined set up providers, currently they are github, gitlab and azure.