### PR TITLE
[PF-1384] Parse json string input to string

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -18,7 +18,8 @@ import org.springframework.stereotype.Controller;
 @Controller
 @Slf4j
 public record SshKeyApiController(
-    HttpServletRequest request, SamService samService, SshKeyPairService sshKeyPairService)
+    HttpServletRequest request, SamService samService, SshKeyPairService sshKeyPairService,
+    ObjectMapper objectMapper)
     implements SshKeyPairApi {
 
   @Override
@@ -43,13 +44,12 @@ public record SshKeyApiController(
   @Override
   public ResponseEntity<SshKeyPair> generateSshKeyPair(SshKeyPairType type, String email) {
     try {
-      String userEmail = new ObjectMapper().readValue(email, String.class);
+      String userEmail = objectMapper.readValue(email, String.class);
       var sshKeyPair =
           sshKeyPairService.generateSshKeyPair(
               getUserIdFromSam(request, samService), userEmail, type);
       return ResponseEntity.ok(OpenApiConverters.Output.convert(sshKeyPair));
     } catch (JsonProcessingException e) {
-      log.error("Failed to parse the email input");
       throw new BadRequestException("Cannot parse the email input", e);
     }
   }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -11,12 +11,10 @@ import bio.terra.externalcreds.services.SshKeyPairService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import javax.servlet.http.HttpServletRequest;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
 @Controller
-@Slf4j
 public record SshKeyApiController(
     HttpServletRequest request, SamService samService, SshKeyPairService sshKeyPairService,
     ObjectMapper objectMapper)

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -51,7 +51,8 @@ class SshKeyApiControllerTest extends BaseTest {
   @Test
   void putGetAndDeleteSshKeyPair() throws Exception {
     String accessToken = RandomStringUtils.randomAlphanumeric(10);
-    String externalUserEmail = String.format("%s@gmail.com", RandomStringUtils.randomAlphabetic(5));
+    String externalUserEmail =
+        String.format("\"%s@gmail.com\"", RandomStringUtils.randomAlphabetic(5));
     mockSamUser(accessToken);
     var sshKeyPairType = "gitlab";
     var rsaEncodedKeyPair = TestUtils.getRSAEncodedKeyPair(externalUserEmail);
@@ -94,7 +95,8 @@ class SshKeyApiControllerTest extends BaseTest {
   void generateGetAndDeleteSshKeyPair() throws Exception {
     String accessToken = RandomStringUtils.randomAlphanumeric(10);
     mockSamUser(accessToken);
-    String externalUserEmail = String.format("%s@gmail.com", RandomStringUtils.randomAlphabetic(5));
+    String externalUserEmail =
+        String.format("\"%s@gmail.com\"", RandomStringUtils.randomAlphabetic(5));
     var sshKeyPairType = "gitlab";
     var postResult =
         mvc.perform(
@@ -139,7 +141,8 @@ class SshKeyApiControllerTest extends BaseTest {
   @Test
   void samThrowsApiException() throws Exception {
     String accessToken = RandomStringUtils.randomAlphanumeric(10);
-    String externalUserEmail = String.format("%s@gmail.com", RandomStringUtils.randomAlphabetic(5));
+    String externalUserEmail =
+        String.format("\"%s@gmail.com\"", RandomStringUtils.randomAlphabetic(5));
     var usersApiMock = mock(UsersApi.class);
     when(samServiceMock.samUsersApi(accessToken)).thenReturn(usersApiMock);
     when(usersApiMock.getUserStatusInfo()).thenThrow(new ApiException());
@@ -156,7 +159,8 @@ class SshKeyApiControllerTest extends BaseTest {
   @Test
   void samThrowsNotFoundException() throws Exception {
     String accessToken = RandomStringUtils.randomAlphanumeric(10);
-    String externalUserEmail = String.format("%s@gmail.com", RandomStringUtils.randomAlphabetic(5));
+    String externalUserEmail =
+        String.format("\"%s@gmail.com\"", RandomStringUtils.randomAlphabetic(5));
     var usersApiMock = mock(UsersApi.class);
     when(samServiceMock.samUsersApi(accessToken)).thenReturn(usersApiMock);
     when(usersApiMock.getUserStatusInfo())

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -128,6 +128,20 @@ class SshKeyApiControllerTest extends BaseTest {
   }
 
   @Test
+  void generateWithInvalidInput() throws Exception {
+    String accessToken = RandomStringUtils.randomAlphanumeric(10);
+    mockSamUser(accessToken);
+    String externalUserEmail = String.format("%s@gmail.com", RandomStringUtils.randomAlphabetic(5));
+    var sshKeyPairType = "gitlab";
+    mvc.perform(
+            post("/api/sshkeypair/v1/{type}", sshKeyPairType)
+                .header("authorization", "Bearer " + accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(externalUserEmail))
+        .andExpect(status().isBadRequest());
+  }
+
+  @Test
   void getSshKeyPairWithInvalidKeyType() throws Exception {
     String accessToken = RandomStringUtils.randomAlphanumeric(10);
     mockSamUser(accessToken);


### PR DESCRIPTION
When calling this api, the request body is a json string that looks like "foo@bar.com". So we need to parse it to a string in order to remove the quotes and thus turns it into foo@bar.com.