### PR TITLE
POL-209 preferred_username, etc.

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -51,7 +51,6 @@ paths:
   /api/oidc/v1/{provider}/authorization-url:
     parameters:
       - $ref: '#/components/parameters/providerParam'
-      - $ref: '#/components/parameters/scopesParam'
       - $ref: '#/components/parameters/redirectUriParam'
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
@@ -71,8 +70,6 @@ paths:
   /api/oidc/v1/{provider}/oauthcode:
     parameters:
       - $ref: '#/components/parameters/providerParam'
-      - $ref: '#/components/parameters/scopesParam'
-      - $ref: '#/components/parameters/redirectUriParam'
       - $ref: '#/components/parameters/stateParam'
       - name: oauthcode
         description: oauth code returned by identity provider
@@ -240,16 +237,6 @@ components:
         type: string
         default: ras
       required: true
-    scopesParam:
-      name: scopes
-      description: list of scopes to authorize
-      in: query
-      required: true
-      example: [ "openid", "email", "ga4gh_passport_v1" ]
-      schema:
-        type: array
-        items:
-          type: string
     redirectUriParam:
       name: redirectUri
       description: oidc redirect uri

--- a/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
+++ b/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
@@ -18,6 +18,9 @@ public interface AuditLogEvent extends WithAuditLogEvent {
   Optional<String> getProviderName();
 
   @JsonInclude(Include.NON_EMPTY)
+  Optional<String> getExternalUserId();
+
+  @JsonInclude(Include.NON_EMPTY)
   Optional<String> getSshKeyPairType();
 
   AuditLogEventType getAuditLogEventType();

--- a/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
@@ -22,6 +22,12 @@ public interface ProviderPropertiesInterface {
 
   Map<String, Object> getAdditionalAuthorizationParameters();
 
+  Collection<Pattern> getAllowedRedirectUriPatterns();
+
+  Collection<String> getScopes();
+
+  String getExternalIdClaim();
+
   // optional overrides for values in provider's /.well-known/openid-configuration
   Optional<String> getUserInfoEndpoint();
 
@@ -32,6 +38,4 @@ public interface ProviderPropertiesInterface {
   Optional<String> getJwksUri();
 
   Optional<String> getValidationEndpoint();
-
-  Collection<Pattern> getAllowedRedirectUriPatterns();
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -18,7 +18,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import lombok.SneakyThrows;
 import org.springframework.http.ResponseEntity;
@@ -51,24 +50,17 @@ public record OidcApiController(
   }
 
   @Override
-  public ResponseEntity<String> getAuthUrl(
-      String providerName, List<String> scopes, String redirectUri) {
+  public ResponseEntity<String> getAuthUrl(String providerName, String redirectUri) {
     var userId = getUserIdFromSam(request, samService);
 
     var authorizationUrl =
-        providerService.getProviderAuthorizationUrl(
-            userId, providerName, redirectUri, Set.copyOf(scopes));
+        providerService.getProviderAuthorizationUrl(userId, providerName, redirectUri);
 
     return ResponseEntity.of(authorizationUrl.map(this::jsonString));
   }
 
   @Override
-  public ResponseEntity<LinkInfo> createLink(
-      String providerName,
-      List<String> scopes,
-      String redirectUri,
-      String state,
-      String oauthcode) {
+  public ResponseEntity<LinkInfo> createLink(String providerName, String state, String oauthcode) {
     var userId = getUserIdFromSam(request, samService);
 
     var auditLogEventBuilder =
@@ -79,8 +71,7 @@ public record OidcApiController(
 
     try {
       var linkedAccountWithPassportAndVisas =
-          providerService.createLink(
-              providerName, userId, oauthcode, redirectUri, Set.copyOf(scopes), state);
+          providerService.createLink(providerName, userId, oauthcode, state);
 
       auditLogger.logEvent(
           auditLogEventBuilder

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -8,7 +8,6 @@ import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.api.OidcApi;
 import bio.terra.externalcreds.generated.model.LinkInfo;
 import bio.terra.externalcreds.models.LinkedAccount;
-import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
 import bio.terra.externalcreds.services.LinkedAccountService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.services.ProviderService;
@@ -77,8 +76,9 @@ public record OidcApiController(
 
       auditLogger.logEvent(
           auditLogEventBuilder
-              .externalUserId(linkedAccountWithPassportAndVisas.map( l ->
-                  l.getLinkedAccount().getExternalUserId()))
+              .externalUserId(
+                  linkedAccountWithPassportAndVisas.map(
+                      l -> l.getLinkedAccount().getExternalUserId()))
               .auditLogEventType(
                   linkedAccountWithPassportAndVisas
                       .map(x -> AuditLogEventType.LinkCreated)

--- a/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
@@ -16,6 +16,8 @@ public interface OAuth2State extends WithOAuth2State {
 
   String getRandom();
 
+  String getRedirectUri();
+
   class Builder extends ImmutableOAuth2State.Builder {}
 
   default String encode(ObjectMapper objectMapper) {

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -236,7 +236,7 @@ public class ProviderService {
         jwtUtils.enrichAccountWithPassportAndVisas(linkedAccount, userInfo));
   }
 
-  public void deleteLink(String userId, String providerName) {
+  public LinkedAccount deleteLink(String userId, String providerName) {
     var providerInfo = externalCredsConfig.getProviders().get(providerName);
 
     if (providerInfo == null) {
@@ -251,6 +251,8 @@ public class ProviderService {
     revokeAccessToken(providerInfo, linkedAccount);
 
     linkedAccountService.deleteLinkedAccount(userId, providerName);
+
+    return linkedAccount;
   }
 
   public int validateAccessTokenVisas() {
@@ -295,6 +297,7 @@ public class ProviderService {
                 .auditLogEventType(AuditLogEventType.LinkRefreshed)
                 .providerName(linkedAccount.getProviderName())
                 .userId(linkedAccount.getUserId())
+                .externalUserId(linkedAccount.getExternalUserId())
                 .build());
 
       } catch (IllegalArgumentException iae) {
@@ -425,6 +428,7 @@ public class ProviderService {
             .auditLogEventType(AuditLogEventType.LinkExpired)
             .providerName(linkedAccount.getProviderName())
             .userId(linkedAccount.getUserId())
+            .externalUserId(linkedAccount.getExternalUserId())
             .build());
 
     linkedAccountService.upsertLinkedAccountWithPassportAndVisas(

--- a/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
@@ -4,7 +4,6 @@ import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import bio.terra.externalcreds.services.JwtUtils;
-import bio.terra.externalcreds.services.ProviderService;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -148,10 +147,10 @@ public class JwtSigningTestUtils {
     return visa;
   }
 
-  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas, String userEmail) {
+  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas) {
     var visaJwts = visas.stream().map(GA4GHVisa::getJwt).toList();
     var jwtId = UUID.randomUUID().toString();
-    var jwtString = createPassportJwtString(passportExpires, visaJwts, jwtId, userEmail);
+    var jwtString = createPassportJwtString(passportExpires, visaJwts, jwtId);
     return new GA4GHPassport.Builder()
         .jwt(jwtString)
         .expires(passportExpiresTime)
@@ -159,13 +158,11 @@ public class JwtSigningTestUtils {
         .build();
   }
 
-  private String createPassportJwtString(
-      Date expires, List<String> visaJwts, String jwtId, String userEmail) {
+  private String createPassportJwtString(Date expires, List<String> visaJwts, String jwtId) {
 
     var passportClaimSetBuilder =
         new JWTClaimsSet.Builder()
             .subject(UUID.randomUUID().toString())
-            .claim(ProviderService.EXTERNAL_USERID_ATTR, userEmail)
             .issuer(getIssuer())
             .jwtID(jwtId)
             .expirationTime(expires);

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -71,7 +71,8 @@ public class TestUtils {
           .setClientSecret(UUID.randomUUID().toString())
           .setIssuer("http://does/not/exist")
           .setLinkLifespan(Duration.ofDays(SecureRandom.getInstanceStrong().nextInt(10)))
-          .setRevokeEndpoint("http://does/not/exist");
+          .setRevokeEndpoint("http://does/not/exist")
+          .setExternalIdClaim("preferred_username");
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -338,6 +338,7 @@ class OidcApiControllerTest extends BaseTest {
                       .externalUserId(externalUserId)
                       .refreshToken("")
                       .expires(new Timestamp(0))
+                      .isAuthenticated(true)
                       .build()));
       when(passportServiceMock.getPassport(userId, providerName)).thenReturn(Optional.of(passport));
 

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -24,7 +24,6 @@ import bio.terra.externalcreds.services.ProviderService;
 import bio.terra.externalcreds.services.SamService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Timestamp;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -73,17 +72,14 @@ class OidcApiControllerTest extends BaseTest {
       var result = "https://test/authorization/uri";
       var providerName = "fake";
       var redirectUri = "fakeuri";
-      var scopes = Set.of("openid", "email");
 
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.getProviderAuthorizationUrl(
-              userId, providerName, redirectUri, scopes))
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, providerName, redirectUri))
           .thenReturn(Optional.of(result));
 
       var queryParams = new LinkedMultiValueMap<String, String>();
       queryParams.add("redirectUri", redirectUri);
-      queryParams.addAll("scopes", List.copyOf(scopes));
       mvc.perform(
               get("/api/oidc/v1/{provider}/authorization-url", providerName)
                   .header("authorization", "Bearer " + accessToken)
@@ -97,17 +93,14 @@ class OidcApiControllerTest extends BaseTest {
       var accessToken = "fakeAccessToken";
       var providerName = "fake";
       var redirectUri = "fakeuri";
-      var scopes = Set.of("openid", "email");
 
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.getProviderAuthorizationUrl(
-              userId, providerName, redirectUri, scopes))
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, providerName, redirectUri))
           .thenReturn(Optional.empty());
 
       var queryParams = new LinkedMultiValueMap<String, String>();
       queryParams.add("redirectUri", redirectUri);
-      queryParams.addAll("scopes", List.copyOf(scopes));
       mvc.perform(
               get("/api/oidc/v1/{provider}/authorization-url", providerName)
                   .header("authorization", "Bearer " + accessToken)
@@ -186,8 +179,6 @@ class OidcApiControllerTest extends BaseTest {
       var accessToken = "testToken";
       var inputLinkedAccount = TestUtils.createRandomLinkedAccount();
 
-      var scopes = new String[] {"email", "foo"};
-      var redirectUri = "http://redirect";
       var state = UUID.randomUUID().toString();
       var oauthcode = UUID.randomUUID().toString();
 
@@ -197,8 +188,6 @@ class OidcApiControllerTest extends BaseTest {
               inputLinkedAccount.getProviderName(),
               inputLinkedAccount.getUserId(),
               oauthcode,
-              redirectUri,
-              Set.of(scopes),
               state))
           .thenReturn(
               Optional.of(
@@ -209,8 +198,6 @@ class OidcApiControllerTest extends BaseTest {
       mvc.perform(
               post("/api/oidc/v1/{provider}/oauthcode", inputLinkedAccount.getProviderName())
                   .header("authorization", "Bearer " + accessToken)
-                  .param("scopes", scopes)
-                  .param("redirectUri", redirectUri)
                   .param("state", state)
                   .param("oauthcode", oauthcode))
           .andExpect(status().isOk())
@@ -227,7 +214,7 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser("userId", accessToken);
 
-      when(providerServiceMock.createLink(any(), any(), any(), any(), any(), any()))
+      when(providerServiceMock.createLink(any(), any(), any(), any()))
           .thenThrow(new ExternalCredsException("This is a drill!"));
 
       // check that an internal server error code is returned

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAOTest.java
@@ -16,15 +16,18 @@ public class OAuth2StateDAOTest extends BaseTest {
   void testCreateAndDelete() {
     var provider = "provider name";
     var userId = "user";
+    var redirectUri = "https://foo";
     var firstState =
         new OAuth2State.Builder()
             .provider(provider)
             .random(OAuth2State.generateRandomState(new SecureRandom()))
+            .redirectUri(redirectUri)
             .build();
     var secondState =
         new OAuth2State.Builder()
             .provider(provider)
             .random(OAuth2State.generateRandomState(new SecureRandom()))
+            .redirectUri(redirectUri)
             .build();
 
     oAuth2StateDAO.upsertOidcState(userId, firstState);

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -72,8 +72,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   @Test
   void testNoVisas() throws URISyntaxException {
     when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
-    var expectedPassport =
-        jwtSigningTestUtils.createTestPassport(Collections.emptyList(), userEmail);
+    var expectedPassport = jwtSigningTestUtils.createTestPassport(Collections.emptyList());
     var expectedLinkedAccount = createTestLinkedAccount();
     runTest(expectedLinkedAccount, expectedPassport, Collections.emptyList());
   }
@@ -82,7 +81,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   void testAccessTokenVisa() throws URISyntaxException {
     when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
     var visa = jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.access_token);
-    var expectedPassport = jwtSigningTestUtils.createTestPassport(List.of(visa), userEmail);
+    var expectedPassport = jwtSigningTestUtils.createTestPassport(List.of(visa));
     var expectedLinkedAccount = createTestLinkedAccount();
     runTest(expectedLinkedAccount, expectedPassport, List.of(visa));
   }
@@ -91,7 +90,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   void testDocumentTokenVisa() throws URISyntaxException {
     when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
     var visa = jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.document_token);
-    var expectedPassport = jwtSigningTestUtils.createTestPassport(List.of(visa), userEmail);
+    var expectedPassport = jwtSigningTestUtils.createTestPassport(List.of(visa));
     var expectedLinkedAccount = createTestLinkedAccount();
     runTest(expectedLinkedAccount, expectedPassport, List.of(visa));
   }
@@ -105,7 +104,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
             jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.access_token),
             jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.document_token),
             jwtSigningTestUtils.createTestVisaWithJwt(TokenTypeEnum.access_token));
-    var expectedPassport = jwtSigningTestUtils.createTestPassport(visas, userEmail);
+    var expectedPassport = jwtSigningTestUtils.createTestPassport(visas);
     var expectedLinkedAccount = createTestLinkedAccount();
     runTest(expectedLinkedAccount, expectedPassport, visas);
   }
@@ -119,7 +118,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   @Test
   void testInvalidAuthorizationCode() {
     var linkedAccount = createTestLinkedAccount();
-    var providerInfo = TestUtils.createRandomProvider();
+    var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
     var providerClient =
         ClientRegistration.withRegistrationId(linkedAccount.getProviderName())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
@@ -129,6 +128,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
         new OAuth2State.Builder()
             .provider(linkedAccount.getProviderName())
             .random(OAuth2State.generateRandomState(new SecureRandom()))
+            .redirectUri(redirectUri)
             .build();
     linkedAccountService.upsertOAuth2State(linkedAccount.getUserId(), state);
 
@@ -155,8 +155,6 @@ class AuthorizationCodeExchangeTest extends BaseTest {
                     linkedAccount.getProviderName(),
                     linkedAccount.getUserId(),
                     authorizationCode,
-                    redirectUri,
-                    scopes,
                     encodedState));
 
     // make sure the BadRequestException is for the right reason
@@ -171,7 +169,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
       Set<String> scopes,
       String state)
       throws URISyntaxException {
-    var providerInfo = TestUtils.createRandomProvider();
+    var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
     var providerClient =
         ClientRegistration.withRegistrationId(linkedAccount.getProviderName())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
@@ -182,12 +180,12 @@ class AuthorizationCodeExchangeTest extends BaseTest {
             .tokenType(TokenType.BEARER)
             .build();
     var userAttributes = new HashMap<String, Object>();
-    userAttributes.put(ProviderService.EXTERNAL_USERID_ATTR, linkedAccount.getExternalUserId());
+    userAttributes.put(providerInfo.getExternalIdClaim(), linkedAccount.getExternalUserId());
     if (passport != null) {
       userAttributes.put(JwtUtils.PASSPORT_JWT_V11_CLAIM, passport.getJwt());
     }
     OAuth2User user =
-        new DefaultOAuth2User(null, userAttributes, ProviderService.EXTERNAL_USERID_ATTR);
+        new DefaultOAuth2User(null, userAttributes, providerInfo.getExternalIdClaim());
 
     when(externalCredsConfigMock.getProviders())
         .thenReturn(Map.of(linkedAccount.getProviderName(), providerInfo));
@@ -220,6 +218,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
         new OAuth2State.Builder()
             .provider(expectedLinkedAccount.getProviderName())
             .random(OAuth2State.generateRandomState(new SecureRandom()))
+            .redirectUri(redirectUri)
             .build();
 
     String encodedState = state.encode(objectMapper);
@@ -238,8 +237,6 @@ class AuthorizationCodeExchangeTest extends BaseTest {
             expectedLinkedAccount.getProviderName(),
             expectedLinkedAccount.getUserId(),
             authorizationCode,
-            redirectUri,
-            scopes,
             encodedState);
 
     assertPresent(linkedAccountWithPassportAndVisas);

--- a/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
@@ -1,9 +1,10 @@
 package bio.terra.externalcreds.services;
 
 import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.config.ProviderProperties;
 import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
 import java.util.Scanner;
-import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -31,13 +32,14 @@ public class OAuth2ServiceTest {
    * to the identity provider.
    */
   void test() {
-    var providerClient = providerClientCache.getProviderClient("ras").orElseThrow();
+    String providerName = "ras-old";
+    var providerClient = providerClientCache.getProviderClient(providerName).orElseThrow();
 
     var redirectUri = "http://localhost:9000/fence-callback";
-    var scopes = Set.of("openid", "email", "ga4gh_passport_v1");
     String state = null;
-    var authorizationParameters =
-        externalCredsConfig.getProviders().get("ras").getAdditionalAuthorizationParameters();
+    ProviderProperties providerProperties = externalCredsConfig.getProviders().get(providerName);
+    var scopes = new HashSet<>(providerProperties.getScopes());
+    var authorizationParameters = providerProperties.getAdditionalAuthorizationParameters();
 
     // 1) test getAuthorizationRequestUri
     var authorizationRequestUri =

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -159,10 +159,8 @@ class PassportServiceTest extends BaseTest {
       var linkedAccount2 = linkedAccount1.withExternalUserId(UUID.randomUUID().toString());
       mockProviderConfig(linkedAccount1);
 
-      var passport1 =
-          jwtSigningTestUtils.createTestPassport(List.of(), linkedAccount1.getExternalUserId());
-      var passport2 =
-          jwtSigningTestUtils.createTestPassport(List.of(), linkedAccount2.getExternalUserId());
+      var passport1 = jwtSigningTestUtils.createTestPassport(List.of());
+      var passport2 = jwtSigningTestUtils.createTestPassport(List.of());
 
       linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
           new LinkedAccountWithPassportAndVisas.Builder()
@@ -217,13 +215,10 @@ class PassportServiceTest extends BaseTest {
           createDbGapVisa(Set.of(notMatchingPermission), params.visaType);
 
       var visas = List.of(visaWithMatchingPermission);
-      var passport =
-          jwtSigningTestUtils.createTestPassport(visas, linkedAccount.getExternalUserId());
+      var passport = jwtSigningTestUtils.createTestPassport(visas);
 
       var otherVisas = List.of(visaWithoutMatchingPermission);
-      var otherPassport =
-          jwtSigningTestUtils.createTestPassport(
-              otherVisas, otherLinkedAccount.getExternalUserId());
+      var otherPassport = jwtSigningTestUtils.createTestPassport(otherVisas);
 
       if (params.persistLinkedAccount) {
         linkedAccountService.upsertLinkedAccountWithPassportAndVisas(

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -659,7 +659,8 @@ public class ProviderServiceTest extends BaseTest {
       var clientRegistration = createClientRegistration(linkedAccount.getProviderName());
       var providerProperties =
           ProviderProperties.create()
-              .setAllowedRedirectUriPatterns(List.of(Pattern.compile(redirectUri)));
+              .setAllowedRedirectUriPatterns(List.of(Pattern.compile(redirectUri)))
+              .setScopes(scopes);
 
       when(externalCredsConfigMock.getProviders())
           .thenReturn(Map.of(linkedAccount.getProviderName(), providerProperties));
@@ -679,7 +680,7 @@ public class ProviderServiceTest extends BaseTest {
 
       var result =
           providerService.getProviderAuthorizationUrl(
-              linkedAccount.getUserId(), linkedAccount.getProviderName(), redirectUri, scopes);
+              linkedAccount.getUserId(), linkedAccount.getProviderName(), redirectUri);
       assertPresent(result);
       // the result here should be only the state because of the mock above
       var savedState =
@@ -700,6 +701,7 @@ public class ProviderServiceTest extends BaseTest {
               .random(
                   bio.terra.externalcreds.models.OAuth2State.generateRandomState(
                       new SecureRandom()))
+              .redirectUri(redirectUri)
               .build();
 
       oAuth2StateDAO.upsertOidcState(expectedLinkedAccount.getUserId(), state);
@@ -711,8 +713,6 @@ public class ProviderServiceTest extends BaseTest {
                   expectedLinkedAccount.getProviderName(),
                   expectedLinkedAccount.getUserId(),
                   UUID.randomUUID().toString(),
-                  redirectUri,
-                  scopes,
                   state.withRandom("wrong").encode(objectMapper)));
     }
 
@@ -725,6 +725,7 @@ public class ProviderServiceTest extends BaseTest {
               .random(
                   bio.terra.externalcreds.models.OAuth2State.generateRandomState(
                       new SecureRandom()))
+              .redirectUri(redirectUri)
               .build();
 
       oAuth2StateDAO.upsertOidcState(expectedLinkedAccount.getUserId(), state);
@@ -736,8 +737,6 @@ public class ProviderServiceTest extends BaseTest {
                   expectedLinkedAccount.getProviderName(),
                   expectedLinkedAccount.getUserId(),
                   UUID.randomUUID().toString(),
-                  redirectUri,
-                  scopes,
                   state.withProvider("wrong").encode(objectMapper)));
     }
 
@@ -753,8 +752,6 @@ public class ProviderServiceTest extends BaseTest {
                       expectedLinkedAccount.getProviderName(),
                       expectedLinkedAccount.getUserId(),
                       UUID.randomUUID().toString(),
-                      redirectUri,
-                      scopes,
                       "not base64 encoded"));
 
       assertInstanceOf(CannotDecodeOAuth2State.class, e.getCause());
@@ -773,8 +770,6 @@ public class ProviderServiceTest extends BaseTest {
                       expectedLinkedAccount.getProviderName(),
                       expectedLinkedAccount.getUserId(),
                       UUID.randomUUID().toString(),
-                      redirectUri,
-                      scopes,
                       new String(Base64.getEncoder().encode("not json".getBytes()))));
 
       assertInstanceOf(CannotDecodeOAuth2State.class, e.getCause());
@@ -793,8 +788,6 @@ public class ProviderServiceTest extends BaseTest {
                       expectedLinkedAccount.getProviderName(),
                       expectedLinkedAccount.getUserId(),
                       UUID.randomUUID().toString(),
-                      redirectUri,
-                      scopes,
                       new String(
                           Base64.getEncoder()
                               .encode(
@@ -834,7 +827,8 @@ public class ProviderServiceTest extends BaseTest {
       var clientRegistration = createClientRegistration(linkedAccount.getProviderName());
       var providerProperties =
           ProviderProperties.create()
-              .setAllowedRedirectUriPatterns(List.of(Pattern.compile(uriPattern)));
+              .setAllowedRedirectUriPatterns(List.of(Pattern.compile(uriPattern)))
+              .setScopes(scopes);
 
       when(externalCredsConfigMock.getProviders())
           .thenReturn(Map.of(linkedAccount.getProviderName(), providerProperties));
@@ -850,7 +844,7 @@ public class ProviderServiceTest extends BaseTest {
           .thenReturn("");
 
       return providerService.getProviderAuthorizationUrl(
-          linkedAccount.getUserId(), linkedAccount.getProviderName(), redirectUri, scopes);
+          linkedAccount.getUserId(), linkedAccount.getProviderName(), redirectUri);
     }
   }
 


### PR DESCRIPTION
a few changes:
* push requested scopes into provider config
* store redirect uri in oauth state so it does not have to be resubmitted with the oauth code
* provider config for external user id
* audit logging external user id