### PR TITLE
[ID-1050] Add Github account linking

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -22,6 +22,30 @@ paths:
                 type: string
         '500':
           $ref: '#/components/responses/ServerError'
+  /api/oauth/v1/{provider}/oauthcode:
+    parameters:
+      - $ref: '#/components/parameters/providerParam'
+      - $ref: '#/components/parameters/stateParam'
+      - name: oauthcode
+        description: oauth code returned by identity provider
+        in: query
+        schema:
+          type: string
+    post:
+      summary: Link the user's account with the provider.
+      tags: [ oauth ]
+      operationId: createLink
+      description: Response same as GET /api/oidc/v1/{provider}. Code from the GET /api/oauth/v1/{provider}/authorization-url goes here.
+      responses:
+        '200':
+          $ref: '#/components/responses/LinkInfoResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/oidc/v1/providers:
     get:
       summary: Lists the available OIDC providers.
@@ -98,6 +122,7 @@ paths:
     post:
       summary: Link the user's account with the provider.
       tags: [ oidc ]
+      deprecated: true
       operationId: createLink
       description: Response same as GET /api/oidc/v1/{provider}. Code from the GET /api/oidc/v1/{provider}/authorization-url goes here.
       responses:

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -1,6 +1,11 @@
 package bio.terra.externalcreds.controllers;
 
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.api.OauthApi;
+import bio.terra.externalcreds.generated.model.LinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.services.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -10,9 +15,11 @@ import org.springframework.stereotype.Controller;
 
 @Controller
 public record OauthApiController(
+    AuditLogger auditLogger,
     HttpServletRequest request,
     ObjectMapper mapper,
     ProviderService providerService,
+    PassportProviderService passportProviderService,
     ExternalCredsSamUserFactory samUserFactory)
     implements OauthApi {
 
@@ -25,5 +32,38 @@ public record OauthApiController(
             samUser.getSubjectId(), providerName.toString(), redirectUri);
 
     return ResponseEntity.of(authorizationUrl);
+  }
+
+  @Override
+  public ResponseEntity<LinkInfo> createLink(
+      Provider providerName, String state, String oauthcode) {
+    var samUser = samUserFactory.from(request);
+
+    var auditLogEventBuilder =
+        new AuditLogEvent.Builder()
+            .providerName(providerName.toString())
+            .userId(samUser.getSubjectId())
+            .clientIP(request.getRemoteAddr());
+
+    try {
+      if (providerName.equals(Provider.RAS)) {
+        var linkedAccountWithPassportAndVisas =
+            passportProviderService.createLink(
+                providerName.toString(),
+                samUser.getSubjectId(),
+                oauthcode,
+                state,
+                auditLogEventBuilder);
+        return ResponseEntity.of(
+            linkedAccountWithPassportAndVisas.map(
+                x -> OpenApiConverters.Output.convert(x.getLinkedAccount())));
+      } else {
+        throw new BadRequestException("Invalid providerName");
+      }
+    } catch (Exception e) {
+      auditLogger.logEvent(
+          auditLogEventBuilder.auditLogEventType(AuditLogEventType.LinkCreationFailed).build());
+      throw e;
+    }
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -10,9 +10,9 @@ import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.services.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Optional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import java.util.Optional;
 
 @Controller
 public record OauthApiController(
@@ -58,8 +58,9 @@ public record OauthApiController(
                   oauthcode,
                   state,
                   auditLogEventBuilder);
-          linkInfo = linkedAccountWithPassportAndVisas.map(
-              x -> OpenApiConverters.Output.convert(x.getLinkedAccount()));
+          linkInfo =
+              linkedAccountWithPassportAndVisas.map(
+                  x -> OpenApiConverters.Output.convert(x.getLinkedAccount()));
         }
         case GITHUB -> {
           var linkedAccount =
@@ -73,10 +74,10 @@ public record OauthApiController(
         }
       }
       return ResponseEntity.of(linkInfo);
-    } catch(Exception e) {
-        auditLogger.logEvent(
-            auditLogEventBuilder.auditLogEventType(AuditLogEventType.LinkCreationFailed).build());
-        throw e;
+    } catch (Exception e) {
+      auditLogger.logEvent(
+          auditLogEventBuilder.auditLogEventType(AuditLogEventType.LinkCreationFailed).build());
+      throw e;
     }
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -1,9 +1,9 @@
 package bio.terra.externalcreds.controllers;
 
