### PR TITLE
PF-2500: make private key an optional field and by default do not return it.

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -165,6 +165,8 @@ paths:
     parameters:
       - $ref: '#/components/parameters/sshKeyPairTypeParam'
     get:
+      parameters:
+        - $ref: '#/components/parameters/includePrivateKey'
       summary: Get the ssh key pair of the given provider.
       tags: [ ssh key pair ]
       operationId: getSshKeyPair
@@ -192,6 +194,8 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
     post:
+      parameters:
+        - $ref: '#/components/parameters/includePrivateKey'
       summary: Generates a pair of ssh keys
       tags: [ ssh key pair ]
       operationId: generateSshKeyPair
@@ -221,7 +225,6 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-
 components:
   parameters:
     sshKeyPairTypeParam:
@@ -230,6 +233,13 @@ components:
       schema:
         $ref: '#/components/schemas/SshKeyPairType'
       required: true
+    includePrivateKey:
+      name: includePrivateKey
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: false
     providerParam:
       name: provider
       in: path
@@ -319,7 +329,7 @@ components:
         - azure
     SshKeyPair:
       type: object
-      required: [ privateKey, publicKey, externalUserEmail ]
+      required: [ publicKey, externalUserEmail ]
       properties:
         privateKey:
           type: string

--- a/integration/src/main/java/scripts/testscripts/EncryptDecryptSshKeyPair.java
+++ b/integration/src/main/java/scripts/testscripts/EncryptDecryptSshKeyPair.java
@@ -21,16 +21,22 @@ public class EncryptDecryptSshKeyPair extends TestScript {
 
     // generate a key for each ssh key pair type
     var githubSshKeyPair =
-        sshKeyPairApi.generateSshKeyPair('"' + testUser.userEmail + '"', SshKeyPairType.GITHUB);
+        sshKeyPairApi.generateSshKeyPair(
+            '"' + testUser.userEmail + '"', SshKeyPairType.GITHUB, /*includePrivateKey=*/ true);
     var gitlabSshKeyPair =
-        sshKeyPairApi.generateSshKeyPair('"' + testUser.userEmail + '"', SshKeyPairType.GITLAB);
+        sshKeyPairApi.generateSshKeyPair(
+            '"' + testUser.userEmail + '"', SshKeyPairType.GITLAB, /*includePrivateKey=*/ false);
     var azureSshKeyPair =
-        sshKeyPairApi.generateSshKeyPair('"' + testUser.userEmail + '"', SshKeyPairType.AZURE);
+        sshKeyPairApi.generateSshKeyPair(
+            '"' + testUser.userEmail + '"', SshKeyPairType.AZURE, /*includePrivateKey=*/ false);
 
     // get the key for each ssh key pair type
-    var githubLoadedSshKeyPair = sshKeyPairApi.getSshKeyPair(SshKeyPairType.GITHUB);
-    var gitlabLoadedSshKeyPair = sshKeyPairApi.getSshKeyPair(SshKeyPairType.GITLAB);
-    var azureLoadedSshKeyPair = sshKeyPairApi.getSshKeyPair(SshKeyPairType.AZURE);
+    var githubLoadedSshKeyPair =
+        sshKeyPairApi.getSshKeyPair(SshKeyPairType.GITHUB, /*includePrivateKey=*/ true);
+    var gitlabLoadedSshKeyPair =
+        sshKeyPairApi.getSshKeyPair(SshKeyPairType.GITLAB, /*includePrivateKey=*/ false);
+    var azureLoadedSshKeyPair =
+        sshKeyPairApi.getSshKeyPair(SshKeyPairType.AZURE, /*includePrivateKey=*/ false);
 
     assertEquals(githubSshKeyPair, githubLoadedSshKeyPair);
     assertEquals(gitlabSshKeyPair, gitlabLoadedSshKeyPair);
@@ -40,7 +46,7 @@ public class EncryptDecryptSshKeyPair extends TestScript {
     var notFoundException =
         assertThrows(
             HttpStatusCodeException.class,
-            () -> sshKeyPairApi.getSshKeyPair(SshKeyPairType.GITHUB));
+            () -> sshKeyPairApi.getSshKeyPair(SshKeyPairType.GITHUB, /*includePrivateKey=*/ false));
     assertEquals(HttpStatus.NOT_FOUND, notFoundException.getStatusCode());
 
     // clean up

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
@@ -75,11 +75,15 @@ public class OpenApiConverters {
           .authenticated(linkedAccount.isAuthenticated());
     }
 
-    public static SshKeyPair convert(SshKeyPairInternal sshKeyPairInternal) {
+    public static SshKeyPair convert(
+        SshKeyPairInternal sshKeyPairInternal, boolean includePrivateKey) {
       return new SshKeyPair()
           .externalUserEmail(sshKeyPairInternal.getExternalUserEmail())
           .publicKey(sshKeyPairInternal.getPublicKey())
-          .privateKey(new String(sshKeyPairInternal.getPrivateKey(), StandardCharsets.UTF_8));
+          .privateKey(
+              includePrivateKey
+                  ? new String(sshKeyPairInternal.getPrivateKey(), StandardCharsets.UTF_8)
+                  : null);
     }
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/SshKeyApiController.java
@@ -45,7 +45,7 @@ public record SshKeyApiController(
   }
 
   @Override
-  public ResponseEntity<SshKeyPair> getSshKeyPair(SshKeyPairType type) {
+  public ResponseEntity<SshKeyPair> getSshKeyPair(SshKeyPairType type, Boolean includePrivateKey) {
     var samUser = samUserFactory.from(request);
     var auditLogEventBuilder =
         new AuditLogEvent.Builder()
@@ -56,7 +56,7 @@ public record SshKeyApiController(
       var sshKeyPair = sshKeyPairService.getSshKeyPair(samUser.getSubjectId(), type);
       auditLogger.logEvent(
           auditLogEventBuilder.auditLogEventType(AuditLogEventType.GetSshKeyPairSucceeded).build());
-      return ResponseEntity.ok(OpenApiConverters.Output.convert(sshKeyPair));
+      return ResponseEntity.ok(OpenApiConverters.Output.convert(sshKeyPair, includePrivateKey));
     } catch (Exception e) {
       auditLogger.logEvent(
           auditLogEventBuilder.auditLogEventType(AuditLogEventType.GetSshKeyPairFailed).build());
@@ -75,11 +75,13 @@ public record SshKeyApiController(
             .clientIP(request.getRemoteAddr())
             .auditLogEventType(AuditLogEventType.PutSshKeyPair)
             .build());
-    return ResponseEntity.ok(OpenApiConverters.Output.convert(sshKeyPair));
+    return ResponseEntity.ok(
+        OpenApiConverters.Output.convert(sshKeyPair, /*includePrivateKey=*/ false));
   }
 
   @Override
-  public ResponseEntity<SshKeyPair> generateSshKeyPair(SshKeyPairType type, String email) {
+  public ResponseEntity<SshKeyPair> generateSshKeyPair(
+      SshKeyPairType type, String email, Boolean includePrivateKey) {
     String userEmail;
     try {
       userEmail = objectMapper.readValue(email, String.class);
@@ -97,7 +99,7 @@ public record SshKeyApiController(
           sshKeyPairService.generateSshKeyPair(samUser.getSubjectId(), userEmail, type);
       auditLogger.logEvent(
           auditLogEventBuilder.auditLogEventType(AuditLogEventType.SshKeyPairCreated).build());
-      return ResponseEntity.ok(OpenApiConverters.Output.convert(generatedKey));
+      return ResponseEntity.ok(OpenApiConverters.Output.convert(generatedKey, includePrivateKey));
     } catch (Exception e) {
       auditLogger.logEvent(
           auditLogEventBuilder

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -99,7 +99,10 @@ class SshKeyApiControllerTest extends BaseTest {
             .andExpect(status().isOk())
             .andReturn();
     verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.PutSshKeyPair);
-    SshKeyPair publicKeyOnly = sshKeyPair.privateKey(null);
+    SshKeyPair publicKeyOnly =
+        new SshKeyPair()
+            .publicKey(sshKeyPair.getPublicKey())
+            .externalUserEmail(sshKeyPair.getExternalUserEmail());
     assertEquals(
         publicKeyOnly,
         objectMapper.readValue(putResult.getResponse().getContentAsByteArray(), SshKeyPair.class));
@@ -174,11 +177,12 @@ class SshKeyApiControllerTest extends BaseTest {
     var getResult =
         mvc.perform(
                 get("/api/sshkeypair/v1/{type}", sshKeyPairType)
-                    .header("authorization", "Bearer " + accessToken))
+                    .header("authorization", "Bearer " + accessToken)
+                    .queryParam("includePrivateKey", "true"))
             .andExpect(status().isOk())
             .andReturn();
     assertEquals(
-        generatedSshKeyPair,
+        generatedSshKeyPairWithPrivateKey,
         objectMapper.readValue(getResult.getResponse().getContentAsByteArray(), SshKeyPair.class));
     verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.GetSshKeyPairSucceeded);
 

--- a/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/SshKeyApiControllerTest.java
@@ -1,6 +1,8 @@
 package bio.terra.externalcreds.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -97,8 +99,9 @@ class SshKeyApiControllerTest extends BaseTest {
             .andExpect(status().isOk())
             .andReturn();
     verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.PutSshKeyPair);
+    SshKeyPair publicKeyOnly = sshKeyPair.privateKey(null);
     assertEquals(
-        sshKeyPair,
+        publicKeyOnly,
         objectMapper.readValue(putResult.getResponse().getContentAsByteArray(), SshKeyPair.class));
 
     var getResult =
@@ -108,8 +111,20 @@ class SshKeyApiControllerTest extends BaseTest {
             .andExpect(status().isOk())
             .andReturn();
     assertEquals(
-        sshKeyPair,
+        publicKeyOnly,
         objectMapper.readValue(getResult.getResponse().getContentAsByteArray(), SshKeyPair.class));
+    verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.GetSshKeyPairSucceeded);
+    var getResultWithPrivateKey =
+        mvc.perform(
+                get("/api/sshkeypair/v1/{type}", sshKeyPairType)
+                    .header("authorization", "Bearer " + accessToken)
+                    .queryParam("includePrivateKey", "true"))
+            .andExpect(status().isOk())
+            .andReturn();
+    assertEquals(
+        sshKeyPair,
+        objectMapper.readValue(
+            getResultWithPrivateKey.getResponse().getContentAsByteArray(), SshKeyPair.class));
     verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.GetSshKeyPairSucceeded);
 
     mvc.perform(
@@ -138,6 +153,22 @@ class SshKeyApiControllerTest extends BaseTest {
 
     var generatedSshKeyPair =
         objectMapper.readValue(postResult.getResponse().getContentAsByteArray(), SshKeyPair.class);
+    assertNull(generatedSshKeyPair.getPrivateKey());
+    verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.SshKeyPairCreated);
+
+    var postResultWithPrivateKey =
+        mvc.perform(
+                post("/api/sshkeypair/v1/{type}", sshKeyPairType)
+                    .header("authorization", "Bearer " + accessToken)
+                    .queryParam("includePrivateKey", "true")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(externalUserEmail))
+            .andExpect(status().isOk())
+            .andReturn();
+    var generatedSshKeyPairWithPrivateKey =
+        objectMapper.readValue(
+            postResultWithPrivateKey.getResponse().getContentAsByteArray(), SshKeyPair.class);
+    assertNotNull(generatedSshKeyPairWithPrivateKey.getPrivateKey());
     verifyAuditLogEvent(sshKeyPairType, AuditLogEventType.SshKeyPairCreated);
 
     var getResult =


### PR DESCRIPTION
Jira: 
https://broadworkbench.atlassian.net/browse/PF-2500

What:

 Make private ssh key an optional field and only include it in the response upon request.

Why:

The UI is not using the private key field. the CLI is using the private key field. For better security, we don't include the private ssh key in the response.
 
How:

add an includPrivateKey query param with default value false.
  
