### PR TITLE
[PF-2511] Fix publishing workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,8 @@ jobs:
   publish-job:
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17
@@ -66,14 +68,6 @@ jobs:
       - name: Push GCR image
         run: docker push ${{ steps.image-name.outputs.name }}
 
-      - name: Deploy to Terra Dev environment
-        uses: broadinstitute/repository-dispatch@master
-        with:
-          token: ${{ secrets.BROADBOT_TOKEN }}
-          repository: broadinstitute/terra-helmfile
-          event-type: update-service
-          client-payload: '{"service": "externalcreds", "version": "${{ steps.tag.outputs.tag }}", "dev_only": false}'
-
       - name: Notify slack on failure
         uses: 8398a7/action-slack@v3
         if: failure()
@@ -84,3 +78,26 @@ jobs:
           author_name: Publish to dev
           fields: job
           text: 'Publish failed :sadpanda:'
+  report-to-sherlock:
+    # Report new ECM version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: tag-publish-job
+    with:
+      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      chart-name: 'externalcreds'
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+  set-version-in-dev:
+    # Put new ECM version in Broad dev environment
+    uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
+    needs: [tag-publish-job, report-to-sherlock]
+    with:
+      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      chart-name: 'externalcreds'
+      environment-name: 'dev'
+    secrets:
+      sync-git-token: ${{ secrets.BROADBOT_TOKEN }}
+    permissions:
+      id-token: 'write'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,9 +81,9 @@ jobs:
   report-to-sherlock:
     # Report new ECM version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-    needs: tag-publish-job
+    needs: publish-job
     with:
-      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.publish-job.outputs.tag }}
       chart-name: 'externalcreds'
     permissions:
       contents: 'read'
@@ -92,9 +92,9 @@ jobs:
   set-version-in-dev:
     # Put new ECM version in Broad dev environment
     uses: broadinstitute/sherlock/.github/workflows/client-set-environment-app-version.yaml@main
-    needs: [tag-publish-job, report-to-sherlock]
+    needs: [publish-job, report-to-sherlock]
     with:
-      new-version: ${{ needs.tag-publish-job.outputs.tag }}
+      new-version: ${{ needs.publish-job.outputs.tag }}
       chart-name: 'externalcreds'
       environment-name: 'dev'
     secrets:


### PR DESCRIPTION
The existing `repository-dispatch` based notification flow is broken in other repos (RBS, Janitor) due to an expired credential. I'm not sure this flow is broken here in ECM given that it uses a different credential, but since no changes have been merged for months, it's hard to tell.
This change moves ECM to the new Devops-endorsed Sherlock client actions instead.