### PR TITLE
use relative path for the JSON key directory path

### DIFF
--- a/integration/src/main/resources/serviceaccounts/delegate-user-sa.json
+++ b/integration/src/main/resources/serviceaccounts/delegate-user-sa.json
@@ -1,5 +1,5 @@
 {
   "name": "firecloud-dev@broad-dsde-dev.iam.gserviceaccount.com",
   "jsonKeyFilename": "user-delegated-sa.json",
-  "jsonKeyDirectoryPath": "./src/main/resources/rendered"
+  "jsonKeyDirectoryPath": "../rendered"
 }

--- a/integration/src/main/resources/serviceaccounts/delegate-user-sa.json
+++ b/integration/src/main/resources/serviceaccounts/delegate-user-sa.json
@@ -1,5 +1,5 @@
 {
   "name": "firecloud-dev@broad-dsde-dev.iam.gserviceaccount.com",
   "jsonKeyFilename": "user-delegated-sa.json",
-  "jsonKeyDirectoryPath": "../rendered"
+  "jsonKeyDirectoryPath": "./rendered"
 }

--- a/integration/src/main/resources/serviceaccounts/testrunner-sa.json
+++ b/integration/src/main/resources/serviceaccounts/testrunner-sa.json
@@ -1,5 +1,5 @@
 {
   "name": "testrunner-perf@broad-dsde-perf.iam.gserviceaccount.com",
   "jsonKeyFilename": "testrunner-sa.json",
-  "jsonKeyDirectoryPath": "../rendered"
+  "jsonKeyDirectoryPath": "./rendered"
 }

--- a/integration/src/main/resources/serviceaccounts/testrunner-sa.json
+++ b/integration/src/main/resources/serviceaccounts/testrunner-sa.json
@@ -1,5 +1,5 @@
 {
   "name": "testrunner-perf@broad-dsde-perf.iam.gserviceaccount.com",
   "jsonKeyFilename": "testrunner-sa.json",
-  "jsonKeyDirectoryPath": "./src/main/resources/rendered"
+  "jsonKeyDirectoryPath": "../rendered"
 }


### PR DESCRIPTION
 Use a relatiev path so that when running the integration test from a doenstream verily ecm repo, we can still find the json file in the rendered/ directory.