### PR TITLE
[ID-1051] Add GitHub account linking

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -93,7 +93,7 @@ paths:
 
   /api/oidc/v1/{provider}/passport:
     parameters:
-      - $ref: '#/components/parameters/providerParam'
+      - $ref: '#/components/parameters/passportProviderParam'
     get:
       summary: Get the original passport from this provider
       tags: [ oidc ]
@@ -240,6 +240,12 @@ components:
       schema:
         type: boolean
         default: false
+    passportProviderParam:
+      name: provider
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/PassportProvider'
     providerParam:
       name: provider
       in: path
@@ -319,8 +325,13 @@ components:
             $ref: '#/components/schemas/ErrorReport'
 
   schemas:
+    PassportProvider:
+      description: Enum containing only passport providers.
+      type: string
+      enum:
+        - ras
     Provider:
-      description: Enum containing valid identity providers.
+      description: Enum containing all valid providers.
       type: string
       enum:
         - ras

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -324,6 +324,7 @@ components:
       type: string
       enum:
         - ras
+        - github
     SshKeyPairType:
       description: Enum containing valid ssh key types.
       type: string

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -7,6 +7,7 @@ import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.controllers.OpenApiConverters.Output;
 import bio.terra.externalcreds.generated.api.OidcApi;
 import bio.terra.externalcreds.generated.model.LinkInfo;
+import bio.terra.externalcreds.generated.model.PassportProvider;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.services.JwtUtils;
@@ -130,7 +131,7 @@ public record OidcApiController(
   }
 
   @Override
-  public ResponseEntity<String> getProviderPassport(Provider providerName) {
+  public ResponseEntity<String> getProviderPassport(PassportProvider providerName) {
     var samUser = samUserFactory.from(request);
     var maybeLinkedAccount =
         linkedAccountService.getLinkedAccount(samUser.getSubjectId(), providerName.name());

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -1,0 +1,82 @@
+package bio.terra.externalcreds.services;
+
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.models.LinkedAccount;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TokenProviderService extends ProviderService {
+
+  public TokenProviderService(
+      ExternalCredsConfig externalCredsConfig,
+      ProviderClientCache providerClientCache,
+      OAuth2Service oAuth2Service,
+      LinkedAccountService linkedAccountService,
+      AuditLogger auditLogger,
+      ObjectMapper objectMapper) {
+    super(
+        externalCredsConfig,
+        providerClientCache,
+        oAuth2Service,
+        linkedAccountService,
+        auditLogger,
+        objectMapper);
+  }
+
+  public Optional<LinkedAccount> createLink(
+      String providerName,
+      String userId,
+      String authorizationCode,
+      String encodedState,
+      AuditLogEvent.Builder auditLogEventBuilder) {
+
+    var oAuth2State = validateOAuth2State(providerName, userId, encodedState);
+
+    Optional<LinkedAccount> linkedAccount =
+        providerClientCache
+            .getProviderClient(providerName)
+            .map(
+                providerClient -> {
+                  var providerInfo = externalCredsConfig.getProviders().get(providerName);
+                  try {
+                    var account =
+                        createLinkedAccount(
+                                providerName,
+                                userId,
+                                authorizationCode,
+                                oAuth2State.getRedirectUri(),
+                                new HashSet<>(providerInfo.getScopes()),
+                                encodedState,
+                                providerClient)
+                            .getLeft();
+                    return linkedAccountService.upsertLinkedAccount(account);
+                  } catch (OAuth2AuthorizationException oauthEx) {
+                    throw new BadRequestException(oauthEx);
+                  }
+                });
+    logLinkCreation(linkedAccount, auditLogEventBuilder);
+    return linkedAccount;
+  }
+
+  private void logLinkCreation(
+      Optional<LinkedAccount> linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+    auditLogger.logEvent(
+        auditLogEventBuilder
+            .externalUserId(linkedAccount.map(LinkedAccount::getExternalUserId))
+            .auditLogEventType(
+                linkedAccount
+                    .map(x -> AuditLogEventType.LinkCreated)
+                    .orElse(AuditLogEventType.LinkCreationFailed))
+            .build());
+  }
+}


### PR DESCRIPTION
**Jira:** 
- https://broadworkbench.atlassian.net/browse/ID-1054
- https://broadworkbench.atlassian.net/browse/ID-1050
- https://broadworkbench.atlassian.net/browse/ID-1051

**What:**
Add `github` as a provider option for the following endpoints:
- GET `/api/oidc/v1/{provider}`
- DELETE `/api/oidc/v1/{provider}`
- GET `/api/oidc/v1/{provider}/authorization-url`
- POST `/api/oidc/v1/{provider}/oauthcode`

The only endpoint changed in this PR is the POST endpoint. If the provider is `github`, the createLink method for token providers will be called (not passport providers).

**Why:**
This PR enables a user to link their github account, which will allow them to import private workflows into their Terra workspace.

**How:**
- Add a new `TokenProviderService` with a `createLink` method that handles account linking for any provider that uses access tokens. 

Note: This is blocked by https://broadworkbench.atlassian.net/browse/ID-1044 (adding github to the ECM provider configuration)
