### PR TITLE
Separate passport-provider specific code

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -243,10 +243,9 @@ components:
     providerParam:
       name: provider
       in: path
-      schema:
-        type: string
-        default: ras
       required: true
+      schema:
+        $ref: '#/components/schemas/Provider'
     redirectUriParam:
       name: redirectUri
       description: oidc redirect uri
@@ -320,6 +319,11 @@ components:
             $ref: '#/components/schemas/ErrorReport'
 
   schemas:
+    Provider:
+      description: Enum containing valid identity providers.
+      type: string
+      enum:
+        - ras
     SshKeyPairType:
       description: Enum containing valid ssh key types.
       type: string

--- a/integration/src/main/java/scripts/testscripts/GetProviderPassport.java
+++ b/integration/src/main/java/scripts/testscripts/GetProviderPassport.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.externalcreds.api.OidcApi;
+import bio.terra.externalcreds.model.Provider;
 import bio.terra.testrunner.runner.TestScript;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import java.util.List;
@@ -31,7 +32,7 @@ public class GetProviderPassport extends TestScript {
 
     // TODO: update GetProviderPassport.json in perf to run 120 tests per second
     // check the response code
-    var passportResponse = oidcApi.getProviderPassportWithHttpInfo(provider);
+    var passportResponse = oidcApi.getProviderPassportWithHttpInfo(Provider.fromValue(provider));
     var httpCode = passportResponse.getStatusCode();
 
     assertEquals(HttpStatus.OK, httpCode);

--- a/service/src/main/java/bio/terra/externalcreds/ExternalCredsCronApplication.java
+++ b/service/src/main/java/bio/terra/externalcreds/ExternalCredsCronApplication.java
@@ -2,7 +2,7 @@ package bio.terra.externalcreds;
 
 import bio.terra.common.logging.LoggingInitializer;
 import bio.terra.common.logging.LoggingUtils;
-import bio.terra.externalcreds.services.ProviderService;
+import bio.terra.externalcreds.services.PassportProviderService;
 import bio.terra.externalcreds.services.SshKeyPairService;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
@@ -34,12 +34,12 @@ public class ExternalCredsCronApplication {
         .run(args);
   }
 
-  private final ProviderService providerService;
+  private final PassportProviderService passportProviderService;
   private final SshKeyPairService sshKeyPairService;
 
   public ExternalCredsCronApplication(
-      ProviderService providerService, SshKeyPairService sshKeyPairService) {
-    this.providerService = providerService;
+      PassportProviderService passportProviderService, SshKeyPairService sshKeyPairService) {
+    this.passportProviderService = passportProviderService;
     this.sshKeyPairService = sshKeyPairService;
   }
 
@@ -47,14 +47,14 @@ public class ExternalCredsCronApplication {
   public void checkForExpiringCredentials() {
     // check and refresh expiring visas and passports
     log.info("beginning checkForExpiringCredentials");
-    var expiringPassportCount = providerService.refreshExpiringPassports();
+    var expiringPassportCount = passportProviderService.refreshExpiringPassports();
     log.info(
         "completed checkForExpiringCredentials",
         Map.of("expiring_passport_count", expiringPassportCount));
 
     // check and validate visas not validated since job was last run
     log.info("beginning validateVisas");
-    var checkedPassportCount = providerService.validateAccessTokenVisas();
+    var checkedPassportCount = passportProviderService.validateAccessTokenVisas();
     log.info("completed validateVisas", Map.of("checked_passport_count", checkedPassportCount));
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -9,9 +9,9 @@ import bio.terra.externalcreds.generated.model.LinkInfo;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.services.JwtUtils;
 import bio.terra.externalcreds.services.LinkedAccountService;
+import bio.terra.externalcreds.services.PassportProviderService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.services.ProviderService;
-import bio.terra.externalcreds.services.PassportProviderService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -76,10 +76,11 @@ public record OidcApiController(
     try {
       if (providerName.equals("ras")) {
         var linkedAccountWithPassportAndVisas =
-            passportProviderService.createLink(providerName, samUser.getSubjectId(), oauthcode,
-                state, auditLogEventBuilder);
-        return ResponseEntity.of(linkedAccountWithPassportAndVisas.map(
-            x -> OpenApiConverters.Output.convert(x.getLinkedAccount())));
+            passportProviderService.createLink(
+                providerName, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
+        return ResponseEntity.of(
+            linkedAccountWithPassportAndVisas.map(
+                x -> OpenApiConverters.Output.convert(x.getLinkedAccount())));
       } else {
         throw new BadRequestException("Invalid providerName");
       }

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
@@ -67,7 +67,7 @@ public class PassportProviderService extends ProviderService {
                   var providerInfo = externalCredsConfig.getProviders().get(providerName);
                   try {
                     var linkedAccount =
-                        createLinkInternal(
+                        createLinkedAccount(
                             providerName,
                             userId,
                             authorizationCode,

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
@@ -1,0 +1,266 @@
+package bio.terra.externalcreds.services;
+
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.common.exception.NotFoundException;
+import bio.terra.externalcreds.ExternalCredsException;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.models.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.*;
+import java.util.stream.Stream;
+
+@Service
+@Slf4j
+public class PassportProviderService extends ProviderService {
+  private final PassportService passportService;
+  private final JwtUtils jwtUtils;
+
+  public PassportProviderService(
+      ExternalCredsConfig externalCredsConfig,
+      ProviderClientCache providerClientCache,
+      OAuth2Service oAuth2Service,
+      LinkedAccountService linkedAccountService,
+      PassportService passportService,
+      JwtUtils jwtUtils,
+      AuditLogger auditLogger,
+      ObjectMapper objectMapper) {
+    super(externalCredsConfig, providerClientCache, oAuth2Service, linkedAccountService, auditLogger, objectMapper);
+    this.passportService = passportService;
+    this.jwtUtils = jwtUtils;
+  }
+
+  public Optional<LinkedAccountWithPassportAndVisas> createLink(
+      String providerName, String userId, String authorizationCode, String encodedState, AuditLogEvent.Builder auditLogEventBuilder) {
+
+    var oAuth2State = validateOAuth2State(providerName, userId, encodedState);
+
+    Optional<LinkedAccountWithPassportAndVisas> linkedAccountWithPassportAndVisas = providerClientCache
+        .getProviderClient(providerName)
+        .map(
+            providerClient -> {
+              var providerInfo = externalCredsConfig.getProviders().get(providerName);
+              try {
+                var linkedAccount = createLinkInternal(
+                    providerName,
+                    userId,
+                    authorizationCode,
+                    oAuth2State.getRedirectUri(),
+                    new HashSet<>(providerInfo.getScopes()),
+                    encodedState,
+                    providerClient);
+                return linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
+                    jwtUtils.enrichAccountWithPassportAndVisas(linkedAccount.getLeft(), linkedAccount.getRight()));
+              } catch (OAuth2AuthorizationException oauthEx) {
+                throw new BadRequestException(oauthEx);
+              }
+            });
+    logLinkCreation(linkedAccountWithPassportAndVisas, auditLogEventBuilder);
+    return linkedAccountWithPassportAndVisas;
+  }
+
+  private void logLinkCreation(Optional<LinkedAccountWithPassportAndVisas> linkedAccountWithPassportAndVisas,
+      AuditLogEvent.Builder auditLogEventBuilder) {
+    var passport =
+        linkedAccountWithPassportAndVisas.flatMap(LinkedAccountWithPassportAndVisas::getPassport);
+    var transactionClaim = passport.flatMap(p -> jwtUtils.getJwtTransactionClaim(p.getJwt()));
+    auditLogger.logEvent(
+        auditLogEventBuilder
+            .externalUserId(
+                linkedAccountWithPassportAndVisas.map(
+                    l -> l.getLinkedAccount().getExternalUserId()))
+            .auditLogEventType(
+                linkedAccountWithPassportAndVisas
+                    .map(x -> AuditLogEventType.LinkCreated)
+                    .orElse(AuditLogEventType.LinkCreationFailed))
+            .transactionClaim(transactionClaim)
+            .build());
+  }
+
+  public int validateAccessTokenVisas() {
+    var visaDetailsList = passportService.getUnvalidatedAccessTokenVisaDetails();
+
+    var linkedAccountIdsToRefresh =
+        visaDetailsList.stream()
+            .flatMap(
+                visaDetails ->
+                    validateVisaWithProvider(visaDetails)
+                        ? Stream.empty()
+                        : Stream.of(visaDetails.getLinkedAccountId()))
+            .distinct();
+
+    linkedAccountIdsToRefresh.forEach(
+        linkedAccountId -> {
+          var linkedAccount = linkedAccountService.getLinkedAccount(linkedAccountId);
+          try {
+            linkedAccount.ifPresentOrElse(
+                this::authAndRefreshPassport,
+                () -> log.info("No linked account found when trying to validate passport."));
+          } catch (Exception e) {
+            log.info("Failed to refresh passport, will try again at the next interval.", e);
+          }
+        });
+
+    return visaDetailsList.size();
+  }
+
+  /**
+   * Get a new passport for each linked accounts with visas or passports expiring within
+   * externalCredsConfig.getVisaAndPassportRefreshInterval time from now
+   *
+   * @return the number of linked accounts with expiring visas or passports
+   */
+  public int refreshExpiringPassports() {
+    var refreshInterval = externalCredsConfig.getVisaAndPassportRefreshDuration();
+    var expirationCutoff = new Timestamp(Instant.now().plus(refreshInterval).toEpochMilli());
+    var expiringLinkedAccounts = linkedAccountService.getExpiringLinkedAccounts(expirationCutoff);
+
+    for (LinkedAccount linkedAccount : expiringLinkedAccounts) {
+      try {
+        authAndRefreshPassport(linkedAccount);
+      } catch (Exception e) {
+        log.info("Failed to refresh passport, will try again at the next interval.", e);
+      }
+    }
+
+    return expiringLinkedAccounts.size();
+  }
+
+
+
+  @VisibleForTesting
+  void authAndRefreshPassport(LinkedAccount linkedAccount) {
+    if (linkedAccount.getExpires().toInstant().isBefore(Instant.now())) {
+      invalidateLinkedAccount(linkedAccount);
+    } else {
+      try {
+        var linkedAccountWithRefreshedPassport = getRefreshedPassportsAndVisas(linkedAccount);
+        linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
+            linkedAccountWithRefreshedPassport);
+        var transactionClaim =
+            linkedAccountWithRefreshedPassport
+                .getPassport()
+                .flatMap(p -> jwtUtils.getJwtTransactionClaim(p.getJwt()));
+        auditLogger.logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.LinkRefreshed)
+                .providerName(linkedAccount.getProviderName())
+                .userId(linkedAccount.getUserId())
+                .externalUserId(linkedAccount.getExternalUserId())
+                .transactionClaim(transactionClaim)
+                .build());
+
+      } catch (IllegalArgumentException iae) {
+        throw new ExternalCredsException(
+            String.format(
+                "Could not contact issuer for provider %s", linkedAccount.getProviderName()),
+            iae);
+      } catch (OAuth2AuthorizationException oauthEx) {
+        // if it looks like the refresh token will never work, delete the passport
+        if (unrecoverableOAuth2ErrorCodes.contains(getRootOAuth2ErrorCode(oauthEx))) {
+          log.info(
+              String.format(
+                  "Caught unrecoverable oauth2 error code refreshing passport for user id [%s].",
+                  linkedAccount.getUserId()),
+              oauthEx);
+          if (linkedAccount.getId().isEmpty()) {
+            throw new ExternalCredsException("linked account id missing");
+          }
+          invalidateLinkedAccount(linkedAccount);
+        } else {
+          // log and try again later
+          throw new ExternalCredsException("Failed to refresh passport: ", oauthEx);
+        }
+      }
+    }
+  }
+
+  private LinkedAccountWithPassportAndVisas getRefreshedPassportsAndVisas(
+      LinkedAccount linkedAccount) {
+    var clientRegistration =
+        providerClientCache
+            .getProviderClient(linkedAccount.getProviderName())
+            .orElseThrow(
+                () ->
+                    new ExternalCredsException(
+                        String.format(
+                            "Unable to find configs for the provider: %s",
+                            linkedAccount.getProviderName())));
+    var accessTokenResponse =
+        oAuth2Service.authorizeWithRefreshToken(
+            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
+
+    // save the linked account with the new refresh token and extracted passport
+    var linkedAccountWithRefreshToken =
+        Optional.ofNullable(accessTokenResponse.getRefreshToken())
+            .map(
+                refreshToken ->
+                    linkedAccountService.upsertLinkedAccount(
+                        linkedAccount.withRefreshToken(refreshToken.getTokenValue())))
+            .orElse(linkedAccount);
+
+    // update the passport and visas
+    var userInfo =
+        oAuth2Service.getUserInfo(clientRegistration, accessTokenResponse.getAccessToken());
+    return jwtUtils.enrichAccountWithPassportAndVisas(linkedAccountWithRefreshToken, userInfo);
+  }
+
+  @VisibleForTesting
+  boolean validateVisaWithProvider(VisaVerificationDetails visaDetails) {
+    var providerProperties = externalCredsConfig.getProviders().get(visaDetails.getProviderName());
+    if (providerProperties == null) {
+      throw new NotFoundException(
+          String.format("Provider %s not found", visaDetails.getProviderName()));
+    }
+
+    var validationEndpoint =
+        providerProperties
+            .getValidationEndpoint()
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        String.format(
+                            "Validation endpoint for provider %s not found",
+                            visaDetails.getProviderName())));
+
+    var response =
+        WebClient.create(validationEndpoint)
+            .get()
+            .uri(uriBuilder -> uriBuilder.queryParam("visa", visaDetails.getVisaJwt()).build())
+            .retrieve();
+    var responseBody =
+        response
+            .onStatus(HttpStatusCode::isError, clientResponse -> Mono.empty())
+            .bodyToMono(String.class)
+            .block(Duration.of(1000, ChronoUnit.MILLIS));
+
+    log.info(
+        "Got visa validation response.",
+        Map.of(
+            "linkedAccountId", visaDetails.getLinkedAccountId(),
+            "providerName", visaDetails.getProviderName(),
+            "validationResponse", Objects.requireNonNullElse(responseBody, "[null]")));
+
+    var visaValid = "valid".equalsIgnoreCase(responseBody);
+
+    if (visaValid) {
+      passportService.updateVisaLastValidated(visaDetails.getVisaId());
+    }
+    return visaValid;
+  }
+
+}

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -129,7 +129,7 @@ public class ProviderService {
     }
   }
 
-  public ImmutablePair<LinkedAccount, OAuth2User> createLinkInternal(
+  protected ImmutablePair<LinkedAccount, OAuth2User> createLinkedAccount(
       String providerName,
       String userId,
       String authorizationCode,
@@ -183,7 +183,7 @@ public class ProviderService {
    * OAuth2AuthorizationExceptions with other OAuth2AuthorizationExceptions that have non-standard
    * error codes. We just want to handle standard error codes which should be in the root cause.
    */
-  public String getRootOAuth2ErrorCode(OAuth2AuthorizationException oauthEx) {
+  protected String getRootOAuth2ErrorCode(OAuth2AuthorizationException oauthEx) {
     var errorCode = oauthEx.getError().getErrorCode();
     Throwable currentThrowable = oauthEx.getCause();
     var visitedThrowables = new ArrayList<Throwable>();
@@ -219,7 +219,7 @@ public class ProviderService {
     return linkedAccount;
   }
 
-  public void invalidateLinkedAccount(LinkedAccount linkedAccount) {
+  protected void invalidateLinkedAccount(LinkedAccount linkedAccount) {
     auditLogger.logEvent(
         new AuditLogEvent.Builder()
             .auditLogEventType(AuditLogEventType.LinkExpired)

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -12,9 +12,7 @@ import bio.terra.externalcreds.models.CannotDecodeOAuth2State;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
 import bio.terra.externalcreds.models.OAuth2State;
-import bio.terra.externalcreds.models.VisaVerificationDetails;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -24,34 +22,30 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
-import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 @Service
 @Slf4j
-public class ProviderService {
-  private final ExternalCredsConfig externalCredsConfig;
-  private final ProviderClientCache providerClientCache;
-  private final OAuth2Service oAuth2Service;
-  private final LinkedAccountService linkedAccountService;
-  private final PassportService passportService;
-  private final JwtUtils jwtUtils;
-  private final AuditLogger auditLogger;
-  private final SecureRandom secureRandom = new SecureRandom();
-  private final ObjectMapper objectMapper;
-  private static final Collection<String> unrecoverableOAuth2ErrorCodes =
+public abstract class ProviderService {
+  public final ExternalCredsConfig externalCredsConfig;
+  public final ProviderClientCache providerClientCache;
+  public final OAuth2Service oAuth2Service;
+  public final LinkedAccountService linkedAccountService;
+  public final AuditLogger auditLogger;
+  public final SecureRandom secureRandom = new SecureRandom();
+  public final ObjectMapper objectMapper;
+  public static final Collection<String> unrecoverableOAuth2ErrorCodes =
       Set.of(
           OAuth2ErrorCodes.ACCESS_DENIED,
           OAuth2ErrorCodes.INSUFFICIENT_SCOPE,
@@ -71,44 +65,18 @@ public class ProviderService {
       ProviderClientCache providerClientCache,
       OAuth2Service oAuth2Service,
       LinkedAccountService linkedAccountService,
-      PassportService passportService,
-      JwtUtils jwtUtils,
       AuditLogger auditLogger,
       ObjectMapper objectMapper) {
     this.externalCredsConfig = externalCredsConfig;
     this.providerClientCache = providerClientCache;
     this.oAuth2Service = oAuth2Service;
     this.linkedAccountService = linkedAccountService;
-    this.passportService = passportService;
-    this.jwtUtils = jwtUtils;
     this.auditLogger = auditLogger;
     this.objectMapper = objectMapper;
   }
 
   public Set<String> getProviderList() {
     return Collections.unmodifiableSet(externalCredsConfig.getProviders().keySet());
-  }
-
-  /**
-   * Get a new passport for each linked accounts with visas or passports expiring within
-   * externalCredsConfig.getVisaAndPassportRefreshInterval time from now
-   *
-   * @return the number of linked accounts with expiring visas or passports
-   */
-  public int refreshExpiringPassports() {
-    var refreshInterval = externalCredsConfig.getVisaAndPassportRefreshDuration();
-    var expirationCutoff = new Timestamp(Instant.now().plus(refreshInterval).toEpochMilli());
-    var expiringLinkedAccounts = linkedAccountService.getExpiringLinkedAccounts(expirationCutoff);
-
-    for (LinkedAccount linkedAccount : expiringLinkedAccounts) {
-      try {
-        authAndRefreshPassport(linkedAccount);
-      } catch (Exception e) {
-        log.info("Failed to refresh passport, will try again at the next interval.", e);
-      }
-    }
-
-    return expiringLinkedAccounts.size();
   }
 
   public Optional<String> getProviderAuthorizationUrl(
@@ -148,32 +116,7 @@ public class ProviderService {
     }
   }
 
-  public Optional<LinkedAccountWithPassportAndVisas> createLink(
-      String providerName, String userId, String authorizationCode, String encodedState) {
-
-    var oAuth2State = validateOAuth2State(providerName, userId, encodedState);
-
-    return providerClientCache
-        .getProviderClient(providerName)
-        .map(
-            providerClient -> {
-              var providerInfo = externalCredsConfig.getProviders().get(providerName);
-              try {
-                return createLinkInternal(
-                    providerName,
-                    userId,
-                    authorizationCode,
-                    oAuth2State.getRedirectUri(),
-                    new HashSet<>(providerInfo.getScopes()),
-                    encodedState,
-                    providerClient);
-              } catch (OAuth2AuthorizationException oauthEx) {
-                throw new BadRequestException(oauthEx);
-              }
-            });
-  }
-
-  private OAuth2State validateOAuth2State(String providerName, String userId, String encodedState) {
+  public OAuth2State validateOAuth2State(String providerName, String userId, String encodedState) {
     try {
       OAuth2State oAuth2State = OAuth2State.decode(objectMapper, encodedState);
       if (!providerName.equals(oAuth2State.getProvider())) {
@@ -186,7 +129,7 @@ public class ProviderService {
     }
   }
 
-  private LinkedAccountWithPassportAndVisas createLinkInternal(
+  public ImmutablePair<LinkedAccount, OAuth2User> createLinkInternal(
       String providerName,
       String userId,
       String authorizationCode,
@@ -222,8 +165,7 @@ public class ProviderService {
               "user info from provider %s did not contain external id claim %s",
               providerName, providerInfo.getExternalIdClaim()));
     }
-    var linkedAccount =
-        new LinkedAccount.Builder()
+    LinkedAccount linkedAccount = new LinkedAccount.Builder()
             .providerName(providerName)
             .userId(userId)
             .expires(expires)
@@ -231,10 +173,32 @@ public class ProviderService {
             .refreshToken(refreshToken.getTokenValue())
             .isAuthenticated(true)
             .build();
-
-    return linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
-        jwtUtils.enrichAccountWithPassportAndVisas(linkedAccount, userInfo));
+    return new ImmutablePair<>(linkedAccount, userInfo);
   }
+
+  /**
+   * Traverse causes for oauthEx until the cause is null or there is a cycle in the causes. Return
+   * the last oauth2 error code found. This is needed because Spring likes to wrap
+   * OAuth2AuthorizationExceptions with other OAuth2AuthorizationExceptions that have non-standard
+   * error codes. We just want to handle standard error codes which should be in the root cause.
+   */
+  public String getRootOAuth2ErrorCode(OAuth2AuthorizationException oauthEx) {
+    var errorCode = oauthEx.getError().getErrorCode();
+    Throwable currentThrowable = oauthEx.getCause();
+    var visitedThrowables = new ArrayList<Throwable>();
+    visitedThrowables.add(oauthEx);
+
+    while (currentThrowable != null && !visitedThrowables.contains(currentThrowable)) {
+      if (currentThrowable instanceof OAuth2AuthorizationException nestedOauthEx) {
+        errorCode = nestedOauthEx.getError().getErrorCode();
+      }
+      visitedThrowables.add(currentThrowable);
+      currentThrowable = currentThrowable.getCause();
+    }
+
+    return errorCode;
+  }
+
 
   public LinkedAccount deleteLink(String userId, String providerName) {
     var providerInfo = externalCredsConfig.getProviders().get(providerName);
@@ -255,178 +219,8 @@ public class ProviderService {
     return linkedAccount;
   }
 
-  public int validateAccessTokenVisas() {
-    var visaDetailsList = passportService.getUnvalidatedAccessTokenVisaDetails();
 
-    var linkedAccountIdsToRefresh =
-        visaDetailsList.stream()
-            .flatMap(
-                visaDetails ->
-                    validateVisaWithProvider(visaDetails)
-                        ? Stream.empty()
-                        : Stream.of(visaDetails.getLinkedAccountId()))
-            .distinct();
-
-    linkedAccountIdsToRefresh.forEach(
-        linkedAccountId -> {
-          var linkedAccount = linkedAccountService.getLinkedAccount(linkedAccountId);
-          try {
-            linkedAccount.ifPresentOrElse(
-                this::authAndRefreshPassport,
-                () -> log.info("No linked account found when trying to validate passport."));
-          } catch (Exception e) {
-            log.info("Failed to refresh passport, will try again at the next interval.", e);
-          }
-        });
-
-    return visaDetailsList.size();
-  }
-
-  @VisibleForTesting
-  void authAndRefreshPassport(LinkedAccount linkedAccount) {
-    if (linkedAccount.getExpires().toInstant().isBefore(Instant.now())) {
-      invalidateLinkedAccount(linkedAccount);
-    } else {
-      try {
-        var linkedAccountWithRefreshedPassport = getRefreshedPassportsAndVisas(linkedAccount);
-        linkedAccountService.upsertLinkedAccountWithPassportAndVisas(
-            linkedAccountWithRefreshedPassport);
-        var transactionClaim =
-            linkedAccountWithRefreshedPassport
-                .getPassport()
-                .flatMap(p -> jwtUtils.getJwtTransactionClaim(p.getJwt()));
-        auditLogger.logEvent(
-            new AuditLogEvent.Builder()
-                .auditLogEventType(AuditLogEventType.LinkRefreshed)
-                .providerName(linkedAccount.getProviderName())
-                .userId(linkedAccount.getUserId())
-                .externalUserId(linkedAccount.getExternalUserId())
-                .transactionClaim(transactionClaim)
-                .build());
-
-      } catch (IllegalArgumentException iae) {
-        throw new ExternalCredsException(
-            String.format(
-                "Could not contact issuer for provider %s", linkedAccount.getProviderName()),
-            iae);
-      } catch (OAuth2AuthorizationException oauthEx) {
-        // if it looks like the refresh token will never work, delete the passport
-        if (unrecoverableOAuth2ErrorCodes.contains(getRootOAuth2ErrorCode(oauthEx))) {
-          log.info(
-              String.format(
-                  "Caught unrecoverable oauth2 error code refreshing passport for user id [%s].",
-                  linkedAccount.getUserId()),
-              oauthEx);
-          if (linkedAccount.getId().isEmpty()) {
-            throw new ExternalCredsException("linked account id missing");
-          }
-          invalidateLinkedAccount(linkedAccount);
-        } else {
-          // log and try again later
-          throw new ExternalCredsException("Failed to refresh passport: ", oauthEx);
-        }
-      }
-    }
-  }
-
-  /**
-   * Traverse causes for oauthEx until the cause is null or there is a cycle in the causes. Return
-   * the last oauth2 error code found. This is needed because Spring likes to wrap
-   * OAuth2AuthorizationExceptions with other OAuth2AuthorizationExceptions that have non-standard
-   * error codes. We just want to handle standard error codes which should be in the root cause.
-   */
-  private String getRootOAuth2ErrorCode(OAuth2AuthorizationException oauthEx) {
-    var errorCode = oauthEx.getError().getErrorCode();
-    Throwable currentThrowable = oauthEx.getCause();
-    var visitedThrowables = new ArrayList<Throwable>();
-    visitedThrowables.add(oauthEx);
-
-    while (currentThrowable != null && !visitedThrowables.contains(currentThrowable)) {
-      if (currentThrowable instanceof OAuth2AuthorizationException nestedOauthEx) {
-        errorCode = nestedOauthEx.getError().getErrorCode();
-      }
-      visitedThrowables.add(currentThrowable);
-      currentThrowable = currentThrowable.getCause();
-    }
-
-    return errorCode;
-  }
-
-  private LinkedAccountWithPassportAndVisas getRefreshedPassportsAndVisas(
-      LinkedAccount linkedAccount) {
-    var clientRegistration =
-        providerClientCache
-            .getProviderClient(linkedAccount.getProviderName())
-            .orElseThrow(
-                () ->
-                    new ExternalCredsException(
-                        String.format(
-                            "Unable to find configs for the provider: %s",
-                            linkedAccount.getProviderName())));
-    var accessTokenResponse =
-        oAuth2Service.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
-
-    // save the linked account with the new refresh token and extracted passport
-    var linkedAccountWithRefreshToken =
-        Optional.ofNullable(accessTokenResponse.getRefreshToken())
-            .map(
-                refreshToken ->
-                    linkedAccountService.upsertLinkedAccount(
-                        linkedAccount.withRefreshToken(refreshToken.getTokenValue())))
-            .orElse(linkedAccount);
-
-    // update the passport and visas
-    var userInfo =
-        oAuth2Service.getUserInfo(clientRegistration, accessTokenResponse.getAccessToken());
-    return jwtUtils.enrichAccountWithPassportAndVisas(linkedAccountWithRefreshToken, userInfo);
-  }
-
-  @VisibleForTesting
-  boolean validateVisaWithProvider(VisaVerificationDetails visaDetails) {
-    var providerProperties = externalCredsConfig.getProviders().get(visaDetails.getProviderName());
-    if (providerProperties == null) {
-      throw new NotFoundException(
-          String.format("Provider %s not found", visaDetails.getProviderName()));
-    }
-
-    var validationEndpoint =
-        providerProperties
-            .getValidationEndpoint()
-            .orElseThrow(
-                () ->
-                    new NotFoundException(
-                        String.format(
-                            "Validation endpoint for provider %s not found",
-                            visaDetails.getProviderName())));
-
-    var response =
-        WebClient.create(validationEndpoint)
-            .get()
-            .uri(uriBuilder -> uriBuilder.queryParam("visa", visaDetails.getVisaJwt()).build())
-            .retrieve();
-    var responseBody =
-        response
-            .onStatus(HttpStatusCode::isError, clientResponse -> Mono.empty())
-            .bodyToMono(String.class)
-            .block(Duration.of(1000, ChronoUnit.MILLIS));
-
-    log.info(
-        "Got visa validation response.",
-        Map.of(
-            "linkedAccountId", visaDetails.getLinkedAccountId(),
-            "providerName", visaDetails.getProviderName(),
-            "validationResponse", Objects.requireNonNullElse(responseBody, "[null]")));
-
-    var visaValid = "valid".equalsIgnoreCase(responseBody);
-
-    if (visaValid) {
-      passportService.updateVisaLastValidated(visaDetails.getVisaId());
-    }
-    return visaValid;
-  }
-
-  private void invalidateLinkedAccount(LinkedAccount linkedAccount) {
+  public void invalidateLinkedAccount(LinkedAccount linkedAccount) {
     auditLogger.logEvent(
         new AuditLogEvent.Builder()
             .auditLogEventType(AuditLogEventType.LinkExpired)

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -37,7 +37,7 @@ import reactor.core.publisher.Mono;
 
 @Service
 @Slf4j
-public abstract class ProviderService {
+public class ProviderService {
   public final ExternalCredsConfig externalCredsConfig;
   public final ProviderClientCache providerClientCache;
   public final OAuth2Service oAuth2Service;
@@ -165,7 +165,8 @@ public abstract class ProviderService {
               "user info from provider %s did not contain external id claim %s",
               providerName, providerInfo.getExternalIdClaim()));
     }
-    LinkedAccount linkedAccount = new LinkedAccount.Builder()
+    LinkedAccount linkedAccount =
+        new LinkedAccount.Builder()
             .providerName(providerName)
             .userId(userId)
             .expires(expires)
@@ -199,7 +200,6 @@ public abstract class ProviderService {
     return errorCode;
   }
 
-
   public LinkedAccount deleteLink(String userId, String providerName) {
     var providerInfo = externalCredsConfig.getProviders().get(providerName);
 
@@ -218,7 +218,6 @@ public abstract class ProviderService {
 
     return linkedAccount;
   }
-
 
   public void invalidateLinkedAccount(LinkedAccount linkedAccount) {
     auditLogger.logEvent(

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -20,9 +20,13 @@ public class TestUtils {
   }
 
   public static LinkedAccount createRandomLinkedAccount() {
+    return createRandomLinkedAccount("ras");
+  }
+
+  public static LinkedAccount createRandomLinkedAccount(String providerName) {
     return new LinkedAccount.Builder()
         .expires(getRandomTimestamp())
-        .providerName(UUID.randomUUID().toString())
+        .providerName(providerName)
         .refreshToken(UUID.randomUUID().toString())
         .userId(UUID.randomUUID().toString())
         .externalUserId(UUID.randomUUID().toString())

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -1,6 +1,7 @@
 package bio.terra.externalcreds;
 
 import bio.terra.externalcreds.config.ProviderProperties;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.LinkedAccount;
@@ -20,7 +21,7 @@ public class TestUtils {
   }
 
   public static LinkedAccount createRandomLinkedAccount() {
-    return createRandomLinkedAccount("ras");
+    return createRandomLinkedAccount(Provider.RAS.name());
   }
 
   public static LinkedAccount createRandomLinkedAccount(String providerName) {

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -21,6 +21,7 @@ import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.auditLogging.AuditLogEvent;
 import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccount.Builder;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
@@ -63,6 +64,7 @@ class OidcApiControllerTest extends BaseTest {
   @MockBean private SamUserFactory samUserFactoryMock;
   @MockBean private PassportService passportServiceMock;
   @MockBean private AuditLogger auditLoggerMock;
+  private String providerName = Provider.RAS.name();
 
   @Test
   void testListProviders() throws Exception {
@@ -82,7 +84,6 @@ class OidcApiControllerTest extends BaseTest {
       var userId = "fakeUser";
       var accessToken = "fakeAccessToken";
       var result = "https://test/authorization/uri";
-      var providerName = "fake";
       var redirectUri = "fakeuri";
 
       mockSamUser(userId, accessToken);
@@ -103,7 +104,6 @@ class OidcApiControllerTest extends BaseTest {
     void testGetAuthUrl404() throws Exception {
       var userId = "fakeUser";
       var accessToken = "fakeAccessToken";
-      var providerName = "fake";
       var redirectUri = "fakeuri";
 
       mockSamUser(userId, accessToken);
@@ -148,7 +148,6 @@ class OidcApiControllerTest extends BaseTest {
     @Test
     void testGetLink404() throws Exception {
       var userId = "non-existent-user";
-      var providerName = "non-existent-provider";
       var accessToken = "testToken";
 
       mockSamUser(userId, accessToken);
@@ -209,7 +208,7 @@ class OidcApiControllerTest extends BaseTest {
           .thenThrow(new ExternalCredsException("This is a drill!"));
 
       // check that an internal server error code is returned
-      var testProviderName = "ras";
+      var testProviderName = Provider.RAS.name();
       mvc.perform(
               post("/api/oidc/v1/{provider}/oauthcode", testProviderName)
                   .header("authorization", "Bearer " + accessToken)
@@ -238,7 +237,6 @@ class OidcApiControllerTest extends BaseTest {
     void testDeleteLink() throws Exception {
       var accessToken = "testToken";
       var userId = UUID.randomUUID().toString();
-      var providerName = UUID.randomUUID().toString();
       var externalId = UUID.randomUUID().toString();
       mockSamUser(userId, accessToken);
 
@@ -276,7 +274,6 @@ class OidcApiControllerTest extends BaseTest {
     void testDeleteLink404() throws Exception {
       var accessToken = "testToken";
       var userId = UUID.randomUUID().toString();
-      var providerName = UUID.randomUUID().toString();
       mockSamUser(userId, accessToken);
 
       doThrow(new NotFoundException("not found"))
@@ -297,7 +294,6 @@ class OidcApiControllerTest extends BaseTest {
     void testGetProviderPassport() throws Exception {
       var accessToken = "testToken";
       var userId = UUID.randomUUID().toString();
-      var providerName = UUID.randomUUID().toString();
       var externalUserId = UUID.randomUUID().toString();
       var passport =
           TestUtils.createRandomPassport()
@@ -340,7 +336,6 @@ class OidcApiControllerTest extends BaseTest {
     void testGetProviderPassportDoesNotReturnExpired() throws Exception {
       var accessToken = "testToken";
       var userId = UUID.randomUUID().toString();
-      var providerName = UUID.randomUUID().toString();
       var passport =
           TestUtils.createRandomPassport()
               .withExpires(new Timestamp(System.currentTimeMillis() - 1000));
@@ -359,7 +354,6 @@ class OidcApiControllerTest extends BaseTest {
     void testGetProviderPassport404() throws Exception {
       var accessToken = "testToken";
       var userId = UUID.randomUUID().toString();
-      var providerName = UUID.randomUUID().toString();
 
       mockSamUser(userId, accessToken);
 

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -24,6 +24,7 @@ import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccount.Builder;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
 import bio.terra.externalcreds.services.LinkedAccountService;
+import bio.terra.externalcreds.services.PassportProviderService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.services.ProviderService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -49,6 +50,7 @@ class OidcApiControllerTest extends BaseTest {
 
   @MockBean private LinkedAccountService linkedAccountServiceMock;
   @MockBean private ProviderService providerServiceMock;
+  @MockBean private PassportProviderService passportProviderServiceMock;
   @MockBean private SamUserFactory samUserFactoryMock;
   @MockBean private PassportService passportServiceMock;
   @MockBean private AuditLogger auditLoggerMock;
@@ -161,11 +163,13 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(inputLinkedAccount.getUserId(), accessToken);
 
-      when(providerServiceMock.createLink(
+      when(passportProviderServiceMock.createLink(
               inputLinkedAccount.getProviderName(),
               inputLinkedAccount.getUserId(),
               oauthcode,
-              state))
+              state,
+              new AuditLogEvent.Builder()
+          ))
           .thenReturn(
               Optional.of(
                   new LinkedAccountWithPassportAndVisas.Builder()
@@ -203,7 +207,7 @@ class OidcApiControllerTest extends BaseTest {
       var userId = "userId";
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.createLink(any(), any(), any(), any()))
+      when(passportProviderServiceMock.createLink(any(), any(), any(), any(), any()))
           .thenThrow(new ExternalCredsException("This is a drill!"));
 
       // check that an internal server error code is returned

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -9,6 +9,8 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.JwtSigningTestUtils;
 import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent.Builder;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
@@ -46,7 +48,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   @MockBean ProviderClientCache providerClientCacheMock;
   @MockBean ExternalCredsConfig externalCredsConfigMock;
 
-  @Autowired ProviderService providerService;
+  @Autowired PassportProviderService passportProviderService;
   @Autowired PassportService passportService;
   @Autowired LinkedAccountService linkedAccountService;
   @Autowired JwtUtils jwtUtils;
@@ -151,11 +153,12 @@ class AuthorizationCodeExchangeTest extends BaseTest {
         assertThrows(
             BadRequestException.class,
             () ->
-                providerService.createLink(
+                passportProviderService.createLink(
                     linkedAccount.getProviderName(),
                     linkedAccount.getUserId(),
                     authorizationCode,
-                    encodedState));
+                    encodedState,
+                    new AuditLogEvent.Builder()));
 
     // make sure the BadRequestException is for the right reason
     assertInstanceOf(OAuth2AuthorizationException.class, exception.getCause());
@@ -233,11 +236,12 @@ class AuthorizationCodeExchangeTest extends BaseTest {
     linkedAccountService.upsertOAuth2State(expectedLinkedAccount.getUserId(), state);
 
     var linkedAccountWithPassportAndVisas =
-        providerService.createLink(
+        passportProviderService.createLink(
             expectedLinkedAccount.getProviderName(),
             expectedLinkedAccount.getUserId(),
             authorizationCode,
-            encodedState);
+            encodedState,
+            new AuditLogEvent.Builder());
 
     assertPresent(linkedAccountWithPassportAndVisas);
 

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -10,7 +10,6 @@ import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.JwtSigningTestUtils;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.auditLogging.AuditLogEvent;
-import bio.terra.externalcreds.auditLogging.AuditLogEvent.Builder;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
@@ -235,13 +234,18 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
     linkedAccountService.upsertOAuth2State(expectedLinkedAccount.getUserId(), state);
 
+    var auditLogEventBuilder =
+        new AuditLogEvent.Builder()
+            .providerName(expectedLinkedAccount.getProviderName())
+            .userId(expectedLinkedAccount.getUserId())
+            .clientIP("127.0.0.1");
     var linkedAccountWithPassportAndVisas =
         passportProviderService.createLink(
             expectedLinkedAccount.getProviderName(),
             expectedLinkedAccount.getUserId(),
             authorizationCode,
             encodedState,
-            new AuditLogEvent.Builder());
+            auditLogEventBuilder);
 
     assertPresent(linkedAccountWithPassportAndVisas);
 

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -228,9 +228,10 @@ class PassportServiceTest extends BaseTest {
     private void runValidPassportTest(ValidPassportTestParams params) throws URISyntaxException {
       when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
 
-      var linkedAccount = TestUtils.createRandomLinkedAccount();
+      var linkedAccount = TestUtils.createRandomLinkedAccount(UUID.randomUUID().toString());
       var otherLinkedAccount =
-          TestUtils.createRandomLinkedAccount().withUserId(linkedAccount.getUserId());
+          TestUtils.createRandomLinkedAccount(UUID.randomUUID().toString())
+              .withUserId(linkedAccount.getUserId());
       mockProviderConfig(linkedAccount, otherLinkedAccount);
 
       var matchingPermission =

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -461,7 +461,8 @@ public class ProviderServiceTest extends BaseTest {
           mockValidationEndpointConfigsAndResponse(
               visaVerificationDetails, HttpStatus.OK, "Valid")) {
 
-        var responseBody = passportProviderService.validateVisaWithProvider(visaVerificationDetails);
+        var responseBody =
+            passportProviderService.validateVisaWithProvider(visaVerificationDetails);
         assertEquals(true, responseBody);
 
         // verify that visa last validated has been updated
@@ -492,7 +493,8 @@ public class ProviderServiceTest extends BaseTest {
           mockValidationEndpointConfigsAndResponse(
               visaVerificationDetails, HttpStatus.BAD_REQUEST, "Invalid Passport")) {
 
-        var responseBody = passportProviderService.validateVisaWithProvider(visaVerificationDetails);
+        var responseBody =
+            passportProviderService.validateVisaWithProvider(visaVerificationDetails);
         assertEquals(false, responseBody);
 
         // verify that visa last validated has NOT been updated

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -19,6 +19,7 @@ import bio.terra.common.exception.NotFoundException;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.ExternalCredsException;
 import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.config.ProviderProperties;
 import bio.terra.externalcreds.dataAccess.GA4GHPassportDAO;
@@ -160,6 +161,7 @@ public class ProviderServiceTest extends BaseTest {
   class AuthAndRefreshPassport {
 
     @Autowired private ProviderService providerService;
+    @Autowired private PassportProviderService passportProviderService;
     @Autowired private GA4GHPassportDAO passportDAO;
     @Autowired private LinkedAccountDAO linkedAccountDAO;
     @Autowired private GA4GHVisaDAO visaDAO;
@@ -181,7 +183,7 @@ public class ProviderServiceTest extends BaseTest {
           TestUtils.createRandomPassport().withLinkedAccountId(expiredLinkedAccount.getId()));
 
       // since the LinkedAccount itself is expired, it should be marked as invalid
-      providerService.authAndRefreshPassport(expiredLinkedAccount);
+      passportProviderService.authAndRefreshPassport(expiredLinkedAccount);
 
       // check that the passport was deleted and the linked account was marked as invalid
       assertEmpty(
@@ -222,7 +224,7 @@ public class ProviderServiceTest extends BaseTest {
       // check that an exception is thrown
       assertThrows(
           ExternalCredsException.class,
-          () -> providerService.authAndRefreshPassport(savedLinkedAccount));
+          () -> passportProviderService.authAndRefreshPassport(savedLinkedAccount));
     }
 
     @Test
@@ -255,7 +257,7 @@ public class ProviderServiceTest extends BaseTest {
                   new OAuth2Error(OAuth2ErrorCodes.INSUFFICIENT_SCOPE)));
 
       // attempt to auth and refresh
-      providerService.authAndRefreshPassport(savedLinkedAccount);
+      passportProviderService.authAndRefreshPassport(savedLinkedAccount);
 
       // check that the passport was deleted and the linked account was marked as invalid
       assertEmpty(
@@ -298,7 +300,7 @@ public class ProviderServiceTest extends BaseTest {
       // check that the expected exception is thrown
       assertThrows(
           ExternalCredsException.class,
-          () -> providerService.authAndRefreshPassport(savedLinkedAccount));
+          () -> passportProviderService.authAndRefreshPassport(savedLinkedAccount));
     }
 
     @Test
@@ -351,7 +353,7 @@ public class ProviderServiceTest extends BaseTest {
                   .build());
 
       // attempt to auth and refresh
-      providerService.authAndRefreshPassport(savedLinkedAccount);
+      passportProviderService.authAndRefreshPassport(savedLinkedAccount);
 
       // check that the passport and visa were updated in the DB
       var actualUpdatedPassport =
@@ -388,7 +390,7 @@ public class ProviderServiceTest extends BaseTest {
       // check that ExternalCredsException is thrown
       assertThrows(
           ExternalCredsException.class,
-          () -> providerService.authAndRefreshPassport(linkedAccount));
+          () -> passportProviderService.authAndRefreshPassport(linkedAccount));
     }
 
     private void mockProviderConfigs(String providerName) {
@@ -402,7 +404,7 @@ public class ProviderServiceTest extends BaseTest {
   class RefreshExpiringPassports {
     @Autowired private GA4GHPassportDAO passportDAO;
     @Autowired private LinkedAccountDAO linkedAccountDAO;
-    @Autowired private ProviderService providerService;
+    @Autowired private PassportProviderService passportProviderService;
 
     @MockBean private ExternalCredsConfig externalCredsConfigMock;
 
@@ -431,7 +433,7 @@ public class ProviderServiceTest extends BaseTest {
           .thenReturn(Duration.ofMinutes(30));
 
       // check that authAndRefreshPassport is called exactly once with the expiring linked account
-      var providerServiceSpy = Mockito.spy(providerService);
+      var providerServiceSpy = Mockito.spy(passportProviderService);
       providerServiceSpy.refreshExpiringPassports();
       verify(providerServiceSpy).authAndRefreshPassport(any());
       verify(providerServiceSpy).authAndRefreshPassport(savedExpiringLinkedAccount);
@@ -441,7 +443,7 @@ public class ProviderServiceTest extends BaseTest {
   @Nested
   @TestComponent
   class ValidateVisaWithProvider {
-    @Autowired private ProviderService providerService;
+    @Autowired private PassportProviderService passportProviderService;
     @Autowired private LinkedAccountService linkedAccountService;
     @Autowired private GA4GHVisaDAO visaDAO;
 
@@ -459,7 +461,7 @@ public class ProviderServiceTest extends BaseTest {
           mockValidationEndpointConfigsAndResponse(
               visaVerificationDetails, HttpStatus.OK, "Valid")) {
 
-        var responseBody = providerService.validateVisaWithProvider(visaVerificationDetails);
+        var responseBody = passportProviderService.validateVisaWithProvider(visaVerificationDetails);
         assertEquals(true, responseBody);
 
         // verify that visa last validated has been updated
@@ -490,7 +492,7 @@ public class ProviderServiceTest extends BaseTest {
           mockValidationEndpointConfigsAndResponse(
               visaVerificationDetails, HttpStatus.BAD_REQUEST, "Invalid Passport")) {
 
-        var responseBody = providerService.validateVisaWithProvider(visaVerificationDetails);
+        var responseBody = passportProviderService.validateVisaWithProvider(visaVerificationDetails);
         assertEquals(false, responseBody);
 
         // verify that visa last validated has NOT been updated
@@ -513,7 +515,7 @@ public class ProviderServiceTest extends BaseTest {
 
       assertThrows(
           NotFoundException.class,
-          () -> providerService.validateVisaWithProvider(visaVerificationDetails));
+          () -> passportProviderService.validateVisaWithProvider(visaVerificationDetails));
     }
 
     @Test
@@ -527,7 +529,7 @@ public class ProviderServiceTest extends BaseTest {
 
       assertThrows(
           NotFoundException.class,
-          () -> providerService.validateVisaWithProvider(visaVerificationDetails));
+          () -> passportProviderService.validateVisaWithProvider(visaVerificationDetails));
     }
 
     private ClientAndServer mockValidationEndpointConfigsAndResponse(
@@ -566,12 +568,12 @@ public class ProviderServiceTest extends BaseTest {
   @Nested
   @TestComponent
   class ValidateAccessTokenVisas {
-    @Autowired private ProviderService providerService;
+    @Autowired private PassportProviderService passportProviderService;
     @Autowired private LinkedAccountService linkedAccountService;
 
     @Test
     void testValidResponse() {
-      var providerServiceSpy = spy(providerService);
+      var providerServiceSpy = spy(passportProviderService);
       LinkedAccountWithPassportAndVisas savedLinkedAccountWithPassportAndVisa =
           createLinkedAccountWithOldVisa(linkedAccountService);
 
@@ -587,7 +589,7 @@ public class ProviderServiceTest extends BaseTest {
 
     @Test
     void testInvalidResponse() {
-      var providerServiceSpy = spy(providerService);
+      var providerServiceSpy = spy(passportProviderService);
       LinkedAccountWithPassportAndVisas savedLinkedAccountWithPassportAndVisa =
           createLinkedAccountWithOldVisa(linkedAccountService);
 
@@ -647,6 +649,7 @@ public class ProviderServiceTest extends BaseTest {
     @MockBean ExternalCredsConfig externalCredsConfigMock;
 
     @Autowired ProviderService providerService;
+    @Autowired PassportProviderService passportProviderService;
     @Autowired OAuth2StateDAO oAuth2StateDAO;
     @Autowired ObjectMapper objectMapper;
 
@@ -709,11 +712,12 @@ public class ProviderServiceTest extends BaseTest {
       assertThrows(
           BadRequestException.class,
           () ->
-              providerService.createLink(
+              passportProviderService.createLink(
                   expectedLinkedAccount.getProviderName(),
                   expectedLinkedAccount.getUserId(),
                   UUID.randomUUID().toString(),
-                  state.withRandom("wrong").encode(objectMapper)));
+                  state.withRandom("wrong").encode(objectMapper),
+                  new AuditLogEvent.Builder()));
     }
 
     @Test
@@ -733,11 +737,12 @@ public class ProviderServiceTest extends BaseTest {
       assertThrows(
           BadRequestException.class,
           () ->
-              providerService.createLink(
+              passportProviderService.createLink(
                   expectedLinkedAccount.getProviderName(),
                   expectedLinkedAccount.getUserId(),
                   UUID.randomUUID().toString(),
-                  state.withProvider("wrong").encode(objectMapper)));
+                  state.withProvider("wrong").encode(objectMapper),
+                  new AuditLogEvent.Builder()));
     }
 
     @Test
@@ -748,11 +753,12 @@ public class ProviderServiceTest extends BaseTest {
           assertThrows(
               BadRequestException.class,
               () ->
-                  providerService.createLink(
+                  passportProviderService.createLink(
                       expectedLinkedAccount.getProviderName(),
                       expectedLinkedAccount.getUserId(),
                       UUID.randomUUID().toString(),
-                      "not base64 encoded"));
+                      "not base64 encoded",
+                      new AuditLogEvent.Builder()));
 
       assertInstanceOf(CannotDecodeOAuth2State.class, e.getCause());
       assertInstanceOf(IllegalArgumentException.class, e.getCause().getCause());
@@ -766,11 +772,12 @@ public class ProviderServiceTest extends BaseTest {
           assertThrows(
               BadRequestException.class,
               () ->
-                  providerService.createLink(
+                  passportProviderService.createLink(
                       expectedLinkedAccount.getProviderName(),
                       expectedLinkedAccount.getUserId(),
                       UUID.randomUUID().toString(),
-                      new String(Base64.getEncoder().encode("not json".getBytes()))));
+                      new String(Base64.getEncoder().encode("not json".getBytes())),
+                      new AuditLogEvent.Builder()));
 
       assertInstanceOf(CannotDecodeOAuth2State.class, e.getCause());
       assertInstanceOf(JsonParseException.class, e.getCause().getCause());
@@ -784,7 +791,7 @@ public class ProviderServiceTest extends BaseTest {
           assertThrows(
               BadRequestException.class,
               () ->
-                  providerService.createLink(
+                  passportProviderService.createLink(
                       expectedLinkedAccount.getProviderName(),
                       expectedLinkedAccount.getUserId(),
                       UUID.randomUUID().toString(),
@@ -793,7 +800,8 @@ public class ProviderServiceTest extends BaseTest {
                               .encode(
                                   objectMapper
                                       .writeValueAsString(Map.of("foo", "bar"))
-                                      .getBytes()))));
+                                      .getBytes())),
+                      new AuditLogEvent.Builder()));
 
       assertInstanceOf(CannotDecodeOAuth2State.class, e.getCause());
       assertInstanceOf(ValueInstantiationException.class, e.getCause().getCause());


### PR DESCRIPTION
**Ticekt:**
This will make it easier to implement https://broadworkbench.atlassian.net/browse/ID-1051 (I can create a separate ticket for this refactor if that makes code review easier).

**What:**
Refactor the OidcApiController `createLink` method and `ProviderService` to separate out the passport provider-specific logic.

**Why:**
We want to add support for linking a GitHub account via ECM, and the functionality to exchange an oauth code for a refresh token has already been implemented. However, it is specific to linking a Ras provider so it is not currently reusable.

**How:**
- Move passport-related methods from `ProviderService` to the new `PassportProviderService`.
- Generalize `createLinkInternal` so it can be re-used for other provider types
- Move `createLink` into PassportProviderService (token and fence account services will have different implementations)
- Move passport-specific audit logging out of OidcApiController `createLink`
- Use an enum for the provider parameter instead of an arbitrary string
