### PR TITLE
check jwt algorithm [POL-212]

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -28,6 +28,12 @@ public interface ExternalCredsConfigInterface {
 
   Duration getVisaAndPassportRefreshDuration();
 
+  /** List of algorithms that are allowable in JWT headers */
+  @Value.Default
+  default Collection<String> getAllowedJwtAlgorithms() {
+    return List.of();
+  }
+
   /** List of URIs that are allowable in jku headers of JWTs */
   @Value.Default
   default Collection<URI> getAllowedJwksUris() {

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -132,6 +132,19 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig) {
             String.format("URI [%s] specified by iss claim not on allowed list", issuer));
       }
 
+      // validate the algorithm field
+      var allowedAlgorithms = externalCredsConfig.getAllowedJwtAlgorithms();
+      var algorithm = ((JWSHeader) jwt.getHeader()).getAlgorithm();
+
+      if (algorithm == null) {
+        throw new InvalidJwtException("jwt missing algorithm (alg) header");
+      }
+
+      if (!allowedAlgorithms.contains(algorithm.toString())) {
+        throw new InvalidJwtException(
+            String.format("Algorithm [%s] is not on allowed list", algorithm));
+      }
+
       var jkuOption = Optional.ofNullable(((JWSHeader) jwt.getHeader()).getJWKURL());
       if (jkuOption.isPresent()) {
         // presence of the jku header means the url it specifies contains the key set that must be

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ externalcreds:
   authorization-change-events-enabled: ${AUTHORIZATION_CHANGE_EVENTS_ENABLED:false}
   # name from: https://github.com/broadinstitute/terraform-ap-modules/blob/master/externalcreds/pubsub.tf
   authorization-change-event-topic-name: projects/${SERVICE_GOOGLE_PROJECT:broad-dsde-dev}/topics/ecm-events
+  # allowed JWT encryption algorithms
+  allowed-jwt-algorithms: [ RS256, ES256 ]
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -71,6 +71,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
   @Test
   void testNoVisas() throws URISyntaxException {
+    when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
     var expectedPassport =
         jwtSigningTestUtils.createTestPassport(Collections.emptyList(), userEmail);
     var expectedLinkedAccount = createTestLinkedAccount();
@@ -79,6 +80,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
   @Test
   void testAccessTokenVisa() throws URISyntaxException {
+    when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
     var visa = jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.access_token);
     var expectedPassport = jwtSigningTestUtils.createTestPassport(List.of(visa), userEmail);
     var expectedLinkedAccount = createTestLinkedAccount();
@@ -87,6 +89,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
   @Test
   void testDocumentTokenVisa() throws URISyntaxException {
+    when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
     var visa = jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.document_token);
     var expectedPassport = jwtSigningTestUtils.createTestPassport(List.of(visa), userEmail);
     var expectedLinkedAccount = createTestLinkedAccount();
@@ -95,6 +98,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
   @Test
   void testMultipleVisas() throws URISyntaxException {
+    when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
     var visas =
         List.of(
             jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.document_token),

--- a/service/src/test/java/bio/terra/externalcreds/services/JwtUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/JwtUtilsTest.java
@@ -12,10 +12,13 @@ import bio.terra.externalcreds.JwtSigningTestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jwt.JWTClaimsSet;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
@@ -46,14 +49,14 @@ public class JwtUtilsTest extends BaseTest {
     @MockBean ExternalCredsConfig externalCredsConfigMock;
 
     @Test
-    void testInvalidJwtSignature() throws URISyntaxException, JOSEException {
+    void testInvalidJwtSignature() {
       var visa = jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.access_token);
       var invalidJwt = visa.getJwt() + "foo";
       assertThrows(InvalidJwtException.class, () -> jwtUtils.decodeAndValidateJwt(invalidJwt));
     }
 
     @Test
-    void testJwtMissingIssuer() throws URISyntaxException, JOSEException {
+    void testJwtMissingIssuer() {
       var visa =
           jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.access_token).withIssuer("null");
       var jwtMissingIssuer = jwtSigningTestUtils.createVisaJwtString(visa);
@@ -62,7 +65,7 @@ public class JwtUtilsTest extends BaseTest {
     }
 
     @Test
-    void testJwtIssuerAllowed() throws URISyntaxException, JOSEException {
+    void testJwtIssuerAllowed() throws URISyntaxException {
       when(externalCredsConfigMock.getAllowedJwtIssuers())
           .thenReturn(List.of(new URI(jwtSigningTestUtils.getIssuer())));
       var jwt =
@@ -74,7 +77,7 @@ public class JwtUtilsTest extends BaseTest {
     }
 
     @Test
-    void testJwtIssuerNotAllowed() throws URISyntaxException, JOSEException {
+    void testJwtIssuerNotAllowed() {
       var jwt =
           jwtSigningTestUtils.createVisaJwtString(
               jwtSigningTestUtils
@@ -84,7 +87,7 @@ public class JwtUtilsTest extends BaseTest {
     }
 
     @Test
-    void testJwtIssuerNotReal() throws URISyntaxException, JOSEException {
+    void testJwtIssuerNotReal() throws URISyntaxException {
       String testIssuer = "http://does.not.exist";
       when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(testIssuer)));
       var jwtNotRealIssuer =
@@ -100,7 +103,7 @@ public class JwtUtilsTest extends BaseTest {
     }
 
     @Test
-    void testJwtJkuNotOnAllowList() throws URISyntaxException, JOSEException {
+    void testJwtJkuNotOnAllowList() {
       var badJwt = jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.document_token).getJwt();
       var exception =
           assertThrows(InvalidJwtException.class, () -> jwtUtils.decodeAndValidateJwt(badJwt));
@@ -109,7 +112,31 @@ public class JwtUtilsTest extends BaseTest {
     }
 
     @Test
-    void testJwtJkuNotResponsive() throws URISyntaxException, JOSEException {
+    void testJwtAlgNotOnAllowList() throws URISyntaxException {
+      var issuer = "https://stsstg.nih.gov";
+      when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(issuer)));
+
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms())
+          .thenReturn(List.of("testAlg", "testAlg2"));
+
+      var visaClaimSet =
+          new JWTClaimsSet.Builder()
+              .expirationTime(new Date(System.currentTimeMillis()))
+              .issuer(issuer)
+              .claim(
+                  JwtUtils.GA4GH_VISA_V1_CLAIM,
+                  Map.of(JwtUtils.VISA_TYPE_CLAIM, TokenTypeEnum.document_token))
+              .build();
+
+      var jwt = jwtSigningTestUtils.createSignedJwt(visaClaimSet);
+      var exception =
+          assertThrows(InvalidJwtException.class, () -> jwtUtils.decodeAndValidateJwt(jwt));
+
+      assertTrue(exception.getMessage().contains("Algorithm"));
+    }
+
+    @Test
+    void testJwtJkuNotResponsive() throws URISyntaxException {
       String testIssuer = "http://localhost:10";
       when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(testIssuer)));
       when(externalCredsConfigMock.getAllowedJwksUris())
@@ -128,7 +155,7 @@ public class JwtUtilsTest extends BaseTest {
     }
 
     @Test
-    void testJwtJkuMalformed() throws URISyntaxException, JOSEException {
+    void testJwtJkuMalformed() throws URISyntaxException {
       String testIssuer = "foobar";
       when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(testIssuer)));
       when(externalCredsConfigMock.getAllowedJwksUris())

--- a/service/src/test/java/bio/terra/externalcreds/services/JwtUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/JwtUtilsTest.java
@@ -66,6 +66,7 @@ public class JwtUtilsTest extends BaseTest {
 
     @Test
     void testJwtIssuerAllowed() throws URISyntaxException {
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       when(externalCredsConfigMock.getAllowedJwtIssuers())
           .thenReturn(List.of(new URI(jwtSigningTestUtils.getIssuer())));
       var jwt =
@@ -89,6 +90,7 @@ public class JwtUtilsTest extends BaseTest {
     @Test
     void testJwtIssuerNotReal() throws URISyntaxException {
       String testIssuer = "http://does.not.exist";
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(testIssuer)));
       var jwtNotRealIssuer =
           jwtSigningTestUtils.createVisaJwtString(
@@ -138,6 +140,7 @@ public class JwtUtilsTest extends BaseTest {
     @Test
     void testJwtJkuNotResponsive() throws URISyntaxException {
       String testIssuer = "http://localhost:10";
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(testIssuer)));
       when(externalCredsConfigMock.getAllowedJwksUris())
           .thenReturn(List.of(new URI(testIssuer + JwtSigningTestUtils.JKU_PATH)));
@@ -157,6 +160,7 @@ public class JwtUtilsTest extends BaseTest {
     @Test
     void testJwtJkuMalformed() throws URISyntaxException {
       String testIssuer = "foobar";
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       when(externalCredsConfigMock.getAllowedJwtIssuers()).thenReturn(List.of(new URI(testIssuer)));
       when(externalCredsConfigMock.getAllowedJwksUris())
           .thenReturn(List.of(new URI(testIssuer + JwtSigningTestUtils.JKU_PATH)));

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -109,14 +109,12 @@ class PassportServiceTest extends BaseTest {
 
     @Test
     void testValidPassportMatchingCriteria() throws URISyntaxException {
-      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       runValidPassportTest(new ValidPassportTestParams());
     }
 
     @Test
     void testValidPassportNotMatchingIssuer() throws URISyntaxException {
       var params = new ValidPassportTestParams();
-      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       params.valid = false;
       params.issuer = "https://some.other.issuer";
       runValidPassportTest(params);
@@ -125,7 +123,6 @@ class PassportServiceTest extends BaseTest {
     @Test
     void testValidPassportNotMatchingVisaType() throws URISyntaxException {
       var params = new ValidPassportTestParams();
-      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       params.valid = false;
       params.visaType = "wrong visa type";
       runValidPassportTest(params);
@@ -134,7 +131,6 @@ class PassportServiceTest extends BaseTest {
     @Test
     void testValidPassportNotMatchingCriteria() throws URISyntaxException {
       var params = new ValidPassportTestParams();
-      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       params.valid = false;
       params.criterionPhsId = "phsDIFFERENT";
       runValidPassportTest(params);
@@ -201,6 +197,8 @@ class PassportServiceTest extends BaseTest {
     }
 
     private void runValidPassportTest(ValidPassportTestParams params) throws URISyntaxException {
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
+
       var linkedAccount = TestUtils.createRandomLinkedAccount();
       var otherLinkedAccount =
           TestUtils.createRandomLinkedAccount().withUserId(linkedAccount.getUserId());

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -109,12 +109,14 @@ class PassportServiceTest extends BaseTest {
 
     @Test
     void testValidPassportMatchingCriteria() throws URISyntaxException {
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       runValidPassportTest(new ValidPassportTestParams());
     }
 
     @Test
     void testValidPassportNotMatchingIssuer() throws URISyntaxException {
       var params = new ValidPassportTestParams();
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       params.valid = false;
       params.issuer = "https://some.other.issuer";
       runValidPassportTest(params);
@@ -123,6 +125,7 @@ class PassportServiceTest extends BaseTest {
     @Test
     void testValidPassportNotMatchingVisaType() throws URISyntaxException {
       var params = new ValidPassportTestParams();
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       params.valid = false;
       params.visaType = "wrong visa type";
       runValidPassportTest(params);
@@ -131,6 +134,7 @@ class PassportServiceTest extends BaseTest {
     @Test
     void testValidPassportNotMatchingCriteria() throws URISyntaxException {
       var params = new ValidPassportTestParams();
+      when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
       params.valid = false;
       params.criterionPhsId = "phsDIFFERENT";
       runValidPassportTest(params);

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -100,7 +100,6 @@ public class ProviderServiceTest extends BaseTest {
     @Test
     void testDeleteLinkLinkNotFound() {
       var linkedAccount = TestUtils.createRandomLinkedAccount();
-
       when(externalCredsConfigMock.getProviders())
           .thenReturn(Map.of(linkedAccount.getProviderName(), TestUtils.createRandomProvider()));
 


### PR DESCRIPTION
Add a config to validate the JWT algorithm.

Let me know if you think there are other tests I should add, the builder complains if I set the algorithm to "none" but that should be caught by the existing test. Codecov is mad about not testing the null check but I wasn't sure how to set up a test for that since the builder complains if you try to give it improperly formed or missing headers. 