### PR TITLE
ID-1131 ECM Code Cleanup

### DIFF
--- a/.run/ExternalCredsApplication.run.xml
+++ b/.run/ExternalCredsApplication.run.xml
@@ -1,11 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ExternalCredsApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <module name="externalcreds.service.main" />
-    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.externalcreds.ExternalCredsWebApplication" />
-    <option name="HIDE_BANNER" value="true" />
     <option name="ACTIVE_PROFILES" value="human-readable-logging" />
-    <option name="ALTERNATIVE_JRE_PATH" />
-    <option name="SHORTEN_COMMAND_LINE" value="NONE" />
     <additionalParameters>
       <param>
         <option name="enabled" value="true" />
@@ -15,7 +10,21 @@
     </additionalParameters>
     <envs>
       <env name="GOOGLE_APPLICATION_CREDENTIALS" value="service/src/main/resources/rendered/ecm-sa.json" />
+      <env name="ECM_LOG_APPENDER" value="Console-Standard" />
     </envs>
+    <option name="HIDE_BANNER" value="true" />
+    <module name="externalcreds.service.main" />
+    <option name="SPRING_BOOT_MAIN_CLASS" value="bio.terra.externalcreds.ExternalCredsWebApplication" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="false" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
+      </ENTRIES>
+    </extension>
     <method v="2">
       <option name="Make" enabled="true" />
     </method>

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -4,6 +4,48 @@ info:
   description: A manager for external credentials
   version: 0.0.1
 paths:
+  /api/oauth/v1/providers:
+    get:
+      summary: Lists the available OIDC providers.
+      tags: [ oauth ]
+      operationId: listProviders
+      responses:
+        '200':
+          description: A JSON array of providers
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/oauth/v1/{provider}:
+    parameters:
+      - $ref: '#/components/parameters/providerParam'
+    get:
+      summary: Returns info about the linked account for the provider.
+      tags: [ oauth ]
+      operationId: getLink
+      responses:
+        '200':
+          $ref: '#/components/responses/LinkInfoResponse'
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+    delete:
+      summary: Delete the account link for the provider, if an account has been linked.
+      tags: [ oauth ]
+      operationId: deleteLink
+      description: Requires an authenticated user.
+      responses:
+        '204':
+          description: Deletes the refresh token and revokes it with the provider.
+        '404':
+          $ref: '#/components/responses/LinkNotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
   /api/oauth/v1/{provider}/authorization-url:
     parameters:
       - $ref: '#/components/parameters/providerParam'
@@ -46,7 +88,7 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
-  /api/oidc/v1/{provider}/access-token:
+  /api/oauth/v1/{provider}/access-token:
     parameters:
       - $ref: '#/components/parameters/providerParam'
     get:
@@ -73,6 +115,7 @@ paths:
       summary: Lists the available OIDC providers.
       tags: [ oidc ]
       operationId: listProviders
+      deprecated: true
       responses:
         '200':
           description: A JSON array of providers
@@ -92,6 +135,7 @@ paths:
       summary: Returns info about the linked account for the provider.
       tags: [ oidc ]
       operationId: getLink
+      deprecated: true
       responses:
         '200':
           $ref: '#/components/responses/LinkInfoResponse'
@@ -104,6 +148,7 @@ paths:
       tags: [ oidc ]
       operationId: deleteLink
       description: Requires an authenticated user.
+      deprecated: true
       responses:
         '204':
           description: Deletes the refresh token and revokes it with the provider.

