### PR TITLE
[PF-2972] Update dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,11 @@ plugins {
 
 repositories { mavenCentral() }
 
+// Dependency versions for libraries managed by Spring dependency management, affecting all projects
+// This can be removed once ECM has migrated to Spring Boot 3
+ext['thymeleaf.version'] = '3.1.2.RELEASE'
+ext['snakeyaml.version'] = '1.33'
+
 subprojects {
 	group = 'bio.terra'
 	version = '0.106.0-SNAPSHOT'

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE' apply false
-	id 'org.springframework.boot' version '2.6.6' apply false
+	id 'org.springframework.boot' version '2.7.15' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false

--- a/client-resttemplate/swagger.gradle
+++ b/client-resttemplate/swagger.gradle
@@ -4,6 +4,13 @@ dependencies {
 
 	implementation 'io.swagger.core.v3:swagger-annotations:2.1.13'
 	swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.33'
+
+	// Transitive dependency constraints due to security vulnerabilities in prior versions.
+	// These are not directly included, they are just constrained if they are pulled in as
+	// transitive dependencies.
+	constraints {
+		implementation('org.yaml:snakeyaml:1.31')
+	}
 }
 
 

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	implementation project(':client-resttemplate')
 
 	// Terra Test Runner Library
-	implementation 'bio.terra:terra-test-runner:0.1.3-SNAPSHOT'
+	implementation 'bio.terra:terra-test-runner:0.2.0-SNAPSHOT'
 }
 
 spotless {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 	id 'com.diffplug.spotless'
 	id 'com.github.ben-manes.versions' version '0.42.0'
-	id 'com.github.spotbugs' version '5.0.6'
+	id 'com.github.spotbugs' version '5.1.3'
 	id 'com.google.cloud.tools.jib'
 	id 'com.gorylenko.gradle-git-properties' version '2.4.0'
 	id 'io.freefair.lombok'
@@ -28,20 +28,28 @@ apply from: 'analysis.gradle'
 dependencies {
 	// google
 	implementation platform('com.google.cloud:libraries-bom:25.1.0')
-	implementation 'com.google.cloud:google-cloud-pubsub:1.116.3'
-	implementation 'com.google.cloud:google-cloud-kms:2.4.2'
+	implementation 'com.google.cloud:google-cloud-pubsub:1.120.19'
+	implementation 'com.google.cloud:google-cloud-kms:2.6.8'
 
 	annotationProcessor 'org.immutables:value:2.9.0'
 	implementation 'bio.terra:terra-common-lib:0.0.93-SNAPSHOT'
-	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:0.1-96c5f4d'
 	// https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on
 	implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
 	implementation 'org.codehaus.janino:janino:3.1.7' // Provides if/else xml parsing for logback config
 	implementation('org.springframework.cloud:spring-cloud-gcp-starter-logging:1.2.8.RELEASE') {
 		exclude group: 'org.springframework', module: 'spring-jcl'
 	}
+	// Transitive dependency constraints due to security vulnerabilities in prior versions.
+	// These are not directly included, they are just constrained if they are pulled in as
+	// transitive dependencies.
+	constraints {
+		implementation('com.google.protobuf:protobuf-java:3.21.10')
+		implementation('org.yaml:snakeyaml:1.31')
+		implementation('org.mozilla:rhino:1.7.12')
+		implementation('org.apache.bcel:bcel:6.6.0')
+	}
 	// for testing with mock web server
-	testImplementation 'org.mock-server:mockserver-netty:5.13.0'
+	testImplementation 'org.mock-server:mockserver-netty:5.15.0'
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core
 	testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -45,7 +45,6 @@ dependencies {
 	constraints {
 		implementation('com.google.protobuf:protobuf-java:3.21.10')
 		implementation('org.mozilla:rhino:1.7.12')
-		spotbugs('org.apache.bcel:bcel:6.6.0')
 	}
 	// for testing with mock web server
 	testImplementation('org.mock-server:mockserver-netty:5.15.0') {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -49,7 +49,10 @@ dependencies {
 		implementation('org.apache.bcel:bcel:6.6.0')
 	}
 	// for testing with mock web server
-	testImplementation 'org.mock-server:mockserver-netty:5.15.0'
+	testImplementation('org.mock-server:mockserver-netty:5.15.0') {
+		// Incompatible with the version brought in as a non-test dependency
+		exclude group: 'com.nimbusds', module: 'nimbus-jose-jwt'
+	}
 	// https://mvnrepository.com/artifact/org.mockito/mockito-core
 	testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.4.0'
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -44,9 +44,8 @@ dependencies {
 	// transitive dependencies.
 	constraints {
 		implementation('com.google.protobuf:protobuf-java:3.21.10')
-		implementation('org.yaml:snakeyaml:1.31')
 		implementation('org.mozilla:rhino:1.7.12')
-		implementation('org.apache.bcel:bcel:6.6.0')
+		spotbugs('org.apache.bcel:bcel:6.6.0')
 	}
 	// for testing with mock web server
 	testImplementation('org.mock-server:mockserver-netty:5.15.0') {

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -3,6 +3,10 @@ configurations { compileOnly { extendsFrom annotationProcessor } }
 def springBootVersion = '2.7.15'
 def springSecurityVersion = '5.6.9'
 
+// Thymeleaf has a known security vulnerability but is managed by the Spring Boot dependency
+// management plugin. This can be removed when ECM is on Spring Boot 3.
+ext['thymeleaf.version'] = '3.1.2.RELEASE'
+
 dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
 	developmentOnly "org.springframework.boot:spring-boot-devtools:$springBootVersion"

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -1,7 +1,7 @@
 configurations { compileOnly { extendsFrom annotationProcessor } }
 
-def springBootVersion = '2.6.6'
-def springSecurityVersion = '5.6.2'
+def springBootVersion = '2.7.15'
+def springSecurityVersion = '5.6.9'
 
 dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
@@ -25,8 +25,8 @@ dependencies {
 	testImplementation 'org.mockito:mockito-inline:4.0.0'
 
 	// DB deps (still versioned by Spring):
-	implementation 'org.liquibase:liquibase-core:4.5.0'
-	runtimeOnly 'org.postgresql:postgresql:42.3.3'
+	implementation 'org.liquibase:liquibase-core:4.8.0'
+	runtimeOnly 'org.postgresql:postgresql:42.3.7'
 }
 
 test { useJUnitPlatform() }

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -3,10 +3,6 @@ configurations { compileOnly { extendsFrom annotationProcessor } }
 def springBootVersion = '2.7.15'
 def springSecurityVersion = '5.6.9'
 
-// Thymeleaf has a known security vulnerability but is managed by the Spring Boot dependency
-// management plugin. This can be removed when ECM is on Spring Boot 3.
-ext['thymeleaf.version'] = '3.1.2.RELEASE'
-
 dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
 	developmentOnly "org.springframework.boot:spring-boot-devtools:$springBootVersion"


### PR DESCRIPTION
Jira: [PF-2972](https://broadworkbench.atlassian.net/browse/PF-2972)

What:
Update a number of dependencies with known vulnerabilities.

Why:
Verily security has started using a different dependency analysis tool which flagged a handful of vulnerabilities. I'd like to update dependencies to fix issues raised by both Verily's tool and Sourceclear.

How:
I verified the dependency versions are changed by generating lockfiles locally, though it looks like this service generally isn't using them anymore so I didn't include them in this PR.
  


[PF-2972]: https://broadworkbench.atlassian.net/browse/PF-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