### PR TITLE
[ID-1054] Return GitHub auth url

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -93,7 +93,7 @@ paths:
 
   /api/oidc/v1/{provider}/passport:
     parameters:
-      - $ref: '#/components/parameters/providerParam'
+      - $ref: '#/components/parameters/passportProviderParam'
     get:
       summary: Get the original passport from this provider
       tags: [ oidc ]
@@ -240,6 +240,12 @@ components:
       schema:
         type: boolean
         default: false
+    passportProviderParam:
+      name: provider
+      in: path
+      required: true
+      schema:
+        $ref: '#/components/schemas/PassportProvider'
     providerParam:
       name: provider
       in: path
@@ -319,11 +325,17 @@ components:
             $ref: '#/components/schemas/ErrorReport'
 
   schemas:
+    PassportProvider:
+      description: Enum containing valid passport providers.
+      type: string
+      enum:
+        - ras
     Provider:
       description: Enum containing valid identity providers.
       type: string
       enum:
         - ras
+        - github
     SshKeyPairType:
       description: Enum containing valid ssh key types.
       type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -4,6 +4,24 @@ info:
   description: A manager for external credentials
   version: 0.0.1
 paths:
+  /api/oauth/v1/{provider}/authorization-url:
+    parameters:
+      - $ref: '#/components/parameters/providerParam'
+      - $ref: '#/components/parameters/redirectUriParam'
+    get:
+      summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
+      tags: [ oauth ]
+      operationId: getAuthUrl
+      description: First step to link a new provider. Creates a 1 time use link. There can only be 1 active link per user per provider. The last link created will invalidate any prior links.
+      responses:
+        '200':
+          description: The authorization URL
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/oidc/v1/providers:
     get:
       summary: Lists the available OIDC providers.
@@ -55,6 +73,7 @@ paths:
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ oidc ]
+      deprecated: true
       operationId: getAuthUrl
       description: First step to link a new provider. Creates a 1 time use link. There can only be 1 active link per user per provider. The last link created will invalidate any prior links.
       responses:

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -11,13 +11,13 @@ paths:
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ oauth ]
-      operationId: getAuthUrl
+      operationId: getAuthorizationUrl
       description: First step to link a new provider. Creates a 1 time use link. There can only be 1 active link per user per provider. The last link created will invalidate any prior links.
       responses:
         '200':
           description: The authorization URL
           content:
-            application/json:
+            text/plain:
               schema:
                 type: string
         '500':

--- a/integration/src/main/java/scripts/testscripts/GetProviderPassport.java
+++ b/integration/src/main/java/scripts/testscripts/GetProviderPassport.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.externalcreds.api.OidcApi;
-import bio.terra.externalcreds.model.Provider;
+import bio.terra.externalcreds.model.PassportProvider;
 import bio.terra.testrunner.runner.TestScript;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
 import java.util.List;
