### PR TITLE
[PF-2478] Only run checks when PR targets default branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,11 +1,13 @@
 name: Build and Test
 
 on:
+  workflow_dispatch: {}
   push:
     branches: [ dev ]
     paths-ignore: [ '*.md' ]
   pull_request:
-    branches: [ '**' ]
+    # Branch settings require status checks before merging, so don't add paths-ignore.
+    branches: [ dev ]
 
 jobs:
   build:


### PR DESCRIPTION
Only run PR checks when the PR targets primary/default branch

currently, all PRs (irrespective of the branch they target) automatically trigger PR checks. This is unnecessary and may cause the checks to be queued up on GitHub runner.

ref -

- https://github.com/DataBiosphere/terra-workspace-manager/pull/1061
- https://broadworkbench.atlassian.net/browse/PF-2478