### PR TITLE
[TERRA-434] Replace deprecated commands in GH actions & workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -29,7 +29,7 @@ jobs:
           restore-keys: v1-${{ runner.os }}-gradle-${{ github.ref }}
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
@@ -62,7 +62,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -93,13 +93,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -141,13 +141,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches
@@ -192,7 +192,7 @@ jobs:
       - name: Archive logs
         id: archive_logs
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: application-logs
           path: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -56,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -91,7 +91,7 @@ jobs:
         ports: [ "5432:5432" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -139,7 +139,7 @@ jobs:
         ports: [ "5432:5432" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -20,7 +20,7 @@ jobs:
       id-token: 'write'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Verify perf version matches dev
         run: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -86,7 +86,7 @@ jobs:
 
       - id: 'auth'
         name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v0'
+        uses: google-github-actions/auth@v1
         with:
           # Centralized in dsp-tools-k8s; ask in #dsp-devops-champions for help troubleshooting
           workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -47,7 +47,7 @@ jobs:
             --create-dirs -o "integration/terra-helmfile/environments/live/perf.yaml"
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -53,7 +53,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Gradle cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -15,7 +15,7 @@ jobs:
         id: tag
         run: echo ::set-output name=tag::$(git branch --show-current)
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -36,7 +36,7 @@ jobs:
       #        ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
       #        ARTIFACTORY_REPO_KEY: "libs-snapshot-local"
       - name: Auth to GCR
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Explicitly auth Docker for GCR

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Parse tag
         id: tag
-        run: echo ::set-output name=tag::$(git branch --show-current)
+        run: echo tag=$(git branch --show-current) >> $GITHUB_OUTPUT
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -43,7 +43,7 @@ jobs:
         run: gcloud auth configure-docker --quiet
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
+        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT        
       - name: Build image locally with jib
         run: './gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain'
       - name: Push GCR image

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -20,7 +20,7 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -43,7 +43,7 @@ jobs:
         run: gcloud auth configure-docker --quiet
       - name: Construct docker image name and tag
         id: image-name
-        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT        
+        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT
       - name: Build image locally with jib
         run: './gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain'
       - name: Push GCR image

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Parse tag
         id: tag
         run: echo ::set-output name=tag::$(git branch --show-current)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT        
+        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT
 
       - name: Add Google Cloud Profiler to Docker Image
         run: docker build ./service -t externalcreds:local

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,7 @@ jobs:
 
       - name: Parse tag
         id: tag
-        run: echo ::set-output name=tag::$(git describe --tags)
-
+        run: echo tag=$(git describe --tags) >> $GITHUB_OUTPUT
       - name: Publish to Artifactory
         run: ./gradlew --build-cache :client-resttemplate:artifactoryPublish
         env:
@@ -47,8 +46,8 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo ::set-output name=name::gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }}
-
+        run: echo status=$pass >> $GITHUB_OUTPUT
+        run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT        
       - name: Add Google Cloud Profiler to Docker Image
         run: docker build ./service -t externalcreds:local
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Cache Gradle packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           ARTIFACTORY_REPO_KEY: libs-snapshot-local
 
       - name: Auth to GCR
-        uses: google-github-actions/auth@v0
+        uses: google-github-actions/auth@v1
         with:
           credentials_json: ${{ secrets.GCR_PUBLISH_KEY_B64 }}
       - name: Explicitly auth Docker for GCR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Parse tag
         id: tag
         run: echo tag=$(git describe --tags) >> $GITHUB_OUTPUT
+
       - name: Publish to Artifactory
         run: ./gradlew --build-cache :client-resttemplate:artifactoryPublish
         env:
@@ -47,6 +48,7 @@ jobs:
       - name: Construct docker image name and tag
         id: image-name
         run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT        
+
       - name: Add Google Cloud Profiler to Docker Image
         run: docker build ./service -t externalcreds:local
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,6 @@ jobs:
 
       - name: Construct docker image name and tag
         id: image-name
-        run: echo status=$pass >> $GITHUB_OUTPUT
         run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT        
       - name: Add Google Cloud Profiler to Docker Image
         run: docker build ./service -t externalcreds:local

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           token: ${{ secrets.BROADBOT_TOKEN }} # this allows the push to succeed later
       - name: Bump the tag to a new version


### PR DESCRIPTION
Jira: https://verily.atlassian.net/browse/TERRA-434

What:

Replace deprecated commands in GH actions & workflows.

- use actions/setup-java@v3 instead of v2
- use actions/checkout@v3 instead of v2
- use actions/cache@v3 instead of v2
- use actions/upload-artifact@v3 instead of v2
- use setup-node@v3 instead of v2
- use google-github-actions/auth@v1 instead of v0
- use google-github-actions/get-gke-credentials@v1 instead of v0
- use actions/github-script@v6 instead of v5
- replace 'set-output' command

Why: This removes deprecation warnings during GH workflow / action runs

How: Use latest version of the actions