@@ -32,7 +32,8 @@ public class GetProviderPassport extends TestScript {
 
     // TODO: update GetProviderPassport.json in perf to run 120 tests per second
     // check the response code
-    var passportResponse = oidcApi.getProviderPassportWithHttpInfo(Provider.fromValue(provider));
+    var passportResponse =
+        oidcApi.getProviderPassportWithHttpInfo(PassportProvider.fromValue(provider));
     var httpCode = passportResponse.getStatusCode();
 
     assertEquals(HttpStatus.OK, httpCode);

--- a/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
@@ -28,6 +28,8 @@ public interface ProviderPropertiesInterface {
 
   String getExternalIdClaim();
 
+  String getUserNameAttributeName();
+
   // optional overrides for values in provider's /.well-known/openid-configuration
   Optional<String> getUserInfoEndpoint();
 

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -1,0 +1,37 @@
+package bio.terra.externalcreds.controllers;
+
+import bio.terra.externalcreds.generated.api.OauthApi;
+import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.services.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.SneakyThrows;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public record OauthApiController(
+    HttpServletRequest request,
+    ObjectMapper mapper,
+    ProviderService providerService,
+    ExternalCredsSamUserFactory samUserFactory)
+    implements OauthApi {
+
+  @Override
+  public ResponseEntity<String> getAuthUrl(Provider providerName, String redirectUri) {
+    var samUser = samUserFactory.from(request);
+
+    var authorizationUrl =
+        providerService.getProviderAuthorizationUrl(
+            samUser.getSubjectId(), providerName.toString(), redirectUri);
+
+    return ResponseEntity.of(authorizationUrl.map(this::jsonString));
+  }
+
+  /** Helper method to format a string as json. Otherwise it isn't quoted or escaped correctly. */
+  @SneakyThrows(JsonProcessingException.class)
+  private String jsonString(String s) {
+    return mapper.writeValueAsString(s);
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -3,10 +3,8 @@ package bio.terra.externalcreds.controllers;
 import bio.terra.externalcreds.generated.api.OauthApi;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.services.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.SneakyThrows;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -19,19 +17,13 @@ public record OauthApiController(
     implements OauthApi {
 
   @Override
-  public ResponseEntity<String> getAuthUrl(Provider providerName, String redirectUri) {
+  public ResponseEntity<String> getAuthorizationUrl(Provider providerName, String redirectUri) {
     var samUser = samUserFactory.from(request);
 
     var authorizationUrl =
         providerService.getProviderAuthorizationUrl(
             samUser.getSubjectId(), providerName.toString(), redirectUri);
 
-    return ResponseEntity.of(authorizationUrl.map(this::jsonString));
-  }
-
-  /** Helper method to format a string as json. Otherwise it isn't quoted or escaped correctly. */
-  @SneakyThrows(JsonProcessingException.class)
-  private String jsonString(String s) {
-    return mapper.writeValueAsString(s);
+    return ResponseEntity.of(authorizationUrl);
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -14,7 +14,6 @@ import bio.terra.externalcreds.services.LinkedAccountService;
 import bio.terra.externalcreds.services.PassportProviderService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.services.ProviderService;
-import bio.terra.externalcreds.services.TokenProviderService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,7 +35,6 @@ public record OidcApiController(
     ObjectMapper mapper,
     PassportService passportService,
     ProviderService providerService,
-    TokenProviderService tokenProviderService,
     PassportProviderService passportProviderService,
     ExternalCredsSamUserFactory samUserFactory)
     implements OidcApi {

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -6,6 +6,7 @@ import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.api.OidcApi;
 import bio.terra.externalcreds.generated.model.LinkInfo;
+import bio.terra.externalcreds.generated.model.PassportProvider;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.services.JwtUtils;
@@ -13,6 +14,7 @@ import bio.terra.externalcreds.services.LinkedAccountService;
 import bio.terra.externalcreds.services.PassportProviderService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.services.ProviderService;
+import bio.terra.externalcreds.services.TokenProviderService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -34,6 +36,7 @@ public record OidcApiController(
     ObjectMapper mapper,
     PassportService passportService,
     ProviderService providerService,
+    TokenProviderService tokenProviderService,
     PassportProviderService passportProviderService,
     ExternalCredsSamUserFactory samUserFactory)
     implements OidcApi {
@@ -116,7 +119,7 @@ public record OidcApiController(
   }
 
   @Override
-  public ResponseEntity<String> getProviderPassport(Provider providerName) {
+  public ResponseEntity<String> getProviderPassport(PassportProvider providerName) {
     var samUser = samUserFactory.from(request);
     var maybeLinkedAccount =
         linkedAccountService.getLinkedAccount(samUser.getSubjectId(), providerName.toString());

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -11,8 +11,10 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 public class TestUtils {
 
@@ -57,12 +59,17 @@ public class TestUtils {
   public static ProviderProperties createRandomProvider() {
     try {
       return ProviderProperties.create()
+          .setAllowedRedirectUriPatterns(List.of(Pattern.compile("http://redirect")))
+          .setAuthorizationEndpoint("http://authorize")
           .setClientId(UUID.randomUUID().toString())
           .setClientSecret(UUID.randomUUID().toString())
           .setIssuer("http://does/not/exist")
           .setLinkLifespan(Duration.ofDays(SecureRandom.getInstanceStrong().nextInt(10)))
           .setRevokeEndpoint("http://does/not/exist")
-          .setExternalIdClaim("preferred_username");
+          .setTokenEndpoint("http://token")
+          .setExternalIdClaim("preferred_username")
+          .setUserNameAttributeName("username")
+          .setUserInfoEndpoint("http://userinfo");
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -56,7 +56,7 @@ class OauthApiControllerTest extends BaseTest {
               get("/api/oauth/v1/{provider}/authorization-url", providerName)
                   .header("authorization", "Bearer " + accessToken)
                   .queryParams(queryParams))
-          .andExpect(content().json("\"" + result + "\""));
+          .andExpect(content().string(result));
     }
 
     @Test

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -1,0 +1,87 @@
+package bio.terra.externalcreds.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.iam.SamUser;
+import bio.terra.common.iam.SamUserFactory;
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.services.ProviderService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.util.LinkedMultiValueMap;
+
+@AutoConfigureMockMvc
+class OauthApiControllerTest extends BaseTest {
+
+  @Autowired private MockMvc mvc;
+
+  @MockBean
+  @Qualifier("providerService")
+  private ProviderService providerServiceMock;
+
+  @MockBean private SamUserFactory samUserFactoryMock;
+  private String providerName = Provider.RAS.toString();
+
+  @Nested
+  class GetAuthUrl {
+
+    @Test
+    void testGetAuthUrl() throws Exception {
+      var userId = "fakeUser";
+      var accessToken = "fakeAccessToken";
+      var result = "https://test/authorization/uri";
+      var redirectUri = "fakeuri";
+
+      mockSamUser(userId, accessToken);
+
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, providerName, redirectUri))
+          .thenReturn(Optional.of(result));
+
+      var queryParams = new LinkedMultiValueMap<String, String>();
+      queryParams.add("redirectUri", redirectUri);
+      mvc.perform(
+              get("/api/oauth/v1/{provider}/authorization-url", providerName)
+                  .header("authorization", "Bearer " + accessToken)
+                  .queryParams(queryParams))
+          .andExpect(content().json("\"" + result + "\""));
+    }
+
+    @Test
+    void testGetAuthUrl404() throws Exception {
+      var userId = "fakeUser";
+      var accessToken = "fakeAccessToken";
+      var redirectUri = "fakeuri";
+
+      mockSamUser(userId, accessToken);
+
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, providerName, redirectUri))
+          .thenReturn(Optional.empty());
+
+      var queryParams = new LinkedMultiValueMap<String, String>();
+      queryParams.add("redirectUri", redirectUri);
+      mvc.perform(
+              get("/api/oauth/v1/{provider}/authorization-url", providerName)
+                  .header("authorization", "Bearer " + accessToken)
+                  .queryParams(queryParams))
+          .andExpect(status().isNotFound());
+    }
+  }
+
+  private void mockSamUser(String userId, String accessToken) {
+    when(samUserFactoryMock.from(any(HttpServletRequest.class), any(String.class)))
+        .thenReturn(new SamUser("email", userId, new BearerToken(accessToken)));
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderClientCacheTest.java
@@ -1,0 +1,61 @@
+package bio.terra.externalcreds.services;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.config.ProviderProperties;
+import bio.terra.externalcreds.generated.model.Provider;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.*;
+
+public class ProviderClientCacheTest extends BaseTest {
+
+  private ProviderClientCache providerClientCache;
+  private ExternalCredsConfig externalCredsConfig;
+
+  @BeforeEach
+  void setUp() {
+    externalCredsConfig =
+        ExternalCredsConfig.create()
+            .setProviders(
+                Map.of(
+                    Provider.GITHUB.toString(),
+                    TestUtils.createRandomProvider(),
+                    Provider.RAS.toString(),
+                    TestUtils.createRandomProvider()));
+    providerClientCache = new ProviderClientCache(externalCredsConfig);
+  }
+
+  @Test
+  void testGitHubBuildClientRegistration() {
+    String providerName = Provider.GITHUB.toString();
+    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(providerName);
+    String redirectUri =
+        providerInfo.getAllowedRedirectUriPatterns().stream()
+            .map(Pattern::toString)
+            .toList()
+            .get(0);
+    ClientRegistration gitHubClient =
+        providerClientCache.buildClientRegistration(
+            providerName, externalCredsConfig.getProviders().get(providerName));
+    ClientRegistration expectedClient =
+        ClientRegistration.withRegistrationId(providerName)
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .clientId(providerInfo.getClientId())
+            .clientSecret(providerInfo.getClientSecret())
+            .issuerUri(providerInfo.getIssuer())
+            .redirectUri(redirectUri)
+            .userNameAttributeName(providerInfo.getUserNameAttributeName())
+            .userInfoUri(providerInfo.getUserInfoEndpoint().get())
+            .authorizationUri(providerInfo.getAuthorizationEndpoint().get())
+            .tokenUri(providerInfo.getTokenEndpoint().get())
+            .build();
+    assertThat(gitHubClient.equals(expectedClient));
+  }
+}


### PR DESCRIPTION
**Jira:** https://broadworkbench.atlassian.net/browse/ID-1054

**What:**
When a user calls `/api/v1/oidc/github/authorization-url` with an allowed `redirectUri`, they should get an authorization url in the format https://github.com/login/oauth/authorize?response_type=code&client_id={id}&state={state}&redirect_uri={redirect_uri}. When you go to that authorization url, it will take you to the github authorization page. When you agree to link your account it will redirect you to the `redirectUri` (terra dev) and add a `code` query parameter to the url.

This PR also deprecates `/api/oidc/v1/github/authorization-url` in favor of `/api/oauth/v1/github/authorization-url` (the only difference is the route name change from oidc -> oauth).
<img width="1276" alt="Screenshot 2024-02-16 at 11 55 30 AM" src="https://github.com/DataBiosphere/terra-external-credentials-manager/assets/6414394/ab7d68d9-c5f7-4c2d-a4a2-3dd1d0370308">


**Why:**
This is the first step in initiating the authorization flow with github. The Terra UI will: 
1. Call GET `/api/oauth/v1/github/authorization-url`
2. Call the github authorization url, which will prompt the user to authorize their account in github and then redirect to the Terra UI
3. Call the POST `/api/oauth/v1/github/oauthcode` endpoint with the state and code (this will exchange the oauth code for a refresh token and store a record of the user's linked account in ECM)

**How:**
- Add `github` as another provider option to all OIDC API endpoints (except for GET /passports)
- Update how the `ClientRegistration` is created to work for Github. The existing implementation was specific to OIDC providers. 

**Testing:**
1. Run ECM locally and authenticate as a Terra dev user
2. Call `/api/oauth/v1/github/authorization-url` with the callback url "https://bvdp-saturn-dev.appspot.com/oauth_callback"
3. Navigate to the url returned by that endpoint and authorize the Terra github app
4. When you get redirected to Terra, confirm that there is now a "code" query parameter in the url