--- a/integration/src/main/java/scripts/testscripts/GetProviderPassport.java
+++ b/integration/src/main/java/scripts/testscripts/GetProviderPassport.java
@@ -14,7 +14,7 @@ import scripts.utils.ClientTestUtils;
 
 @Slf4j
 public class GetProviderPassport extends TestScript {
-  private String provider;
+  private PassportProvider provider;
   private OidcApi oidcApi;
 
   @Override
@@ -22,8 +22,7 @@ public class GetProviderPassport extends TestScript {
     // TODO: do we want to loop through this list in case we want multiple test users in the future?
     var apiClient = ClientTestUtils.getClientWithTestUserAuth(testUsers.get(0), server);
     oidcApi = new OidcApi(apiClient);
-    provider = oidcApi.listProviders().get(0);
-    if (provider == null) throw new Exception("No provider found.");
+    provider = PassportProvider.RAS;
   }
 
   @Override
@@ -32,8 +31,7 @@ public class GetProviderPassport extends TestScript {
 
     // TODO: update GetProviderPassport.json in perf to run 120 tests per second
     // check the response code
-    var passportResponse =
-        oidcApi.getProviderPassportWithHttpInfo(PassportProvider.fromValue(provider));
+    var passportResponse = oidcApi.getProviderPassportWithHttpInfo(provider);
     var httpCode = passportResponse.getStatusCode();
 
     assertEquals(HttpStatus.OK, httpCode);

--- a/integration/src/main/java/scripts/testscripts/ListProviders.java
+++ b/integration/src/main/java/scripts/testscripts/ListProviders.java
@@ -4,8 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import bio.terra.externalcreds.api.OidcApi;
+import bio.terra.externalcreds.model.Provider;
 import bio.terra.testrunner.runner.TestScript;
 import bio.terra.testrunner.runner.config.TestUserSpecification;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import scripts.utils.ClientTestUtils;
@@ -28,5 +32,9 @@ public class ListProviders extends TestScript {
 
     // check the response body
     assertNotNull(providersResponse.getBody());
+    var expected =
+        Arrays.stream(Provider.values()).map(Provider::toString).collect(Collectors.toSet());
+    var actual = new HashSet<>(providersResponse.getBody());
+    assertEquals(expected, actual);
   }
 }

--- a/integration/src/main/resources/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/resources/datageneration/regenerate_perf_data.sql
@@ -12,7 +12,7 @@ LANGUAGE SQL
 AS $$
   -- Insert a linked account with the given values
   INSERT INTO linked_account
-  (id, user_id, provider_name, refresh_token, expires, external_user_id, is_authenticated)
+  (id, user_id, provider, refresh_token, expires, external_user_id, is_authenticated)
   VALUES (
     nextval('linked_account_id_seq'),
     user_id,

--- a/integration/src/main/resources/datageneration/regenerate_perf_data.sql
+++ b/integration/src/main/resources/datageneration/regenerate_perf_data.sql
@@ -16,7 +16,7 @@ AS $$
   VALUES (
     nextval('linked_account_id_seq'),
     user_id,
-    'ras',
+    'RAS'::provider,
     'testToken',
     current_timestamp + interval '3000 year',
     external_user_id,

--- a/service/src/main/java/bio/terra/externalcreds/ExternalCredsSpringConfig.java
+++ b/service/src/main/java/bio/terra/externalcreds/ExternalCredsSpringConfig.java
@@ -5,6 +5,7 @@ import bio.terra.externalcreds.models.StringToSshKeyPairTypeConverter;
 import javax.sql.DataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,6 +15,7 @@ import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 /** Spring configuration class for loading application config and code defined beans. */
@@ -46,5 +48,10 @@ public class ExternalCredsSpringConfig implements WebMvcConfigurer {
   @Override
   public void addFormatters(FormatterRegistry registry) {
     registry.addConverter(new StringToSshKeyPairTypeConverter());
+  }
+
+  @Bean
+  public RestTemplate restTemplate(RestTemplateBuilder builder) {
+    return builder.build();
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
+++ b/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.auditLogging;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -15,7 +16,12 @@ public interface AuditLogEvent extends WithAuditLogEvent {
   Optional<String> getClientIP();
 
   @JsonInclude(Include.NON_EMPTY)
-  Optional<String> getProviderName();
+  @Value.Derived
+  default Optional<String> getProviderName() {
+    return Optional.of(provider().toString());
+  }
+
+  Optional<Provider> provider();
 
   @JsonInclude(Include.NON_EMPTY)
   Optional<String> getExternalUserId();

--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.config;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import jakarta.annotation.Nullable;
 import java.net.URI;
 import java.time.Duration;
@@ -12,7 +13,7 @@ import org.immutables.value.Value;
 @Value.Modifiable
 @PropertiesInterfaceStyle
 public interface ExternalCredsConfigInterface {
-  Map<String, ProviderProperties> getProviders();
+  Map<Provider, ProviderProperties> getProviders();
 
   // Nullable to make the generated class play nicely with spring: spring likes to call the getter
   // before the setter and without Nullable the immutables generated code errors because the field

--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.config;
 
+import bio.terra.common.exception.NotFoundException;
 import bio.terra.externalcreds.generated.model.Provider;
 import jakarta.annotation.Nullable;
 import java.net.URI;
@@ -13,7 +14,16 @@ import org.immutables.value.Value;
 @Value.Modifiable
 @PropertiesInterfaceStyle
 public interface ExternalCredsConfigInterface {
+
   Map<Provider, ProviderProperties> getProviders();
+
+  @Value.Derived
+  default ProviderProperties getProviderProperties(Provider provider) {
+    if (!getProviders().containsKey(provider)) {
+      throw new NotFoundException("Provider not found: " + provider);
+    }
+    return getProviders().get(provider);
+  }
 
   // Nullable to make the generated class play nicely with spring: spring likes to call the getter
   // before the setter and without Nullable the immutables generated code errors because the field

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -3,14 +3,12 @@ package bio.terra.externalcreds.controllers;
 import bio.terra.externalcreds.auditLogging.AuditLogEvent;
 import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
-import bio.terra.externalcreds.controllers.OpenApiConverters.Output;
 import bio.terra.externalcreds.generated.api.OauthApi;
 import bio.terra.externalcreds.generated.model.LinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.services.*;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.Optional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -32,7 +30,7 @@ public record OauthApiController(
     var authorizationUrl =
         providerService.getProviderAuthorizationUrl(samUser.getSubjectId(), provider, redirectUri);
 
-    return ResponseEntity.of(authorizationUrl);
+    return ResponseEntity.ok(authorizationUrl);
   }
 
   @Override
@@ -61,25 +59,24 @@ public record OauthApiController(
             .userId(samUser.getSubjectId())
             .clientIP(request.getRemoteAddr());
 
-    Optional<LinkInfo> linkInfo = Optional.empty();
     try {
-      switch (provider) {
-        case RAS -> {
-          var linkedAccountWithPassportAndVisas =
-              passportProviderService.createLink(
-                  provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
-          linkInfo =
-              linkedAccountWithPassportAndVisas.map(
-                  x -> OpenApiConverters.Output.convert(x.getLinkedAccount()));
-        }
-        case GITHUB -> {
-          var linkedAccount =
-              tokenProviderService.createLink(
-                  provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
-          linkInfo = linkedAccount.map(Output::convert);
-        }
-      }
-      return ResponseEntity.of(linkInfo);
+      LinkInfo linkInfo =
+          switch (provider) {
+            case RAS -> {
+              var linkedAccountWithPassportAndVisas =
+                  passportProviderService.createLink(
+                      provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
+              yield OpenApiConverters.Output.convert(
+                  linkedAccountWithPassportAndVisas.getLinkedAccount());
+            }
+            case GITHUB -> {
+              var linkedAccount =
+                  tokenProviderService.createLink(
+                      provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
+              yield OpenApiConverters.Output.convert(linkedAccount);
+            }
+          };
+      return ResponseEntity.ok(linkInfo);
     } catch (Exception e) {
       auditLogger.logEvent(
           auditLogEventBuilder.auditLogEventType(AuditLogEventType.LinkCreationFailed).build());

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -114,7 +114,7 @@ public record OidcApiController(
   @Override
   public ResponseEntity<String> getProviderPassport(PassportProvider passportProvider) {
     var samUser = samUserFactory.from(request);
-    var provider = Provider.fromValue(passportProvider.toString());
+    var provider = Provider.valueOf(passportProvider.name());
     var maybeLinkedAccount =
         linkedAccountService.getLinkedAccount(samUser.getSubjectId(), provider);
     var maybePassport = passportService.getPassport(samUser.getSubjectId(), provider);

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -63,7 +63,7 @@ public record OidcApiController(
     var authorizationUrl =
         providerService.getProviderAuthorizationUrl(samUser.getSubjectId(), provider, redirectUri);
 
-    return ResponseEntity.of(authorizationUrl.map(this::jsonString));
+    return ResponseEntity.ok(jsonString(authorizationUrl));
   }
 
   @Override
@@ -81,9 +81,8 @@ public record OidcApiController(
         var linkedAccountWithPassportAndVisas =
             passportProviderService.createLink(
                 provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
-        return ResponseEntity.of(
-            linkedAccountWithPassportAndVisas.map(
-                x -> OpenApiConverters.Output.convert(x.getLinkedAccount())));
+        return ResponseEntity.ok(
+            OpenApiConverters.Output.convert(linkedAccountWithPassportAndVisas.getLinkedAccount()));
       } else {
         throw new BadRequestException("Invalid providerName");
       }

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAO.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.dataAccess;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
 import java.sql.ResultSet;
@@ -60,9 +61,9 @@ public class GA4GHPassportDAO {
   }
 
   @WithSpan
-  public Optional<GA4GHPassport> getPassport(String userId, String providerName) {
+  public Optional<GA4GHPassport> getPassport(String userId, Provider provider) {
     var namedParameters =
-        new MapSqlParameterSource("userId", userId).addValue("providerName", providerName);
+        new MapSqlParameterSource("userId", userId).addValue("providerName", provider.toString());
     var query =
         "SELECT p.* FROM ga4gh_passport p"
             + " INNER JOIN linked_account la ON la.id = p.linked_account_id"

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHPassportDAO.java
@@ -63,12 +63,14 @@ public class GA4GHPassportDAO {
   @WithSpan
   public Optional<GA4GHPassport> getPassport(String userId, Provider provider) {
     var namedParameters =
-        new MapSqlParameterSource("userId", userId).addValue("providerName", provider.toString());
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("provider", provider.name());
     var query =
         "SELECT p.* FROM ga4gh_passport p"
             + " INNER JOIN linked_account la ON la.id = p.linked_account_id"
             + " WHERE la.user_id = :userId"
-            + " AND la.provider_name = :providerName";
+            + " AND la.provider = :provider::provider_enum";
     return Optional.ofNullable(
         DataAccessUtils.singleResult(
             jdbcTemplate.query(query, namedParameters, new GA4GHPassportRowMapper())));

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.dataAccess;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import bio.terra.externalcreds.models.VisaVerificationDetails;
@@ -57,9 +58,9 @@ public class GA4GHVisaDAO {
   }
 
   @WithSpan
-  public List<GA4GHVisa> listVisas(String userId, String providerName) {
+  public List<GA4GHVisa> listVisas(String userId, Provider provider) {
     var namedParameters =
-        new MapSqlParameterSource("userId", userId).addValue("providerName", providerName);
+        new MapSqlParameterSource("userId", userId).addValue("providerName", provider.toString());
     var query =
         "SELECT v.* FROM ga4gh_visa v"
             + " INNER JOIN ga4gh_passport p ON p.id = v.passport_id"
@@ -121,7 +122,7 @@ public class GA4GHVisaDAO {
     public VisaVerificationDetails mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new VisaVerificationDetails.Builder()
           .linkedAccountId(rs.getInt("linked_account_id"))
-          .providerName(rs.getString("provider_name"))
+          .provider(Provider.fromValue(rs.getString("provider_name")))
           .visaJwt(rs.getString("jwt"))
           .visaId(rs.getInt("visa_id"))
           .build();

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
@@ -60,13 +60,15 @@ public class GA4GHVisaDAO {
   @WithSpan
   public List<GA4GHVisa> listVisas(String userId, Provider provider) {
     var namedParameters =
-        new MapSqlParameterSource("userId", userId).addValue("providerName", provider.toString());
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("provider", provider.name());
     var query =
         "SELECT v.* FROM ga4gh_visa v"
             + " INNER JOIN ga4gh_passport p ON p.id = v.passport_id"
             + " INNER JOIN linked_account la ON la.id = p.linked_account_id"
             + " WHERE la.user_id = :userId"
-            + " AND la.provider_name = :providerName";
+            + " AND la.provider = :provider::provider_enum";
     return jdbcTemplate.query(query, namedParameters, new GA4GHVisaRowMapper());
   }
 
@@ -77,7 +79,7 @@ public class GA4GHVisaDAO {
             .addValue("validationCutoff", validationCutoff);
 
     var query =
-        "SELECT DISTINCT la.id as linked_account_id, la.provider_name as provider_name, v.jwt as jwt, v.id as visa_id FROM linked_account la"
+        "SELECT DISTINCT la.id as linked_account_id, la.provider as provider, v.jwt as jwt, v.id as visa_id FROM linked_account la"
             + " JOIN ga4gh_passport p"
             + " ON p.linked_account_id = la.id"
             + " JOIN ga4gh_visa v"
@@ -122,7 +124,7 @@ public class GA4GHVisaDAO {
     public VisaVerificationDetails mapRow(ResultSet rs, int rowNum) throws SQLException {
       return new VisaVerificationDetails.Builder()
           .linkedAccountId(rs.getInt("linked_account_id"))
-          .provider(Provider.fromValue(rs.getString("provider_name")))
+          .provider(Provider.valueOf(rs.getString("provider")))
           .visaJwt(rs.getString("jwt"))
           .visaId(rs.getInt("visa_id"))
           .build();

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAO.java
@@ -27,7 +27,7 @@ public class OAuth2StateDAO {
     var namedParameters =
         new MapSqlParameterSource()
             .addValue("userId", userId)
-            .addValue("providerName", oAuth2State.getProvider())
+            .addValue("providerName", oAuth2State.getProvider().toString())
             .addValue("random", oAuth2State.getRandom());
 
     jdbcTemplate.update(query, namedParameters);
@@ -42,7 +42,7 @@ public class OAuth2StateDAO {
     var namedParameters =
         new MapSqlParameterSource()
             .addValue("userId", userId)
-            .addValue("providerName", oAuth2State.getProvider())
+            .addValue("providerName", oAuth2State.getProvider().toString())
             .addValue("random", oAuth2State.getRandom());
 
     return jdbcTemplate.update(query, namedParameters) > 0;

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAO.java
@@ -19,15 +19,15 @@ public class OAuth2StateDAO {
   @WithSpan
   public OAuth2State upsertOidcState(String userId, OAuth2State oAuth2State) {
     var query =
-        "INSERT INTO oauth2_state (user_id, provider_name, random)"
-            + " VALUES (:userId, :providerName, :random)"
-            + " ON CONFLICT (user_id, provider_name) DO UPDATE SET"
+        "INSERT INTO oauth2_state (user_id, provider, random)"
+            + " VALUES (:userId, :provider::provider_enum, :random)"
+            + " ON CONFLICT (user_id, provider) DO UPDATE SET"
             + " random = excluded.random";
 
     var namedParameters =
         new MapSqlParameterSource()
             .addValue("userId", userId)
-            .addValue("providerName", oAuth2State.getProvider().toString())
+            .addValue("provider", oAuth2State.getProvider().name())
             .addValue("random", oAuth2State.getRandom());
 
     jdbcTemplate.update(query, namedParameters);
@@ -38,11 +38,11 @@ public class OAuth2StateDAO {
   @WithSpan
   public boolean deleteOidcStateIfExists(String userId, OAuth2State oAuth2State) {
     var query =
-        "DELETE FROM oauth2_state WHERE user_id = :userId and provider_name = :providerName and random = :random";
+        "DELETE FROM oauth2_state WHERE user_id = :userId and provider = :provider::provider_enum and random = :random";
     var namedParameters =
         new MapSqlParameterSource()
             .addValue("userId", userId)
-            .addValue("providerName", oAuth2State.getProvider().toString())
+            .addValue("provider", oAuth2State.getProvider().name())
             .addValue("random", oAuth2State.getRandom());
 
     return jdbcTemplate.update(query, namedParameters) > 0;

--- a/service/src/main/java/bio/terra/externalcreds/models/AuthorizationChangeEvent.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/AuthorizationChangeEvent.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.models;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
@@ -8,7 +9,12 @@ import org.immutables.value.Value;
 public interface AuthorizationChangeEvent extends WithAuthorizationChangeEvent {
   String getUserId();
 
-  String getProviderName();
+  @Value.Derived
+  default String getProviderName() {
+    return provider().toString();
+  }
+
+  Provider provider();
 
   class Builder extends ImmutableAuthorizationChangeEvent.Builder {}
 }

--- a/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.models;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import java.sql.Timestamp;
 import java.util.Optional;
 import org.immutables.value.Value;
@@ -10,7 +11,7 @@ public interface LinkedAccount extends WithLinkedAccount {
 
   String getUserId();
 
-  String getProviderName();
+  Provider getProvider();
 
   String getRefreshToken();
 

--- a/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
@@ -1,6 +1,7 @@
 package bio.terra.externalcreds.models;
 
 import bio.terra.externalcreds.ExternalCredsException;
+import bio.terra.externalcreds.generated.model.Provider;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -12,7 +13,7 @@ import org.immutables.value.Value;
 @Value.Immutable
 @JsonDeserialize(as = ImmutableOAuth2State.class)
 public interface OAuth2State extends WithOAuth2State {
-  String getProvider();
+  Provider getProvider();
 
   String getRandom();
 

--- a/service/src/main/java/bio/terra/externalcreds/models/VisaVerificationDetails.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/VisaVerificationDetails.java
@@ -1,12 +1,13 @@
 package bio.terra.externalcreds.models;
 
+import bio.terra.externalcreds.generated.model.Provider;
 import org.immutables.value.Value;
 
 @Value.Immutable
 public interface VisaVerificationDetails {
   Integer getLinkedAccountId();
 
-  String getProviderName();
+  Provider getProvider();
 
   String getVisaJwt();
 

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -8,6 +8,7 @@ import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.GA4GHPassportDAO;
 import bio.terra.externalcreds.dataAccess.GA4GHVisaDAO;
 import bio.terra.externalcreds.dataAccess.LinkedAccountDAO;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.PassportWithVisas;
@@ -57,8 +58,8 @@ public class PassportService {
   }
 
   @ReadTransaction
-  public Optional<GA4GHPassport> getPassport(String userId, String providerName) {
-    return passportDAO.getPassport(userId, providerName);
+  public Optional<GA4GHPassport> getPassport(String userId, Provider provider) {
+    return passportDAO.getPassport(userId, provider);
   }
 
   @ReadTransaction

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
@@ -1,9 +1,7 @@
 package bio.terra.externalcreds.services;
 
 import bio.terra.externalcreds.config.ExternalCredsConfig;
-import bio.terra.externalcreds.config.ProviderProperties;
 import bio.terra.externalcreds.generated.model.Provider;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
@@ -32,20 +30,12 @@ public class ProviderOAuthClientCache {
   }
 
   @Cacheable(cacheNames = "providerOAuthClients", sync = true)
-  public Optional<ClientRegistration> getProviderClient(Provider provider) {
+  public ClientRegistration getProviderClient(Provider provider) {
     log.info("Loading ProviderOAuthClient {}", provider);
-    return Optional.ofNullable(externalCredsConfig.getProviders().get(provider))
-        .map(p -> buildClientRegistration(provider, p));
-  }
-
-  @Scheduled(fixedRateString = "6", timeUnit = TimeUnit.HOURS)
-  @CacheEvict(allEntries = true, cacheNames = "providerOAuthClients")
-  public void resetCache() {
-    log.info("ProviderOAuthClientCache reset");
-  }
-
-  public ClientRegistration buildClientRegistration(
-      Provider provider, ProviderProperties providerInfo) {
+    var providerInfo = externalCredsConfig.getProviderProperties(provider);
+    if (providerInfo == null) {
+      throw new IllegalArgumentException("Provider not found: " + provider);
+    }
     ClientRegistration.Builder builder =
         switch (provider) {
           case RAS -> ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
@@ -75,5 +65,11 @@ public class ProviderOAuthClientCache {
     providerInfo.getJwksUri().ifPresent(builder::jwkSetUri);
 
     return builder.build();
+  }
+
+  @Scheduled(fixedRateString = "6", timeUnit = TimeUnit.HOURS)
+  @CacheEvict(allEntries = true, cacheNames = "providerOAuthClients")
+  public void resetCache() {
+    log.info("ProviderOAuthClientCache reset");
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
@@ -32,10 +32,10 @@ public class ProviderOAuthClientCache {
   }
 
   @Cacheable(cacheNames = "providerOAuthClients", sync = true)
-  public Optional<ClientRegistration> getProviderClient(String providerName) {
-    log.info("Loading ProviderOAuthClient {}", providerName);
-    return Optional.ofNullable(externalCredsConfig.getProviders().get(providerName))
-        .map(p -> buildClientRegistration(providerName, p));
+  public Optional<ClientRegistration> getProviderClient(Provider provider) {
+    log.info("Loading ProviderOAuthClient {}", provider);
+    return Optional.ofNullable(externalCredsConfig.getProviders().get(provider))
+        .map(p -> buildClientRegistration(provider, p));
   }
 
   @Scheduled(fixedRateString = "6", timeUnit = TimeUnit.HOURS)
@@ -45,8 +45,7 @@ public class ProviderOAuthClientCache {
   }
 
   public ClientRegistration buildClientRegistration(
-      String providerName, ProviderProperties providerInfo) {
-    Provider provider = Provider.fromValue(providerName);
+      Provider provider, ProviderProperties providerInfo) {
     ClientRegistration.Builder builder =
         switch (provider) {
           case RAS -> ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
@@ -59,7 +58,7 @@ public class ProviderOAuthClientCache {
                     .map(Pattern::toString)
                     .toList()
                     .get(0);
-            yield ClientRegistration.withRegistrationId(providerName)
+            yield ClientRegistration.withRegistrationId(provider.toString())
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                 .clientId(providerInfo.getClientId())
                 .clientSecret(providerInfo.getClientSecret())

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -203,10 +203,6 @@ public class ProviderService {
   public LinkedAccount deleteLink(String userId, Provider provider) {
     var providerInfo = externalCredsConfig.getProviderProperties(provider);
 
-    if (providerInfo == null) {
-      throw new NotFoundException(String.format("Provider %s not found", provider));
-    }
-
     var linkedAccount =
         linkedAccountService
             .getLinkedAccount(userId, provider)

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -8,6 +8,7 @@ import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.config.ProviderProperties;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.CannotDecodeOAuth2State;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
@@ -20,10 +21,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.http.HttpStatusCode;
@@ -79,16 +80,18 @@ public class ProviderService {
   }
 
   public Set<String> getProviderList() {
-    return Collections.unmodifiableSet(externalCredsConfig.getProviders().keySet());
+    return externalCredsConfig.getProviders().keySet().stream()
+        .map(Provider::toString)
+        .collect(Collectors.toSet());
   }
 
   public Optional<String> getProviderAuthorizationUrl(
-      String userId, String providerName, String redirectUri) {
+      String userId, Provider provider, String redirectUri) {
     return providerOAuthClientCache
-        .getProviderClient(providerName)
+        .getProviderClient(provider)
         .map(
             providerClient -> {
-              var providerInfo = externalCredsConfig.getProviders().get(providerName);
+              var providerInfo = externalCredsConfig.getProviders().get(provider);
 
               validateRedirectUri(redirectUri, providerInfo);
 
@@ -97,7 +100,7 @@ public class ProviderService {
               // a random value is generated and stored here then validated in createLink below
               var oAuth2State =
                   new OAuth2State.Builder()
-                      .provider(providerName)
+                      .provider(provider)
                       .random(OAuth2State.generateRandomState(secureRandom))
                       .redirectUri(redirectUri)
                       .build();
@@ -119,10 +122,10 @@ public class ProviderService {
     }
   }
 
-  public OAuth2State validateOAuth2State(String providerName, String userId, String encodedState) {
+  public OAuth2State validateOAuth2State(Provider provider, String userId, String encodedState) {
     try {
       OAuth2State oAuth2State = OAuth2State.decode(objectMapper, encodedState);
-      if (!providerName.equals(oAuth2State.getProvider())) {
+      if (!provider.equals(oAuth2State.getProvider())) {
         throw new InvalidOAuth2State();
       }
       linkedAccountService.validateAndDeleteOAuth2State(userId, oAuth2State);
@@ -133,14 +136,14 @@ public class ProviderService {
   }
 
   protected ImmutablePair<LinkedAccount, OAuth2User> createLinkedAccount(
-      String providerName,
+      Provider provider,
       String userId,
       String authorizationCode,
       String redirectUri,
       Set<String> scopes,
       String state,
       ClientRegistration providerClient) {
-    var providerInfo = externalCredsConfig.getProviders().get(providerName);
+    var providerInfo = externalCredsConfig.getProviders().get(provider);
 
     var tokenResponse =
         oAuth2Service.authorizationCodeExchange(
@@ -166,11 +169,11 @@ public class ProviderService {
       throw new ExternalCredsException(
           String.format(
               "user info from provider %s did not contain external id claim %s",
-              providerName, providerInfo.getExternalIdClaim()));
+              provider, providerInfo.getExternalIdClaim()));
     }
     LinkedAccount linkedAccount =
         new LinkedAccount.Builder()
-            .providerName(providerName)
+            .provider(provider)
             .userId(userId)
             .expires(expires)
             .externalUserId(externalUserId)
@@ -203,21 +206,21 @@ public class ProviderService {
     return errorCode;
   }
 
-  public LinkedAccount deleteLink(String userId, String providerName) {
-    var providerInfo = externalCredsConfig.getProviders().get(providerName);
+  public LinkedAccount deleteLink(String userId, Provider provider) {
+    var providerInfo = externalCredsConfig.getProviders().get(provider);
 
     if (providerInfo == null) {
-      throw new NotFoundException(String.format("Provider %s not found", providerName));
+      throw new NotFoundException(String.format("Provider %s not found", provider));
     }
 
     var linkedAccount =
         linkedAccountService
-            .getLinkedAccount(userId, providerName)
+            .getLinkedAccount(userId, provider)
             .orElseThrow(() -> new NotFoundException("Link not found for user"));
 
     revokeAccessToken(providerInfo, linkedAccount);
 
-    linkedAccountService.deleteLinkedAccount(userId, providerName);
+    linkedAccountService.deleteLinkedAccount(userId, provider);
 
     return linkedAccount;
   }
@@ -226,7 +229,7 @@ public class ProviderService {
     auditLogger.logEvent(
         new AuditLogEvent.Builder()
             .auditLogEventType(AuditLogEventType.LinkExpired)
-            .providerName(linkedAccount.getProviderName())
+            .provider(linkedAccount.getProvider())
             .userId(linkedAccount.getUserId())
             .externalUserId(linkedAccount.getExternalUserId())
             .build());
@@ -264,7 +267,7 @@ public class ProviderService {
     log.info(
         "Token revocation request for user [{}], provider [{}] returned with the result: [{}]",
         linkedAccount.getUserId(),
-        linkedAccount.getProviderName(),
+        linkedAccount.getProvider().toString(),
         responseBody);
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderTokenClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderTokenClientCache.java
@@ -33,10 +33,10 @@ public class ProviderTokenClientCache {
   }
 
   @Cacheable(cacheNames = "providerTokenClients", sync = true)
-  public Optional<ClientRegistration> getProviderClient(String providerName) {
-    log.info("Loading ProviderTokenClient {}", providerName);
-    return Optional.ofNullable(externalCredsConfig.getProviders().get(providerName))
-        .map(p -> buildClientRegistration(providerName, p));
+  public Optional<ClientRegistration> getProviderClient(Provider provider) {
+    log.info("Loading ProviderTokenClient {}", provider);
+    return Optional.ofNullable(externalCredsConfig.getProviders().get(provider))
+        .map(p -> buildClientRegistration(provider, p));
   }
 
   @Scheduled(fixedRateString = "6", timeUnit = TimeUnit.HOURS)
@@ -46,8 +46,7 @@ public class ProviderTokenClientCache {
   }
 
   public ClientRegistration buildClientRegistration(
-      String providerName, ProviderProperties providerInfo) {
-    Provider provider = Provider.fromValue(providerName);
+      Provider provider, ProviderProperties providerInfo) {
     ClientRegistration.Builder builder =
         switch (provider) {
           case RAS -> ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
@@ -60,7 +59,7 @@ public class ProviderTokenClientCache {
                     .map(Pattern::toString)
                     .toList()
                     .get(0);
-            yield ClientRegistration.withRegistrationId(providerName)
+            yield ClientRegistration.withRegistrationId(provider.toString())
                 .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .clientId(providerInfo.getClientId())
                 .clientSecret(providerInfo.getClientSecret())

--- a/service/src/main/resources/db/changelog/changesets/20240304_provider_name_to_provider.yaml
+++ b/service/src/main/resources/db/changelog/changesets/20240304_provider_name_to_provider.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: "20240304_provider_name_to_provider"
+      author: tlangs
+      changes:
+        - sql:
+            sql: >
+              CREATE TYPE provider_enum AS ENUM ('GITHUB', 'RAS');
+              
+              update linked_account set provider_name = 'GITHUB' where provider_name = 'github';
+              update linked_account set provider_name = 'RAS' where provider_name = 'ras';
+              delete from linked_account where provider_name not in ('GITHUB', 'RAS');
+              alter table linked_account rename column provider_name to provider;
+              alter table linked_account alter column provider type provider_enum using provider::provider_enum;
+              
+              update oauth2_state set provider_name = 'GITHUB' where provider_name = 'github';
+              update oauth2_state set provider_name = 'RAS' where provider_name = 'ras';
+              delete from oauth2_state where provider_name not in ('GITHUB', 'RAS');
+              alter table oauth2_state rename column provider_name to provider;
+              alter table oauth2_state alter column provider type provider_enum using provider::provider_enum;
+

--- a/service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -29,3 +29,7 @@ databaseChangeLog:
   - include:
       file: changesets/20220412_add_last_encrypt_timestamp_to_ssh_key_pair_table.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20240304_provider_name_to_provider.yaml
+      relativeToChangelogFile: true
+

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -23,13 +23,17 @@ public class TestUtils {
   }
 
   public static LinkedAccount createRandomLinkedAccount() {
-    return createRandomLinkedAccount(Provider.RAS.toString());
+    return createRandomLinkedAccount(Provider.GITHUB);
   }
 
-  public static LinkedAccount createRandomLinkedAccount(String providerName) {
+  public static LinkedAccount createRandomPassportLinkedAccount() {
+    return createRandomLinkedAccount(Provider.RAS);
+  }
+
+  public static LinkedAccount createRandomLinkedAccount(Provider provider) {
     return new LinkedAccount.Builder()
         .expires(getRandomTimestamp())
-        .providerName(providerName)
+        .provider(provider)
         .refreshToken(UUID.randomUUID().toString())
         .userId(UUID.randomUUID().toString())
         .externalUserId(UUID.randomUUID().toString())
@@ -79,7 +83,7 @@ public class TestUtils {
     return new VisaVerificationDetails.Builder()
         .visaId(21)
         .linkedAccountId(42)
-        .providerName(UUID.randomUUID().toString())
+        .provider(Provider.RAS)
         .visaJwt(UUID.randomUUID().toString())
         .build();
   }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
@@ -108,7 +109,7 @@ class OauthApiControllerTest extends BaseTest {
       mockSamUser(userId, accessToken);
 
       when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
-          .thenReturn(Optional.of(result));
+          .thenReturn(result);
 
       var queryParams = new LinkedMultiValueMap<String, String>();
       queryParams.add("redirectUri", redirectUri);
@@ -120,7 +121,7 @@ class OauthApiControllerTest extends BaseTest {
     }
 
     @Test
-    void testGetAuthUrl404() throws Exception {
+    void testGetAuthUrlBadRequest() throws Exception {
       var userId = "fakeUser";
       var accessToken = "fakeAccessToken";
       var redirectUri = "fakeuri";
@@ -128,7 +129,7 @@ class OauthApiControllerTest extends BaseTest {
       mockSamUser(userId, accessToken);
 
       when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
-          .thenReturn(Optional.empty());
+          .thenThrow(new BadRequestException("Invalid redirectUri"));
 
       var queryParams = new LinkedMultiValueMap<String, String>();
       queryParams.add("redirectUri", redirectUri);
@@ -136,7 +137,7 @@ class OauthApiControllerTest extends BaseTest {
               get("/api/oauth/v1/{provider}/authorization-url", provider)
                   .header("authorization", "Bearer " + accessToken)
                   .queryParams(queryParams))
-          .andExpect(status().isNotFound());
+          .andExpect(status().isBadRequest());
     }
   }
 
@@ -156,7 +157,7 @@ class OauthApiControllerTest extends BaseTest {
               eq(oauthcode),
               eq(state),
               any(AuditLogEvent.Builder.class)))
-          .thenReturn(Optional.of(inputLinkedAccount));
+          .thenReturn(inputLinkedAccount);
       testCreatesLinkSuccessfully(inputLinkedAccount, state, oauthcode);
     }
 
@@ -177,7 +178,7 @@ class OauthApiControllerTest extends BaseTest {
               eq(oauthcode),
               eq(state),
               any(AuditLogEvent.Builder.class)))
-          .thenReturn(Optional.of(linkedAccountWithPassportAndVisas));
+          .thenReturn(linkedAccountWithPassportAndVisas);
 
       testCreatesLinkSuccessfully(inputLinkedAccount, state, oauthcode);
     }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -64,7 +64,7 @@ class OidcApiControllerTest extends BaseTest {
   @MockBean private SamUserFactory samUserFactoryMock;
   @MockBean private PassportService passportServiceMock;
   @MockBean private AuditLogger auditLoggerMock;
-  private String providerName = Provider.RAS.toString();
+  private Provider provider = Provider.RAS;
 
   @Test
   void testListProviders() throws Exception {
@@ -88,13 +88,13 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.getProviderAuthorizationUrl(userId, providerName, redirectUri))
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
           .thenReturn(Optional.of(result));
 
       var queryParams = new LinkedMultiValueMap<String, String>();
       queryParams.add("redirectUri", redirectUri);
       mvc.perform(
-              get("/api/oidc/v1/{provider}/authorization-url", providerName)
+              get("/api/oidc/v1/{provider}/authorization-url", provider)
                   .header("authorization", "Bearer " + accessToken)
                   .queryParams(queryParams))
           .andExpect(content().json("\"" + result + "\""));
@@ -108,13 +108,13 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.getProviderAuthorizationUrl(userId, providerName, redirectUri))
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
           .thenReturn(Optional.empty());
 
       var queryParams = new LinkedMultiValueMap<String, String>();
       queryParams.add("redirectUri", redirectUri);
       mvc.perform(
-              get("/api/oidc/v1/{provider}/authorization-url", providerName)
+              get("/api/oidc/v1/{provider}/authorization-url", provider)
                   .header("authorization", "Bearer " + accessToken)
                   .queryParams(queryParams))
           .andExpect(status().isNotFound());
@@ -132,11 +132,11 @@ class OidcApiControllerTest extends BaseTest {
       mockSamUser(inputLinkedAccount.getUserId(), accessToken);
 
       when(linkedAccountServiceMock.getLinkedAccount(
-              inputLinkedAccount.getUserId(), inputLinkedAccount.getProviderName()))
+              inputLinkedAccount.getUserId(), inputLinkedAccount.getProvider()))
           .thenReturn(Optional.of(inputLinkedAccount));
 
       mvc.perform(
-              get("/api/oidc/v1/" + inputLinkedAccount.getProviderName())
+              get("/api/oidc/v1/" + inputLinkedAccount.getProvider().toString())
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(
               content()
@@ -146,14 +146,14 @@ class OidcApiControllerTest extends BaseTest {
     }
 
     @Test
-    void testGetLinkCaseInsensitive() throws Exception {
+    void testEnforcesCaseSensitivity() throws Exception {
       var accessToken = "testToken";
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount();
+      var inputLinkedAccount = TestUtils.createRandomPassportLinkedAccount();
 
       mockSamUser(inputLinkedAccount.getUserId(), accessToken);
 
       when(linkedAccountServiceMock.getLinkedAccount(
-              inputLinkedAccount.getUserId(), inputLinkedAccount.getProviderName()))
+              inputLinkedAccount.getUserId(), inputLinkedAccount.getProvider()))
           .thenReturn(Optional.of(inputLinkedAccount));
 
       mvc.perform(get("/api/oidc/v1/" + "RaS").header("authorization", "Bearer " + accessToken))
@@ -171,8 +171,7 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      mvc.perform(
-              get("/api/oidc/v1/" + providerName).header("authorization", "Bearer " + accessToken))
+      mvc.perform(get("/api/oidc/v1/" + provider).header("authorization", "Bearer " + accessToken))
           .andExpect(status().isNotFound());
     }
   }
@@ -183,7 +182,7 @@ class OidcApiControllerTest extends BaseTest {
     @Test
     void testCreatesLinkSuccessfully() throws Exception {
       var accessToken = "testToken";
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount();
+      var inputLinkedAccount = TestUtils.createRandomPassportLinkedAccount();
 
       var state = UUID.randomUUID().toString();
       var oauthcode = UUID.randomUUID().toString();
@@ -196,7 +195,7 @@ class OidcApiControllerTest extends BaseTest {
               .passport(TestUtils.createRandomPassport())
               .build();
       when(passportProviderServiceMock.createLink(
-              eq(inputLinkedAccount.getProviderName()),
+              eq(inputLinkedAccount.getProvider()),
               eq(inputLinkedAccount.getUserId()),
               eq(oauthcode),
               eq(state),
@@ -204,7 +203,7 @@ class OidcApiControllerTest extends BaseTest {
           .thenReturn(Optional.of(linkedAccountWithPassportAndVisas));
 
       mvc.perform(
-              post("/api/oidc/v1/{provider}/oauthcode", inputLinkedAccount.getProviderName())
+              post("/api/oidc/v1/{provider}/oauthcode", inputLinkedAccount.getProvider().toString())
                   .header("authorization", "Bearer " + accessToken)
                   .param("state", state)
                   .param("oauthcode", oauthcode))
@@ -228,7 +227,7 @@ class OidcApiControllerTest extends BaseTest {
 
       // check that an internal server error code is returned
       mvc.perform(
-              post("/api/oidc/v1/{provider}/oauthcode", providerName)
+              post("/api/oidc/v1/{provider}/oauthcode", provider)
                   .header("authorization", "Bearer " + accessToken)
                   .param("scopes", "foo")
                   .param("redirectUri", "redirectUri")
@@ -241,7 +240,7 @@ class OidcApiControllerTest extends BaseTest {
           .logEvent(
               new AuditLogEvent.Builder()
                   .auditLogEventType(AuditLogEventType.LinkCreationFailed)
-                  .providerName(providerName)
+                  .provider(provider)
                   .userId(userId)
                   .clientIP("127.0.0.1")
                   .build());
@@ -258,10 +257,10 @@ class OidcApiControllerTest extends BaseTest {
       var externalId = UUID.randomUUID().toString();
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.deleteLink(userId, providerName))
+      when(providerServiceMock.deleteLink(userId, provider))
           .thenReturn(
               new Builder()
-                  .providerName(providerName)
+                  .provider(provider)
                   .userId(userId)
                   .externalUserId(externalId)
                   .expires(new Timestamp(0))
@@ -270,18 +269,18 @@ class OidcApiControllerTest extends BaseTest {
                   .build());
 
       mvc.perform(
-              delete("/api/oidc/v1/{provider}", providerName)
+              delete("/api/oidc/v1/{provider}", provider)
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(status().isOk());
 
-      verify(providerServiceMock).deleteLink(userId, providerName);
+      verify(providerServiceMock).deleteLink(userId, provider);
 
       // check that a log was recorded
       verify(auditLoggerMock)
           .logEvent(
               new AuditLogEvent.Builder()
                   .auditLogEventType(AuditLogEventType.LinkDeleted)
-                  .providerName(providerName)
+                  .provider(provider)
                   .userId(userId)
                   .clientIP("127.0.0.1")
                   .externalUserId(externalId)
@@ -296,10 +295,10 @@ class OidcApiControllerTest extends BaseTest {
 
       doThrow(new NotFoundException("not found"))
           .when(providerServiceMock)
-          .deleteLink(userId, providerName);
+          .deleteLink(userId, provider);
 
       mvc.perform(
-              delete("/api/oidc/v1/{provider}", providerName)
+              delete("/api/oidc/v1/{provider}", provider)
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(status().isNotFound());
     }
@@ -319,21 +318,21 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      when(linkedAccountServiceMock.getLinkedAccount(userId, providerName))
+      when(linkedAccountServiceMock.getLinkedAccount(userId, provider))
           .thenReturn(
               Optional.of(
                   new LinkedAccount.Builder()
-                      .providerName(providerName)
+                      .provider(provider)
                       .userId(userId)
                       .externalUserId(externalUserId)
                       .refreshToken("")
                       .expires(new Timestamp(0))
                       .isAuthenticated(true)
                       .build()));
-      when(passportServiceMock.getPassport(userId, providerName)).thenReturn(Optional.of(passport));
+      when(passportServiceMock.getPassport(userId, provider)).thenReturn(Optional.of(passport));
 
       mvc.perform(
-              get("/api/oidc/v1/{provider}/passport", providerName)
+              get("/api/oidc/v1/{provider}/passport", provider)
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(status().isOk())
           .andExpect(content().string(passport.getJwt()));
@@ -343,7 +342,7 @@ class OidcApiControllerTest extends BaseTest {
           .logEvent(
               new AuditLogEvent.Builder()
                   .auditLogEventType(AuditLogEventType.GetPassport)
-                  .providerName(providerName)
+                  .provider(provider)
                   .userId(userId)
                   .clientIP("127.0.0.1")
                   .externalUserId(externalUserId)
@@ -360,10 +359,10 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      when(passportServiceMock.getPassport(userId, providerName)).thenReturn(Optional.of(passport));
+      when(passportServiceMock.getPassport(userId, provider)).thenReturn(Optional.of(passport));
 
       mvc.perform(
-              get("/api/oidc/v1/{provider}/passport", providerName)
+              get("/api/oidc/v1/{provider}/passport", provider)
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(status().isNotFound());
     }
@@ -376,7 +375,7 @@ class OidcApiControllerTest extends BaseTest {
       mockSamUser(userId, accessToken);
 
       mvc.perform(
-              get("/api/oidc/v1/{provider}/passport", providerName)
+              get("/api/oidc/v1/{provider}/passport", provider)
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(status().isNotFound());
     }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import bio.terra.externalcreds.models.VisaVerificationDetails;
 import java.sql.Timestamp;
@@ -67,7 +68,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       // create linked account with passport and one visa that was NOT validated in the validation
       // window and one that was to make sure it still returns the account info
       var savedLinkedAccountUnvalidatedVisa2 =
-          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomPassportLinkedAccount());
       var savedPassportUnvalidatedVisa2 =
           passportDAO.insertPassport(
               TestUtils.createRandomPassport()
@@ -87,7 +88,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       var passportWithUnvalidatedVisaDetails =
           new VisaVerificationDetails.Builder()
               .linkedAccountId(savedLinkedAccountUnvalidatedVisa.getId().get())
-              .providerName(savedLinkedAccountUnvalidatedVisa.getProviderName())
+              .provider(savedLinkedAccountUnvalidatedVisa.getProvider())
               .visaJwt(savedUnvalidatedVisa.getJwt())
               .visaId(savedUnvalidatedVisa.getId().get())
               .build();
@@ -95,7 +96,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       var passportWithUnvalidatedVisaDetails2 =
           new VisaVerificationDetails.Builder()
               .linkedAccountId(savedLinkedAccountUnvalidatedVisa2.getId().get())
-              .providerName(savedLinkedAccountUnvalidatedVisa2.getProviderName())
+              .provider(savedLinkedAccountUnvalidatedVisa2.getProvider())
               .visaJwt(savedUnvalidatedVisa2.getJwt())
               .visaId(savedUnvalidatedVisa2.getId().get())
               .build();
@@ -141,7 +142,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       var passportWithUnvalidatedVisaDetails =
           new VisaVerificationDetails.Builder()
               .linkedAccountId(savedLinkedAccountUnvalidatedVisa.getId().get())
-              .providerName(savedLinkedAccountUnvalidatedVisa.getProviderName())
+              .provider(savedLinkedAccountUnvalidatedVisa.getProvider())
               .visaJwt(savedUnvalidatedVisa.getJwt())
               .visaId(savedUnvalidatedVisa.getId().get())
               .build();
@@ -155,7 +156,7 @@ class GA4GHVisaDAOTest extends BaseTest {
   @Test
   void testInsertAndListVisa() {
     var savedLinkedAccount =
-        linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+        linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomPassportLinkedAccount());
     var savedPassport =
         passportDAO.insertPassport(
             TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId()));
@@ -173,7 +174,7 @@ class GA4GHVisaDAOTest extends BaseTest {
     assertEquals(expectedVisa2, savedVisa2.withId(Optional.empty()));
 
     var loadedVisas =
-        visaDAO.listVisas(savedLinkedAccount.getUserId(), savedLinkedAccount.getProviderName());
+        visaDAO.listVisas(savedLinkedAccount.getUserId(), savedLinkedAccount.getProvider());
     assertEquals(2, loadedVisas.size());
     assertEquals(Set.of(savedVisa1, savedVisa2), Set.copyOf(loadedVisas));
   }
@@ -186,7 +187,7 @@ class GA4GHVisaDAOTest extends BaseTest {
 
   @Test
   void testListNoVisas() {
-    var loadedVisas = visaDAO.listVisas("foo", "bar");
+    var loadedVisas = visaDAO.listVisas("foo", Provider.RAS);
     assertEquals(Collections.emptyList(), loadedVisas);
   }
 
@@ -203,8 +204,7 @@ class GA4GHVisaDAOTest extends BaseTest {
     Timestamp expectedLastValidated = new Timestamp(2363245);
     visaDAO.updateLastValidated(savedVisa.getId().get(), expectedLastValidated);
 
-    var visas =
-        visaDAO.listVisas(savedLinkedAccount.getUserId(), savedLinkedAccount.getProviderName());
+    var visas = visaDAO.listVisas(savedLinkedAccount.getUserId(), savedLinkedAccount.getProvider());
     assertEquals(1, visas.size());
     assertEquals(expectedLastValidated, visas.get(0).getLastValidated().get());
   }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/OAuth2StateDAOTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.OAuth2State;
 import java.security.SecureRandom;
 import org.junit.jupiter.api.Test;
@@ -14,7 +15,7 @@ public class OAuth2StateDAOTest extends BaseTest {
 
   @Test
   void testCreateAndDelete() {
-    var provider = "provider name";
+    var provider = Provider.RAS;
     var userId = "user";
     var redirectUri = "https://foo";
     var firstState =

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -121,13 +121,13 @@ class AuthorizationCodeExchangeTest extends BaseTest {
     var linkedAccount = createTestLinkedAccount();
     var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
     var providerClient =
-        ClientRegistration.withRegistrationId(linkedAccount.getProviderName())
+        ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
             .build();
 
     var state =
         new OAuth2State.Builder()
-            .provider(linkedAccount.getProviderName())
+            .provider(linkedAccount.getProvider())
             .random(OAuth2State.generateRandomState(new SecureRandom()))
             .redirectUri(redirectUri)
             .build();
@@ -136,8 +136,8 @@ class AuthorizationCodeExchangeTest extends BaseTest {
     String encodedState = state.encode(objectMapper);
 
     when(externalCredsConfigMock.getProviders())
-        .thenReturn(Map.of(linkedAccount.getProviderName(), providerInfo));
-    when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProviderName()))
+        .thenReturn(Map.of(linkedAccount.getProvider(), providerInfo));
+    when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(Optional.of(providerClient));
     when(oAuth2ServiceMock.authorizationCodeExchange(
             providerClient,
@@ -153,7 +153,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
             BadRequestException.class,
             () ->
                 passportProviderService.createLink(
-                    linkedAccount.getProviderName(),
+                    linkedAccount.getProvider(),
                     linkedAccount.getUserId(),
                     authorizationCode,
                     encodedState,
@@ -173,7 +173,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
       throws URISyntaxException {
     var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
     var providerClient =
-        ClientRegistration.withRegistrationId(linkedAccount.getProviderName())
+        ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
             .build();
     var accessTokenResponse =
@@ -190,13 +190,13 @@ class AuthorizationCodeExchangeTest extends BaseTest {
         new DefaultOAuth2User(null, userAttributes, providerInfo.getExternalIdClaim());
 
     when(externalCredsConfigMock.getProviders())
-        .thenReturn(Map.of(linkedAccount.getProviderName(), providerInfo));
+        .thenReturn(Map.of(linkedAccount.getProvider(), providerInfo));
     when(externalCredsConfigMock.getAllowedJwtIssuers())
         .thenReturn(List.of(new URI(jwtSigningTestUtils.getIssuer())));
     when(externalCredsConfigMock.getAllowedJwksUris())
         .thenReturn(
             List.of(new URI(jwtSigningTestUtils.getIssuer() + JwtSigningTestUtils.JKU_PATH)));
-    when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProviderName()))
+    when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(Optional.of(providerClient));
     when(oAuth2ServiceMock.authorizationCodeExchange(
             providerClient,
@@ -218,7 +218,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
     var state =
         new OAuth2State.Builder()
-            .provider(expectedLinkedAccount.getProviderName())
+            .provider(expectedLinkedAccount.getProvider())
             .random(OAuth2State.generateRandomState(new SecureRandom()))
             .redirectUri(redirectUri)
             .build();
@@ -236,12 +236,12 @@ class AuthorizationCodeExchangeTest extends BaseTest {
 
     var auditLogEventBuilder =
         new AuditLogEvent.Builder()
-            .providerName(expectedLinkedAccount.getProviderName())
+            .provider(expectedLinkedAccount.getProvider())
             .userId(expectedLinkedAccount.getUserId())
             .clientIP("127.0.0.1");
     var linkedAccountWithPassportAndVisas =
         passportProviderService.createLink(
-            expectedLinkedAccount.getProviderName(),
+            expectedLinkedAccount.getProvider(),
             expectedLinkedAccount.getUserId(),
             authorizationCode,
             encodedState,

--- a/service/src/test/java/bio/terra/externalcreds/services/LinkedAccountServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/LinkedAccountServiceTest.java
@@ -48,7 +48,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
       var savedLinkedAccount =
           linkedAccountService.getLinkedAccount(
-              linkedAccount.getUserId(), linkedAccount.getProviderName());
+              linkedAccount.getUserId(), linkedAccount.getProvider());
       assertPresent(savedLinkedAccount);
       assertEquals(linkedAccount, savedLinkedAccount.get().withId(Optional.empty()));
     }
@@ -125,7 +125,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
       var expectedEvent =
           new AuthorizationChangeEvent.Builder()
-              .providerName(linkedAccount.getProviderName())
+              .provider(linkedAccount.getProvider())
               .userId(linkedAccount.getUserId())
               .build();
 
@@ -163,7 +163,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
       var expectedEvent =
           new AuthorizationChangeEvent.Builder()
-              .providerName(linkedAccount.getProviderName())
+              .provider(linkedAccount.getProvider())
               .userId(linkedAccount.getUserId())
               .build();
 
@@ -226,7 +226,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
       var expectedEvent =
           new AuthorizationChangeEvent.Builder()
-              .providerName(linkedAccount.getProviderName())
+              .provider(linkedAccount.getProvider())
               .userId(linkedAccount.getUserId())
               .build();
 
@@ -261,7 +261,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
       var expectedEvent =
           new AuthorizationChangeEvent.Builder()
-              .providerName(linkedAccount.getProviderName())
+              .provider(linkedAccount.getProvider())
               .userId(linkedAccount.getUserId())
               .build();
 
@@ -345,13 +345,13 @@ public class LinkedAccountServiceTest extends BaseTest {
       var linkedAccount = TestUtils.createRandomLinkedAccount();
       assertFalse(
           linkedAccountService.deleteLinkedAccount(
-              linkedAccount.getUserId(), linkedAccount.getProviderName()));
+              linkedAccount.getUserId(), linkedAccount.getProvider()));
 
       Mockito.verify(eventPublisherMock, never())
           .publishAuthorizationChangeEvent(
               new AuthorizationChangeEvent.Builder()
                   .userId(linkedAccount.getUserId())
-                  .providerName(linkedAccount.getProviderName())
+                  .provider(linkedAccount.getProvider())
                   .build());
     }
 
@@ -370,7 +370,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
       assertTrue(
           linkedAccountService.deleteLinkedAccount(
-              linkedAccount.getUserId(), linkedAccount.getProviderName()));
+              linkedAccount.getUserId(), linkedAccount.getProvider()));
 
       assertEmpty(linkedAccountService.getLinkedAccount(savedLinkedAccount1.getId().get()));
 
@@ -379,7 +379,7 @@ public class LinkedAccountServiceTest extends BaseTest {
           .publishAuthorizationChangeEvent(
               new AuthorizationChangeEvent.Builder()
                   .userId(linkedAccount.getUserId())
-                  .providerName(linkedAccount.getProviderName())
+                  .provider(linkedAccount.getProvider())
                   .build());
     }
 
@@ -397,13 +397,13 @@ public class LinkedAccountServiceTest extends BaseTest {
           visaDAO);
 
       linkedAccountService.deleteLinkedAccount(
-          linkedAccount.getUserId(), linkedAccount.getProviderName());
+          linkedAccount.getUserId(), linkedAccount.getProvider());
 
       verify(eventPublisherMock, never())
           .publishAuthorizationChangeEvent(
               new AuthorizationChangeEvent.Builder()
                   .userId(linkedAccount.getUserId())
-                  .providerName(linkedAccount.getProviderName())
+                  .provider(linkedAccount.getProvider())
                   .build());
     }
   }
@@ -428,7 +428,7 @@ public class LinkedAccountServiceTest extends BaseTest {
 
     var savedPassport =
         passportDAO.getPassport(
-            saved.getLinkedAccount().getUserId(), saved.getLinkedAccount().getProviderName());
+            saved.getLinkedAccount().getUserId(), saved.getLinkedAccount().getProvider());
     if (passport == null) {
       assertEmpty(savedPassport);
     } else {
@@ -439,7 +439,7 @@ public class LinkedAccountServiceTest extends BaseTest {
           savedPassport.get().withId(Optional.empty()).withLinkedAccountId(Optional.empty()));
       var savedVisas =
           visaDAO.listVisas(
-              saved.getLinkedAccount().getUserId(), saved.getLinkedAccount().getProviderName());
+              saved.getLinkedAccount().getUserId(), saved.getLinkedAccount().getProvider());
       assertEquals(
           visas,
           savedVisas.stream()

--- a/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
@@ -34,11 +34,11 @@ public class OAuth2ServiceTest {
    */
   void test() {
     Provider provider = Provider.RAS;
-    var providerClient = providerOAuthClientCache.getProviderClient(provider).orElseThrow();
+    var providerClient = providerOAuthClientCache.getProviderClient(provider);
 
     var redirectUri = "http://localhost:9000/fence-callback";
     String state = null;
-    ProviderProperties providerProperties = externalCredsConfig.getProviders().get(provider);
+    ProviderProperties providerProperties = externalCredsConfig.getProviderProperties(provider);
     var scopes = new HashSet<>(providerProperties.getScopes());
     var authorizationParameters = providerProperties.getAdditionalAuthorizationParameters();
 

--- a/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
@@ -2,6 +2,7 @@ package bio.terra.externalcreds.services;
 
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.config.ProviderProperties;
+import bio.terra.externalcreds.generated.model.Provider;
 import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Scanner;
@@ -32,12 +33,12 @@ public class OAuth2ServiceTest {
    * to the identity provider.
    */
   void test() {
-    String providerName = "ras-old";
-    var providerClient = providerOAuthClientCache.getProviderClient(providerName).orElseThrow();
+    Provider provider = Provider.RAS;
+    var providerClient = providerOAuthClientCache.getProviderClient(provider).orElseThrow();
 
     var redirectUri = "http://localhost:9000/fence-callback";
     String state = null;
-    ProviderProperties providerProperties = externalCredsConfig.getProviders().get(providerName);
+    ProviderProperties providerProperties = externalCredsConfig.getProviders().get(provider);
     var scopes = new HashSet<>(providerProperties.getScopes());
     var authorizationParameters = providerProperties.getAdditionalAuthorizationParameters();
 

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -328,19 +328,12 @@ class PassportServiceTest extends BaseTest {
     }
 
     private void mockProviderConfig(LinkedAccount... linkedAccounts) throws URISyntaxException {
-      var providerInfos =
-          Arrays.stream(linkedAccounts)
-              .map(
-                  linkedAccount ->
-                      Map.of(linkedAccount.getProvider(), TestUtils.createRandomProvider()))
-              .reduce(
-                  new HashMap<>(),
-                  (a, b) -> {
-                    a.putAll(b);
-                    return a;
-                  });
+      Arrays.stream(linkedAccounts)
+          .forEach(
+              linkedAccount ->
+                  when(externalCredsConfigMock.getProviderProperties(linkedAccount.getProvider()))
+                      .thenReturn(TestUtils.createRandomProvider()));
 
-      when(externalCredsConfigMock.getProviders()).thenReturn(providerInfos);
       when(externalCredsConfigMock.getAllowedJwtIssuers())
           .thenReturn(List.of(new URI(jwtSigningTestUtils.getIssuer())));
       when(externalCredsConfigMock.getAllowedJwksUris())
@@ -355,7 +348,7 @@ class PassportServiceTest extends BaseTest {
                         .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                         .build();
                 when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-                    .thenReturn(Optional.of(providerClient));
+                    .thenReturn(providerClient);
               });
     }
 

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -11,6 +11,7 @@ import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.GA4GHPassportDAO;
 import bio.terra.externalcreds.dataAccess.LinkedAccountDAO;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.LinkedAccount;
@@ -77,7 +78,7 @@ class PassportServiceTest extends BaseTest {
           passportDAO.insertPassport(passport.withLinkedAccountId(savedLinkedAccount.getId()));
 
       var loadedPassport =
-          passportService.getPassport(linkedAccount.getUserId(), linkedAccount.getProviderName());
+          passportService.getPassport(linkedAccount.getUserId(), linkedAccount.getProvider());
 
       assertPresent(loadedPassport);
       assertEquals(passport.getJwt(), savedPassport.getJwt());
@@ -87,9 +88,9 @@ class PassportServiceTest extends BaseTest {
     @Test
     void testGetGA4GHPassportNoLinkedAccount() {
       var userId = "nonexistent_user_id";
-      var providerName = "fake_provider";
+      var provider = Provider.RAS;
 
-      assertEmpty(passportService.getPassport(userId, providerName));
+      assertEmpty(passportService.getPassport(userId, provider));
     }
 
     @Test
@@ -98,7 +99,7 @@ class PassportServiceTest extends BaseTest {
       linkedAccountDAO.upsertLinkedAccount(linkedAccount);
 
       assertEmpty(
-          passportService.getPassport(linkedAccount.getUserId(), linkedAccount.getProviderName()));
+          passportService.getPassport(linkedAccount.getUserId(), linkedAccount.getProvider()));
     }
   }
 
@@ -228,10 +229,9 @@ class PassportServiceTest extends BaseTest {
     private void runValidPassportTest(ValidPassportTestParams params) throws URISyntaxException {
       when(externalCredsConfigMock.getAllowedJwtAlgorithms()).thenReturn(List.of("RS256", "ES256"));
 
-      var linkedAccount = TestUtils.createRandomLinkedAccount(UUID.randomUUID().toString());
+      var linkedAccount = TestUtils.createRandomLinkedAccount();
       var otherLinkedAccount =
-          TestUtils.createRandomLinkedAccount(UUID.randomUUID().toString())
-              .withUserId(linkedAccount.getUserId());
+          TestUtils.createRandomPassportLinkedAccount().withUserId(linkedAccount.getUserId());
       mockProviderConfig(linkedAccount, otherLinkedAccount);
 
       var matchingPermission =
@@ -332,7 +332,7 @@ class PassportServiceTest extends BaseTest {
           Arrays.stream(linkedAccounts)
               .map(
                   linkedAccount ->
-                      Map.of(linkedAccount.getProviderName(), TestUtils.createRandomProvider()))
+                      Map.of(linkedAccount.getProvider(), TestUtils.createRandomProvider()))
               .reduce(
                   new HashMap<>(),
                   (a, b) -> {
@@ -351,11 +351,10 @@ class PassportServiceTest extends BaseTest {
           .forEach(
               linkedAccount -> {
                 var providerClient =
-                    ClientRegistration.withRegistrationId(linkedAccount.getProviderName())
+                    ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
                         .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                         .build();
-                when(providerOAuthClientCacheMock.getProviderClient(
-                        linkedAccount.getProviderName()))
+                when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProvider()))
                     .thenReturn(Optional.of(providerClient));
               });
     }

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
@@ -25,17 +25,17 @@ class ProviderOAuthClientCacheTest extends BaseTest {
         ExternalCredsConfig.create()
             .setProviders(
                 Map.of(
-                    Provider.GITHUB.toString(),
+                    Provider.GITHUB,
                     TestUtils.createRandomProvider(),
-                    Provider.RAS.toString(),
+                    Provider.RAS,
                     TestUtils.createRandomProvider()));
     providerOAuthClientCache = new ProviderOAuthClientCache(externalCredsConfig);
   }
 
   @Test
   void testGitHubBuildClientRegistration() {
-    String providerName = Provider.GITHUB.toString();
-    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(providerName);
+    Provider provider = Provider.GITHUB;
+    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(provider);
     String redirectUri =
         providerInfo.getAllowedRedirectUriPatterns().stream()
             .map(Pattern::toString)
@@ -43,7 +43,7 @@ class ProviderOAuthClientCacheTest extends BaseTest {
             .get(0);
     ClientRegistration gitHubClient =
         providerOAuthClientCache.buildClientRegistration(
-            providerName, externalCredsConfig.getProviders().get(providerName));
+            provider, externalCredsConfig.getProviders().get(provider));
 
     assertEquals(
         AuthorizationGrantType.AUTHORIZATION_CODE, gitHubClient.getAuthorizationGrantType());

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
@@ -35,15 +35,13 @@ class ProviderOAuthClientCacheTest extends BaseTest {
   @Test
   void testGitHubBuildClientRegistration() {
     Provider provider = Provider.GITHUB;
-    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(provider);
+    ProviderProperties providerInfo = externalCredsConfig.getProviderProperties(provider);
     String redirectUri =
         providerInfo.getAllowedRedirectUriPatterns().stream()
             .map(Pattern::toString)
             .toList()
             .get(0);
-    ClientRegistration gitHubClient =
-        providerOAuthClientCache.buildClientRegistration(
-            provider, externalCredsConfig.getProviders().get(provider));
+    ClientRegistration gitHubClient = providerOAuthClientCache.getProviderClient(provider);
 
     assertEquals(
         AuthorizationGrantType.AUTHORIZATION_CODE, gitHubClient.getAuthorizationGrantType());

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
@@ -35,15 +35,13 @@ class ProviderTokenClientCacheTest extends BaseTest {
   @Test
   void testGitHubBuildClientRegistration() {
     Provider provider = Provider.GITHUB;
-    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(provider);
+    ProviderProperties providerInfo = externalCredsConfig.getProviderProperties(provider);
     String redirectUri =
         providerInfo.getAllowedRedirectUriPatterns().stream()
             .map(Pattern::toString)
             .toList()
             .get(0);
-    ClientRegistration gitHubClient =
-        providerTokenClientCache.buildClientRegistration(
-            provider, externalCredsConfig.getProviders().get(provider));
+    ClientRegistration gitHubClient = providerTokenClientCache.getProviderClient(provider);
 
     assertEquals(AuthorizationGrantType.REFRESH_TOKEN, gitHubClient.getAuthorizationGrantType());
     assertEquals(providerInfo.getClientId(), gitHubClient.getClientId());

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
@@ -25,17 +25,17 @@ class ProviderTokenClientCacheTest extends BaseTest {
         ExternalCredsConfig.create()
             .setProviders(
                 Map.of(
-                    Provider.GITHUB.toString(),
+                    Provider.GITHUB,
                     TestUtils.createRandomProvider(),
-                    Provider.RAS.toString(),
+                    Provider.RAS,
                     TestUtils.createRandomProvider()));
     providerTokenClientCache = new ProviderTokenClientCache(externalCredsConfig);
   }
 
   @Test
   void testGitHubBuildClientRegistration() {
-    String providerName = Provider.GITHUB.toString();
-    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(providerName);
+    Provider provider = Provider.GITHUB;
+    ProviderProperties providerInfo = externalCredsConfig.getProviders().get(provider);
     String redirectUri =
         providerInfo.getAllowedRedirectUriPatterns().stream()
             .map(Pattern::toString)
@@ -43,7 +43,7 @@ class ProviderTokenClientCacheTest extends BaseTest {
             .get(0);
     ClientRegistration gitHubClient =
         providerTokenClientCache.buildClientRegistration(
-            providerName, externalCredsConfig.getProviders().get(providerName));
+            provider, externalCredsConfig.getProviders().get(provider));
 
     assertEquals(AuthorizationGrantType.REFRESH_TOKEN, gitHubClient.getAuthorizationGrantType());
     assertEquals(providerInfo.getClientId(), gitHubClient.getClientId());

--- a/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
@@ -75,7 +75,7 @@ public class TokenProviderServiceTest extends BaseTest {
     when(linkedAccountService.getLinkedAccount(linkedAccount.getUserId(), provider))
         .thenReturn(Optional.of(linkedAccount));
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-        .thenReturn(Optional.of(clientRegistration));
+        .thenReturn(clientRegistration);
 
     var accessToken = "tokenValue";
     var updatedRefreshToken = "newRefreshToken";
@@ -137,7 +137,7 @@ public class TokenProviderServiceTest extends BaseTest {
     when(linkedAccountService.getLinkedAccount(linkedAccount.getUserId(), provider))
         .thenReturn(Optional.of(linkedAccount));
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-        .thenReturn(Optional.of(clientRegistration));
+        .thenReturn(clientRegistration);
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
             clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
         .thenThrow(


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1131

While we were developing GitHub Account Linking in ECM, we made some decisions to defer maintenance to get the feature out the door. Now, we're going back through and making improvements!

The biggest change is migrating Providers to use an `enum` instead of being represented as a `String`. This brings type safety to provider types, simplifying the code in a lot of places.
