### PR TITLE
[POL-210] Logging transaction claims from Jwt

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
+++ b/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
@@ -23,6 +23,9 @@ public interface AuditLogEvent extends WithAuditLogEvent {
   @JsonInclude(Include.NON_EMPTY)
   Optional<String> getSshKeyPairType();
 
+  @JsonInclude(Include.NON_EMPTY)
+  Optional<String> getTransactionClaim();
+
   AuditLogEventType getAuditLogEventType();
 
   class Builder extends ImmutableAuditLogEvent.Builder {}

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -70,7 +70,7 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig) {
         .build();
   }
 
-  public Optional<String> getJwtTransactionId(String jwtString) {
+  public Optional<String> getJwtTransactionClaim(String jwtString) {
     var txnClaim = decodeAndValidateJwt(jwtString).getClaims().get(JWT_TRANSACTION_CLAIM);
     return Optional.ofNullable(txnClaim).map(Objects::toString);
   }

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -36,6 +36,7 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig) {
   public static final String VISA_TYPE_CLAIM = "type";
   public static final String JKU_HEADER = "jku";
   public static final String JWT_ID_CLAIM = "jti";
+  public static final String JWT_TRANSACTION_CLAIM = "txn";
 
   public LinkedAccountWithPassportAndVisas enrichAccountWithPassportAndVisas(
       LinkedAccount linkedAccount, OAuth2User userInfo) {
@@ -67,6 +68,17 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig) {
         .passport(buildPassport(passportJwt))
         .visas(visas)
         .build();
+  }
+
+  public static Optional<String> getJwtTransactionId(String jwt) {
+    try {
+      // TODO: look for more foolproof ways of parsing this (decode entire JWT?, call decode and validate?)
+      var parsedJwt = JWTParser.parse(jwt);
+      var txnClaim = parsedJwt.getJWTClaimsSet().getClaim(JWT_TRANSACTION_CLAIM);
+      return Optional.ofNullable(txnClaim.toString());
+    } catch (ParseException e) {
+      throw new InvalidJwtException(e);
+    }
   }
 
   private static GA4GHPassport buildPassport(Jwt passportJwt) {

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -70,12 +70,10 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig) {
         .build();
   }
 
-  public static Optional<String> getJwtTransactionId(String jwt) {
+  public static Optional<String> getJwtTransactionId(String jwtString) {
     try {
-      // TODO: look for more foolproof ways of parsing this (decode entire JWT?, call decode and validate?)
-      var parsedJwt = JWTParser.parse(jwt);
-      var txnClaim = parsedJwt.getJWTClaimsSet().getClaim(JWT_TRANSACTION_CLAIM);
-      return Optional.ofNullable(txnClaim.toString());
+      var txnClaim = JWTParser.parse(jwtString).getJWTClaimsSet().getClaim(JWT_TRANSACTION_CLAIM);
+      return Optional.ofNullable(txnClaim).map(Objects::toString);
     } catch (ParseException e) {
       throw new InvalidJwtException(e);
     }

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -70,13 +70,9 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig) {
         .build();
   }
 
-  public static Optional<String> getJwtTransactionId(String jwtString) {
-    try {
-      var txnClaim = JWTParser.parse(jwtString).getJWTClaimsSet().getClaim(JWT_TRANSACTION_CLAIM);
-      return Optional.ofNullable(txnClaim).map(Objects::toString);
-    } catch (ParseException e) {
-      throw new InvalidJwtException(e);
-    }
+  public Optional<String> getJwtTransactionId(String jwtString) {
+    var txnClaim = decodeAndValidateJwt(jwtString).getClaims().get(JWT_TRANSACTION_CLAIM);
+    return Optional.ofNullable(txnClaim).map(Objects::toString);
   }
 
   private static GA4GHPassport buildPassport(Jwt passportJwt) {

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -18,6 +18,7 @@ import bio.terra.externalcreds.visaComparators.VisaCriterionInternal;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,13 +93,14 @@ public class PassportService {
             var linkedAccount =
                 linkedAccountsByJwtId.get(passportWithVisas.getPassport().getJwtId());
             var auditInfoMap =
-                Map.of(
-                    "passport_jti",
-                    passportWithVisas.getPassport().getJwtId(),
-                    "external_user_id",
-                    linkedAccount.getExternalUserId(),
-                    "internal_user_id",
-                    linkedAccount.getUserId());
+                new HashMap<>(
+                    Map.of(
+                        "passport_jti",
+                        passportWithVisas.getPassport().getJwtId(),
+                        "external_user_id",
+                        linkedAccount.getExternalUserId(),
+                        "internal_user_id",
+                        linkedAccount.getUserId()));
             transactionClaim.map(t -> auditInfoMap.put("txn", t));
             return new ValidatePassportResultInternal.Builder()
                 .valid(true)

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -82,7 +82,7 @@ public class PassportService {
     var linkedAccountsByJwtId = getLinkedAccountsForAllPassports(passports);
 
     for (var passportWithVisas : passports) {
-      var transactionClaim = JwtUtils.getJwtTransactionId(passportWithVisas.getPassport().getJwt());
+      var transactionClaim = jwtUtils.getJwtTransactionId(passportWithVisas.getPassport().getJwt());
       for (var criterion : criteria) {
         for (var visa : passportWithVisas.getVisas()) {
           VisaComparator visaComparator = getVisaComparator(criterion);
@@ -98,7 +98,7 @@ public class PassportService {
                 linkedAccount.getExternalUserId(),
                 "internal_user_id",
                 linkedAccount.getUserId());
-            transactionClaim.map(t -> auditInfoMap.put("transaction_claim", t));
+            transactionClaim.map(t -> auditInfoMap.put("txn", t));
             return new ValidatePassportResultInternal.Builder()
                 .valid(true)
                 .matchedCriterion(criterion)

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -83,7 +83,8 @@ public class PassportService {
     var linkedAccountsByJwtId = getLinkedAccountsForAllPassports(passports);
 
     for (var passportWithVisas : passports) {
-      var transactionClaim = jwtUtils.getJwtTransactionId(passportWithVisas.getPassport().getJwt());
+      var transactionClaim =
+          jwtUtils.getJwtTransactionClaim(passportWithVisas.getPassport().getJwt());
       for (var criterion : criteria) {
         for (var visa : passportWithVisas.getVisas()) {
           VisaComparator visaComparator = getVisaComparator(criterion);

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -91,13 +91,14 @@ public class PassportService {
               && visaComparator.matchesCriterion(visa, criterion)) {
             var linkedAccount =
                 linkedAccountsByJwtId.get(passportWithVisas.getPassport().getJwtId());
-            var auditInfoMap = Map.of(
-                "passport_jti",
-                passportWithVisas.getPassport().getJwtId(),
-                "external_user_id",
-                linkedAccount.getExternalUserId(),
-                "internal_user_id",
-                linkedAccount.getUserId());
+            var auditInfoMap =
+                Map.of(
+                    "passport_jti",
+                    passportWithVisas.getPassport().getJwtId(),
+                    "external_user_id",
+                    linkedAccount.getExternalUserId(),
+                    "internal_user_id",
+                    linkedAccount.getUserId());
             transactionClaim.map(t -> auditInfoMap.put("txn", t));
             return new ValidatePassportResultInternal.Builder()
                 .valid(true)

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -291,13 +291,17 @@ public class ProviderService {
         var linkedAccountWithRefreshedPassport = getRefreshedPassportsAndVisas(linkedAccount);
         linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
             linkedAccountWithRefreshedPassport);
-
+        var transactionClaim =
+            linkedAccountWithRefreshedPassport
+                .getPassport()
+                .flatMap(p -> jwtUtils.getJwtTransactionClaim(p.getJwt()));
         auditLogger.logEvent(
             new AuditLogEvent.Builder()
                 .auditLogEventType(AuditLogEventType.LinkRefreshed)
                 .providerName(linkedAccount.getProviderName())
                 .userId(linkedAccount.getUserId())
                 .externalUserId(linkedAccount.getExternalUserId())
+                .transactionClaim(transactionClaim)
                 .build());
 
       } catch (IllegalArgumentException iae) {

--- a/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
@@ -17,6 +17,7 @@ import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
 import java.net.URI;
 import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -147,10 +148,10 @@ public class JwtSigningTestUtils {
     return visa;
   }
 
-  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas) {
+  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas, Map<String, String> customClaims) {
     var visaJwts = visas.stream().map(GA4GHVisa::getJwt).toList();
     var jwtId = UUID.randomUUID().toString();
-    var jwtString = createPassportJwtString(passportExpires, visaJwts, jwtId);
+    var jwtString = createPassportJwtString(passportExpires, visaJwts, jwtId, customClaims);
     return new GA4GHPassport.Builder()
         .jwt(jwtString)
         .expires(passportExpiresTime)
@@ -158,7 +159,12 @@ public class JwtSigningTestUtils {
         .build();
   }
 
-  private String createPassportJwtString(Date expires, List<String> visaJwts, String jwtId) {
+  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas) {
+    return createTestPassport(visas, Collections.emptyMap());
+  }
+
+  private String createPassportJwtString(
+      Date expires, List<String> visaJwts, String jwtId, Map<String, String> customClaims) {
 
     var passportClaimSetBuilder =
         new JWTClaimsSet.Builder()
@@ -170,6 +176,8 @@ public class JwtSigningTestUtils {
     if (!visaJwts.isEmpty()) {
       passportClaimSetBuilder.claim(JwtUtils.GA4GH_PASSPORT_V1_CLAIM, visaJwts);
     }
+
+    customClaims.forEach(passportClaimSetBuilder::claim);
 
     var claimsSet = passportClaimSetBuilder.build();
     return createSignedJwt(claimsSet);

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -292,12 +292,10 @@ class PassportServiceTest extends BaseTest {
                   "internal_user_id",
                   linkedAccount.getUserId()));
       expectedAuditInfo.putAll(customInfoExpected);
-      var testVar = 1 + 1;
       return expectedAuditInfo;
     }
 
     private Map<String, String> expectedAuditInfo(LinkedAccount linkedAccount) {
-      // TODO: decide if readability is better if I put additionalInfoExpected here as well
       return Map.of("internal_user_id", linkedAccount.getUserId());
     }
 

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -25,6 +25,7 @@ import com.nimbusds.jose.JOSEException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -137,6 +138,15 @@ class PassportServiceTest extends BaseTest {
     }
 
     @Test
+    void testTransactionIdAppearsInAuditInfo() throws URISyntaxException {
+      var params = new ValidPassportTestParams();
+      var transactionClaim = Map.of("txn", "testTransactionId");
+      params.customJwtClaims = transactionClaim;
+      params.customAuditInfoExpected = transactionClaim;
+      runValidPassportTest(params);
+    }
+
+    @Test
     void testValidPassportWithoutUserThrows() {
       var params = new ValidPassportTestParams();
       params.persistLinkedAccount = false;
@@ -192,6 +202,8 @@ class PassportServiceTest extends BaseTest {
       String visaPhsId = "phs000123";
       String criterionPhsId = visaPhsId;
       boolean persistLinkedAccount = true;
+      Map<String, String> customJwtClaims = Collections.emptyMap();
+      Map<String, String> customAuditInfoExpected = Collections.emptyMap();
     }
 
     private void runValidPassportTest(ValidPassportTestParams params) throws URISyntaxException {
@@ -215,10 +227,11 @@ class PassportServiceTest extends BaseTest {
           createDbGapVisa(Set.of(notMatchingPermission), params.visaType);
 
       var visas = List.of(visaWithMatchingPermission);
-      var passport = jwtSigningTestUtils.createTestPassport(visas);
+      var passport = jwtSigningTestUtils.createTestPassport(visas, params.customJwtClaims);
 
       var otherVisas = List.of(visaWithoutMatchingPermission);
-      var otherPassport = jwtSigningTestUtils.createTestPassport(otherVisas);
+      var otherPassport =
+          jwtSigningTestUtils.createTestPassport(otherVisas, params.customJwtClaims);
 
       if (params.persistLinkedAccount) {
         linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
@@ -250,7 +263,8 @@ class PassportServiceTest extends BaseTest {
         assertEquals(
             new ValidatePassportResultInternal.Builder()
                 .valid(true)
-                .auditInfo(expectedAuditInfo(linkedAccount, passport))
+                .auditInfo(
+                    expectedAuditInfo(linkedAccount, passport, params.customAuditInfoExpected))
                 .matchedCriterion(criterion)
                 .build(),
             result);
@@ -265,17 +279,25 @@ class PassportServiceTest extends BaseTest {
     }
 
     private Map<String, String> expectedAuditInfo(
-        LinkedAccount linkedAccount, GA4GHPassport passport) {
-      return Map.of(
-          "passport_jti",
-          passport.getJwtId(),
-          "external_user_id",
-          linkedAccount.getExternalUserId(),
-          "internal_user_id",
-          linkedAccount.getUserId());
+        LinkedAccount linkedAccount,
+        GA4GHPassport passport,
+        Map<String, String> customInfoExpected) {
+      var expectedAuditInfo =
+          new HashMap<>(
+              Map.of(
+                  "passport_jti",
+                  passport.getJwtId(),
+                  "external_user_id",
+                  linkedAccount.getExternalUserId(),
+                  "internal_user_id",
+                  linkedAccount.getUserId()));
+      expectedAuditInfo.putAll(customInfoExpected);
+      var testVar = 1 + 1;
+      return expectedAuditInfo;
     }
 
     private Map<String, String> expectedAuditInfo(LinkedAccount linkedAccount) {
+      // TODO: decide if readability is better if I put additionalInfoExpected here as well
       return Map.of("internal_user_id", linkedAccount.getUserId());
     }
 


### PR DESCRIPTION
Added:
- Parsing the transaction ("txn") claim from the passport JWT
- If the transaction claim exists, then also:
  - Include it in the returned audit info
  - Include it in the audit logs when we get a new passport
- Unit tests can now specify "custom JWT claims" when generating a test passport JWT
 
Let me know if anyone can think of any other unit tests I should add. 