### PR TITLE
ID-159 Don't log post bodies

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/logging/LoggerInterceptor.java
+++ b/service/src/main/java/bio/terra/externalcreds/logging/LoggerInterceptor.java
@@ -92,6 +92,8 @@ public record LoggerInterceptor(AuthenticatedUserRequestFactory authenticatedUse
       Map<String, String> stackDriverPayload = new HashMap<>();
       if (RequestMethod.POST.name().equalsIgnoreCase(method)
           || RequestMethod.PUT.name().equalsIgnoreCase(method)) {
+        // ECM will not log POST bodies, because the `validate` endpoint contains passports
+        // in the POST body.
         stackDriverPayload.put("userId", userId);
         stackDriverPayload.put("userEmail", userEmail);
         stackDriverPayload.put("params", paramString);

--- a/service/src/main/java/bio/terra/externalcreds/logging/LoggerInterceptor.java
+++ b/service/src/main/java/bio/terra/externalcreds/logging/LoggerInterceptor.java
@@ -92,15 +92,6 @@ public record LoggerInterceptor(AuthenticatedUserRequestFactory authenticatedUse
       Map<String, String> stackDriverPayload = new HashMap<>();
       if (RequestMethod.POST.name().equalsIgnoreCase(method)
           || RequestMethod.PUT.name().equalsIgnoreCase(method)) {
-        String requestBody =
-            new String(
-                ((ContentCachingRequestWrapper) request).getContentAsByteArray(),
-                StandardCharsets.UTF_8);
-        String requestBodyPayload =
-            requestBody.length() > STACKDRIVER_MAX_CHARS
-                ? requestBody.substring(0, STACKDRIVER_MAX_CHARS)
-                : requestBody;
-        stackDriverPayload.put("requestBody", requestBodyPayload);
         stackDriverPayload.put("userId", userId);
         stackDriverPayload.put("userEmail", userEmail);
         stackDriverPayload.put("params", paramString);


### PR DESCRIPTION
I had a realization that ECM shouldn't be logging POST bodies, as the `validatePassport` endpoint gets a passport as its body, and we shouldn't be saving that to logs! This is a follow-on to the logging improvements recently made.
