### PR TITLE
[ID-799] update ecm slack notification on publish failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           status: ${{ job.status }}
           author_name: Publish to dev
           fields: job
-          text: 'ECM Publish to dev job failed :sadpanda:'
+          text: 'ECM publish to dev job failed :sadpanda:'
   report-to-sherlock:
     # Report new ECM version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
           status: ${{ job.status }}
           author_name: Publish to dev
           fields: job
-          text: 'Publish failed :sadpanda:'
+          text: 'ECM Publish job to dev failed :sadpanda:'
   report-to-sherlock:
     # Report new ECM version to Broad DevOps
     uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main


### PR DESCRIPTION
Jira: \<[Link to Jira ticket](https://broadworkbench.atlassian.net/browse/ID-799)\>

Updating the notification to make it clearer which service is failing the publish job 