### PR TITLE
PF-2972: Sync client and service Spring Boot versions.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,15 @@ plugins {
 
 repositories { mavenCentral() }
 
-// Dependency versions for libraries managed by Spring dependency management, affecting all projects
-// This can be removed once ECM has migrated to Spring Boot 3
-ext['thymeleaf.version'] = '3.1.2.RELEASE'
-ext['snakeyaml.version'] = '1.33'
+ext {
+	springBootVersion = '2.7.15'
+	springSecurityVersion = '5.6.9'
+
+	// Dependency versions for libraries managed by Spring dependency management, affecting all projects
+	// This can be removed once ECM has migrated to Spring Boot 3
+	set('thymeleaf.version', '3.1.2.RELEASE')
+	set('snakeyaml.version', '1.33')
+}
 
 subprojects {
 	group = 'bio.terra'

--- a/client-resttemplate/swagger.gradle
+++ b/client-resttemplate/swagger.gradle
@@ -1,6 +1,6 @@
 // All version controlled by dependency management plugin
 dependencies {
-	api 'org.springframework.boot:spring-boot-starter-json:2.7.1'
+	api "org.springframework.boot:spring-boot-starter-json:$springBootVersion"
 
 	implementation 'io.swagger.core.v3:swagger-annotations:2.1.13'
 	swaggerCodegen 'io.swagger.codegen.v3:swagger-codegen-cli:3.0.33'

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -1,8 +1,5 @@
 configurations { compileOnly { extendsFrom annotationProcessor } }
 
-def springBootVersion = '2.7.15'
-def springSecurityVersion = '5.6.9'
-
 dependencies {
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:$springBootVersion"
 	developmentOnly "org.springframework.boot:spring-boot-devtools:$springBootVersion"


### PR DESCRIPTION
Jira: [PF-2972](https://broadworkbench.atlassian.net/browse/PF-2972) (continued)

What: A [previous PR](https://github.com/DataBiosphere/terra-external-credentials-manager/pull/156) bumped Spring version forward to address a vulnerability for the service, but missed that the client version is also explicitly set.  This PR fixes the client too.

Why: Client's sole Spring Boot dependency (`spring-boot-starter-json`) does not have vulnerability at this version, but it is locking downstream consumers of the client to a Spring Boot version that causes them to pull vulnerable version of other Spring Boot libraries.  Also, having the client and server Spring Boot versions diverge seems bad.

How: Move the `springBootVersion` variable up to the top level project and consume it in both client and service sub-projects so that they stay in sync (and at the safe version).
  


[PF-2972]: https://broadworkbench.atlassian.net/browse/PF-2972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