### PR TITLE
[DR-3412] Upgrade Spring Boot 3.1.6 -> 3.1.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.4' apply false
-	id 'org.springframework.boot' version '3.1.6' apply false
+	id 'org.springframework.boot' version '3.1.7' apply false
 	id 'com.diffplug.spotless' version '6.3.0' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.1.4' apply false

--- a/service/spring.gradle
+++ b/service/spring.gradle
@@ -25,13 +25,6 @@ dependencies {
 	// DB deps (still versioned by Spring):
 	implementation 'org.liquibase:liquibase-core'
 	runtimeOnly 'org.postgresql:postgresql'
-
-	// See https://nvd.nist.gov/vuln/detail/cve-2023-6378
-	// TODO: when latest versions of Spring are released on 2023-12-21, see if upgrading also brings
-	// its logback versions >= 1.4.14, which would allow us to stop explicitly pulling them in.
-	var logbackVersion = '1.4.14'
-	implementation "ch.qos.logback:logback-classic:$logbackVersion"
-	implementation "ch.qos.logback:logback-core:$logbackVersion"
 }
 
 test { useJUnitPlatform() }


### PR DESCRIPTION
**Jira:** https://broadworkbench.atlassian.net/browse/DR-3412

**What:** Upgrade Spring Boot 3.1.6 -> 3.1.7

**Why:**  Because this release includes a logback upgrade to 1.4.14, we can now remove our pin of this version which addressed a security vulnerability.

**How:** Dependency insights verify that the pin is no longer necessary:

```
(base) okotsopo@wm111-e35 terra-external-credentials-manager % ./gradlew service:dependencyInsight --dependency logback-classic 

> Task :service:dependencyInsight
ch.qos.logback:logback-classic:1.4.14 (selected by rule)
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 17
   ]

ch.qos.logback:logback-classic:1.4.14
\--- org.springframework.boot:spring-boot-starter-logging:3.1.7
     \--- org.springframework.boot:spring-boot-starter:3.1.7
          +--- org.springframework.boot:spring-boot-starter-jdbc:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-jdbc)
          +--- org.springframework.boot:spring-boot-starter-thymeleaf:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-thymeleaf)
          +--- org.springframework.boot:spring-boot-starter-web:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
          +--- org.springframework.boot:spring-boot-starter-webflux:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-webflux)
          +--- org.springframework.boot:spring-boot-starter-cache:3.1.7
          |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-cache)
          +--- org.springframework.boot:spring-boot-starter-json:3.1.7
          |    +--- org.springframework.boot:spring-boot-starter-web:3.1.7 (*)
          |    \--- org.springframework.boot:spring-boot-starter-webflux:3.1.7 (*)
          \--- com.google.cloud:spring-cloud-gcp-starter:4.9.0 (requested org.springframework.boot:spring-boot-starter:3.1.5)
               \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
                    \--- compileClasspath

ch.qos.logback:logback-classic:1.1.3 -> 1.4.14
\--- ch.qos.logback.contrib:logback-json-classic:0.1.5
     \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
          \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
               \--- compileClasspath

ch.qos.logback:logback-classic:1.2.11 -> 1.4.14
\--- com.google.cloud:google-cloud-logging-logback:0.130.28-alpha
     +--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
     |    \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
     |         \--- compileClasspath
     \--- com.google.cloud:libraries-bom:26.28.0
          \--- compileClasspath

(*) - dependencies omitted (listed previously)

(base) okotsopo@wm111-e35 terra-external-credentials-manager % ./gradlew service:dependencyInsight --dependency logback-core    

> Task :service:dependencyInsight
ch.qos.logback:logback-core:1.4.14 (selected by rule)
   variant "compile" [
      org.gradle.status              = release (not requested)
      org.gradle.usage               = java-api
      org.gradle.libraryelements     = jar (compatible with: classes)
      org.gradle.category            = library

      Requested attributes not found in the selected variant:
         org.gradle.dependency.bundling = external
         org.gradle.jvm.environment     = standard-jvm
         org.gradle.jvm.version         = 17
   ]

ch.qos.logback:logback-core:1.4.14
\--- ch.qos.logback:logback-classic:1.4.14
     +--- com.google.cloud:google-cloud-logging-logback:0.130.28-alpha (requested ch.qos.logback:logback-classic:1.2.11)
     |    +--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
     |    |    \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
     |    |         \--- compileClasspath
     |    \--- com.google.cloud:libraries-bom:26.28.0
     |         \--- compileClasspath
     +--- org.springframework.boot:spring-boot-starter-logging:3.1.7
     |    \--- org.springframework.boot:spring-boot-starter:3.1.7
     |         +--- org.springframework.boot:spring-boot-starter-jdbc:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-jdbc)
     |         +--- org.springframework.boot:spring-boot-starter-thymeleaf:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-thymeleaf)
     |         +--- org.springframework.boot:spring-boot-starter-web:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-web)
     |         +--- org.springframework.boot:spring-boot-starter-webflux:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-webflux)
     |         +--- org.springframework.boot:spring-boot-starter-cache:3.1.7
     |         |    \--- compileClasspath (requested org.springframework.boot:spring-boot-starter-cache)
     |         +--- org.springframework.boot:spring-boot-starter-json:3.1.7
     |         |    +--- org.springframework.boot:spring-boot-starter-web:3.1.7 (*)
     |         |    \--- org.springframework.boot:spring-boot-starter-webflux:3.1.7 (*)
     |         \--- com.google.cloud:spring-cloud-gcp-starter:4.9.0 (requested org.springframework.boot:spring-boot-starter:3.1.5)
     |              \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0 (*)
     \--- ch.qos.logback.contrib:logback-json-classic:0.1.5 (requested ch.qos.logback:logback-classic:1.1.3)
          \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0 (*)

ch.qos.logback:logback-core:1.1.3 -> 1.4.14
\--- ch.qos.logback.contrib:logback-json-core:0.1.5
     \--- ch.qos.logback.contrib:logback-json-classic:0.1.5
          \--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
               \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
                    \--- compileClasspath

ch.qos.logback:logback-core:1.2.11 -> 1.4.14
\--- com.google.cloud:google-cloud-logging-logback:0.130.28-alpha
     +--- com.google.cloud:spring-cloud-gcp-logging:4.9.0
     |    \--- com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0
     |         \--- compileClasspath
     \--- com.google.cloud:libraries-bom:26.28.0
          \--- compileClasspath

(*) - dependencies omitted (listed previously)
```
