### PR TITLE
ID-162 External User Passport Support

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/logging/LoggerInterceptor.java
+++ b/service/src/main/java/bio/terra/externalcreds/logging/LoggerInterceptor.java
@@ -6,7 +6,6 @@ import bio.terra.common.iam.AuthenticatedUserRequestFactory;
 import com.google.gson.Gson;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -17,7 +16,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
-import org.springframework.web.util.ContentCachingRequestWrapper;
 
 @Component
 @Slf4j

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -17,6 +17,7 @@ import java.sql.Timestamp;
 import java.text.ParseException;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -71,6 +72,14 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig, JwtDecoderCache 
   public Optional<String> getJwtTransactionClaim(String jwtString) {
     var txnClaim = decodeAndValidateJwt(jwtString).getClaims().get(JWT_TRANSACTION_CLAIM);
     return Optional.ofNullable(txnClaim).map(Objects::toString);
+  }
+
+  public Date getJwtIssuedAt(String jwtString) {
+    try {
+      return JWTParser.parse(jwtString).getJWTClaimsSet().getIssueTime();
+    } catch (ParseException e) {
+      throw new InvalidJwtException(e);
+    }
   }
 
   private static GA4GHPassport buildPassport(Jwt passportJwt) {

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -15,9 +15,7 @@ import bio.terra.externalcreds.models.ValidatePassportResultInternal;
 import bio.terra.externalcreds.models.VisaVerificationDetails;
 import bio.terra.externalcreds.visaComparators.VisaComparator;
 import bio.terra.externalcreds.visaComparators.VisaCriterionInternal;
-import com.nimbusds.jwt.JWTParser;
 import java.sql.Timestamp;
-import java.text.ParseException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -144,15 +142,9 @@ public class PassportService {
   }
 
   private boolean isPassportIssueTimeValid(GA4GHPassport passport) {
-    try {
-      var issueTime = JWTParser.parse(passport.getJwt()).getJWTClaimsSet().getIssueTime().getTime();
-      var now = Instant.now().toEpochMilli();
-      return (now - issueTime < VISA_VALIDITY_TIME);
-    } catch (ParseException ex) {
-      throw new ExternalCredsException(
-          String.format("Unable to parse JWT for passport with JWT ID: %s", passport.getJwtId()),
-          ex);
-    }
+    var issueTime = jwtUtils.getJwtIssuedAt(passport.getJwt()).getTime();
+    var now = Instant.now().toEpochMilli();
+    return (now - issueTime < VISA_VALIDITY_TIME);
   }
 
   private Collection<PassportWithVisas> decodeAndValidatePassports(

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -39,7 +39,7 @@ public class PassportService {
   private final JwtUtils jwtUtils;
   private final Collection<VisaComparator> visaComparators;
 
-  private static final long VISA_VALIDITY_TIME = Duration.of(1, ChronoUnit.HOURS).toMillis();
+  private static final Duration VISA_VALIDITY_TIME = Duration.of(1, ChronoUnit.HOURS);
 
   public PassportService(
       LinkedAccountDAO linkedAccountDAO,
@@ -142,9 +142,10 @@ public class PassportService {
   }
 
   private boolean isPassportIssueTimeValid(GA4GHPassport passport) {
-    var issueTime = jwtUtils.getJwtIssuedAt(passport.getJwt()).getTime();
-    var now = Instant.now().toEpochMilli();
-    return (now - issueTime < VISA_VALIDITY_TIME);
+    int comparison =
+        Duration.between(jwtUtils.getJwtIssuedAt(passport.getJwt()).toInstant(), Instant.now())
+            .compareTo(VISA_VALIDITY_TIME);
+    return comparison < 0;
   }
 
   private Collection<PassportWithVisas> decodeAndValidatePassports(

--- a/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/JwtSigningTestUtils.java
@@ -148,7 +148,7 @@ public class JwtSigningTestUtils {
     return visa;
   }
 
-  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas, Map<String, String> customClaims) {
+  public GA4GHPassport createTestPassport(List<GA4GHVisa> visas, Map<String, Object> customClaims) {
     var visaJwts = visas.stream().map(GA4GHVisa::getJwt).toList();
     var jwtId = UUID.randomUUID().toString();
     var jwtString = createPassportJwtString(passportExpires, visaJwts, jwtId, customClaims);
@@ -164,7 +164,7 @@ public class JwtSigningTestUtils {
   }
 
   private String createPassportJwtString(
-      Date expires, List<String> visaJwts, String jwtId, Map<String, String> customClaims) {
+      Date expires, List<String> visaJwts, String jwtId, Map<String, Object> customClaims) {
 
     var passportClaimSetBuilder =
         new JWTClaimsSet.Builder()

--- a/service/src/test/java/bio/terra/externalcreds/services/JwtUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/JwtUtilsTest.java
@@ -176,5 +176,10 @@ public class JwtUtilsTest extends BaseTest {
               InvalidJwtException.class, () -> jwtUtils.decodeAndValidateJwt(jwtMalformedJku));
       assertTrue(exception.getMessage().contains("URI is not absolute"));
     }
+
+    @Test
+    void testJwtGetIssuedJkuMalformed() {
+      assertThrows(InvalidJwtException.class, () -> jwtUtils.getJwtIssuedAt("garbage"));
+    }
   }
 }


### PR DESCRIPTION
Adding support for the validation of passports from non-Terra users. This is a naive addition to support passports from SevenBridges, who have confirmed that the passports they send will never be more than 20 minutes old. This lets us simply check that a passport was issues less than an hour ago to validate all its visas. We don't need to reach out to RAS in this case to re-validate the visas! 

I've hardcoded the visa validity time for ease of implementation. This will probably need to be configured per-provider in the future, but since we only have RAS at this point, the hardcoded value will suffice. 

I've added tests to make sure that a "young" external passport is deemed valid, and that one over an hour old is deemed invalid. 