-import bio.terra.common.exception.BadRequestException;
 import bio.terra.externalcreds.auditLogging.AuditLogEvent;
 import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.controllers.OpenApiConverters.Output;
 import bio.terra.externalcreds.generated.api.OauthApi;
 import bio.terra.externalcreds.generated.model.LinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import java.util.Optional;
 
 @Controller
 public record OauthApiController(
@@ -20,6 +21,7 @@ public record OauthApiController(
     ObjectMapper mapper,
     ProviderService providerService,
     PassportProviderService passportProviderService,
+    TokenProviderService tokenProviderService,
     ExternalCredsSamUserFactory samUserFactory)
     implements OauthApi {
 
@@ -45,25 +47,36 @@ public record OauthApiController(
             .userId(samUser.getSubjectId())
             .clientIP(request.getRemoteAddr());
 
+    Optional<LinkInfo> linkInfo = Optional.empty();
     try {
-      if (providerName.equals(Provider.RAS)) {
-        var linkedAccountWithPassportAndVisas =
-            passportProviderService.createLink(
-                providerName.toString(),
-                samUser.getSubjectId(),
-                oauthcode,
-                state,
-                auditLogEventBuilder);
-        return ResponseEntity.of(
-            linkedAccountWithPassportAndVisas.map(
-                x -> OpenApiConverters.Output.convert(x.getLinkedAccount())));
-      } else {
-        throw new BadRequestException("Invalid providerName");
+      switch (providerName) {
+        case RAS -> {
+          var linkedAccountWithPassportAndVisas =
+              passportProviderService.createLink(
+                  providerName.toString(),
+                  samUser.getSubjectId(),
+                  oauthcode,
+                  state,
+                  auditLogEventBuilder);
+          linkInfo = linkedAccountWithPassportAndVisas.map(
+              x -> OpenApiConverters.Output.convert(x.getLinkedAccount()));
+        }
+        case GITHUB -> {
+          var linkedAccount =
+              tokenProviderService.createLink(
+                  providerName.toString(),
+                  samUser.getSubjectId(),
+                  oauthcode,
+                  state,
+                  auditLogEventBuilder);
+          linkInfo = linkedAccount.map(Output::convert);
+        }
       }
-    } catch (Exception e) {
-      auditLogger.logEvent(
-          auditLogEventBuilder.auditLogEventType(AuditLogEventType.LinkCreationFailed).build());
-      throw e;
+      return ResponseEntity.of(linkInfo);
+    } catch(Exception e) {
+        auditLogger.logEvent(
+            auditLogEventBuilder.auditLogEventType(AuditLogEventType.LinkCreationFailed).build());
+        throw e;
     }
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -1,0 +1,82 @@
+package bio.terra.externalcreds.services;
+
+import bio.terra.common.exception.BadRequestException;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.models.LinkedAccount;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class TokenProviderService extends ProviderService {
+
+  public TokenProviderService(
+      ExternalCredsConfig externalCredsConfig,
+      ProviderClientCache providerClientCache,
+      OAuth2Service oAuth2Service,
+      LinkedAccountService linkedAccountService,
+      AuditLogger auditLogger,
+      ObjectMapper objectMapper) {
+    super(
+        externalCredsConfig,
+        providerClientCache,
+        oAuth2Service,
+        linkedAccountService,
+        auditLogger,
+        objectMapper);
+  }
+
+  public Optional<LinkedAccount> createLink(
+      String providerName,
+      String userId,
+      String authorizationCode,
+      String encodedState,
+      AuditLogEvent.Builder auditLogEventBuilder) {
+
+    var oAuth2State = validateOAuth2State(providerName, userId, encodedState);
+
+    Optional<LinkedAccount> linkedAccount =
+        providerClientCache
+            .getProviderClient(providerName)
+            .map(
+                providerClient -> {
+                  var providerInfo = externalCredsConfig.getProviders().get(providerName);
+                  try {
+                    var account =
+                        createLinkedAccount(
+                                providerName,
+                                userId,
+                                authorizationCode,
+                                oAuth2State.getRedirectUri(),
+                                new HashSet<>(providerInfo.getScopes()),
+                                encodedState,
+                                providerClient)
+                            .getLeft();
+                    return linkedAccountService.upsertLinkedAccount(account);
+                  } catch (OAuth2AuthorizationException oauthEx) {
+                    throw new BadRequestException(oauthEx);
+                  }
+                });
+    logLinkCreation(linkedAccount, auditLogEventBuilder);
+    return linkedAccount;
+  }
+
+  private void logLinkCreation(
+      Optional<LinkedAccount> linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+    auditLogger.logEvent(
+        auditLogEventBuilder
+            .externalUserId(linkedAccount.map(LinkedAccount::getExternalUserId))
+            .auditLogEventType(
+                linkedAccount
+                    .map(x -> AuditLogEventType.LinkCreated)
+                    .orElse(AuditLogEventType.LinkCreationFailed))
+            .build());
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -68,7 +68,7 @@ public class TokenProviderService extends ProviderService {
     return linkedAccount;
   }
 
-  private void logLinkCreation(
+  public void logLinkCreation(
       Optional<LinkedAccount> linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
     auditLogger.logEvent(
         auditLogEventBuilder

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -107,7 +107,7 @@ class OauthApiControllerTest extends BaseTest {
 
     @Test
     void testCreatesTokenProviderLinkSuccessfully() throws Exception {
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount();
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.GITHUB.toString());
 
       var state = UUID.randomUUID().toString();
       var oauthcode = UUID.randomUUID().toString();

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -156,7 +156,7 @@ class OauthApiControllerTest extends BaseTest {
 
       // check that an internal server error code is returned
       mvc.perform(
-              post("/api/oidc/v1/{provider}/oauthcode", providerName)
+              post("/api/oauth/v1/{provider}/oauthcode", providerName)
                   .header("authorization", "Bearer " + accessToken)
                   .param("scopes", "foo")
                   .param("redirectUri", "redirectUri")

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -113,11 +113,11 @@ class OauthApiControllerTest extends BaseTest {
       var oauthcode = UUID.randomUUID().toString();
 
       when(tokenProviderServiceMock.createLink(
-          eq(inputLinkedAccount.getProviderName()),
-          eq(inputLinkedAccount.getUserId()),
-          eq(oauthcode),
-          eq(state),
-          any(AuditLogEvent.Builder.class)))
+              eq(inputLinkedAccount.getProviderName()),
+              eq(inputLinkedAccount.getUserId()),
+              eq(oauthcode),
+              eq(state),
+              any(AuditLogEvent.Builder.class)))
           .thenReturn(Optional.of(inputLinkedAccount));
       testCreatesLinkSuccessfully(inputLinkedAccount, state, oauthcode);
     }
@@ -134,11 +134,11 @@ class OauthApiControllerTest extends BaseTest {
               .passport(TestUtils.createRandomPassport())
               .build();
       when(passportProviderServiceMock.createLink(
-          eq(inputLinkedAccount.getProviderName()),
-          eq(inputLinkedAccount.getUserId()),
-          eq(oauthcode),
-          eq(state),
-          any(AuditLogEvent.Builder.class)))
+              eq(inputLinkedAccount.getProviderName()),
+              eq(inputLinkedAccount.getUserId()),
+              eq(oauthcode),
+              eq(state),
+              any(AuditLogEvent.Builder.class)))
           .thenReturn(Optional.of(linkedAccountWithPassportAndVisas));
 
       testCreatesLinkSuccessfully(inputLinkedAccount, state, oauthcode);
@@ -176,7 +176,8 @@ class OauthApiControllerTest extends BaseTest {
     }
   }
 
-  private void testCreatesLinkSuccessfully(LinkedAccount inputLinkedAccount, String state, String oauthcode) throws Exception {
+  private void testCreatesLinkSuccessfully(
+      LinkedAccount inputLinkedAccount, String state, String oauthcode) throws Exception {
     var accessToken = "testToken";
     mockSamUser(inputLinkedAccount.getUserId(), accessToken);
     mvc.perform(

--- a/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
@@ -1,0 +1,58 @@
+package bio.terra.externalcreds.services;
+
+import static org.mockito.Mockito.verify;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent.Builder;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.models.LinkedAccount;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+public class TokenProviderServiceTest extends BaseTest {
+
+  @Autowired private TokenProviderService tokenProviderService;
+  @MockBean private AuditLogger auditLoggerMock;
+  private final String providerName = Provider.GITHUB.toString();
+  private final String userId = UUID.randomUUID().toString();
+  private final String clientIP = "127.0.0.1";
+  private final AuditLogEvent.Builder auditLogEventBuilder =
+      new Builder().providerName(providerName).userId(userId).clientIP(clientIP);
+
+  @Test
+  void testLogLinkCreateSuccess() {
+    Optional<LinkedAccount> linkedAccount =
+        Optional.ofNullable(TestUtils.createRandomLinkedAccount(providerName));
+    tokenProviderService.logLinkCreation(linkedAccount, auditLogEventBuilder);
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.LinkCreated)
+                .providerName(providerName)
+                .userId(userId)
+                .externalUserId(linkedAccount.map(LinkedAccount::getExternalUserId))
+                .clientIP(clientIP)
+                .build());
+  }
+
+  @Test
+  void testLogLinkCreateFailure() {
+    tokenProviderService.logLinkCreation(Optional.empty(), auditLogEventBuilder);
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.LinkCreationFailed)
+                .providerName(providerName)
+                .userId(userId)
+                .externalUserId(Optional.empty())
+                .clientIP(clientIP)
+                .build());
+  }
+}


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1050

**What:**
Add a new POST `/api/oauth/v1/{provider}/oauthcode` endpoint (supporting both Github and RAS) and deprecate the existing `/api/oidc/v1/{provider}/oauthcode` endpoint

**Why:**
After a user authorizes Github via the Terra UI, Terra will call this endpoint in ECM to exchange the oauth code for a refresh token and store a record for this user's linked account. 

**How:**
When the POST endpoint is called with Github as the provider, call `tokenProviderService.createLink` to exchange the oauthcode for a refresh token, get info about the user from github (this gets the externalUserId), and store an entry in the linked account table.

**Testing:**
1. Run ECM locally and authenticate as a Terra dev user
2. Call `/api/oauth/v1/github/authorization-url` with the callback url "https://bvdp-saturn-dev.appspot.com/oauth_callback"
3. Navigate to the url returned by that endpoint and authorize the Terra github app
4. When you get redirected to Terra, note the "code" and "state" query parameters from the url
5. Call the POST `/api/oauth/v1/github/oauthcode` endpoint with this state and code (this should return a success code and you can confirm by looking at your local ECM database 🎉) 
6. Call the DELETE `/api/oidc/v1/github` endpoint (can also confirm by looking at your local ECM database) - this endpoint required no changes!