### PR TITLE
[ID-1118] Add provider configs to application.yml

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -74,6 +74,7 @@ Run in IntelliJ (recommended) or use the command line:
 
 ```sh
 ./render_config.sh # only when building ECM for the first time
+source ${PWD}/service/src/main/resources/rendered/secrets.env
 cd service
 ../gradlew bootRun
 ```

--- a/render_config.sh
+++ b/render_config.sh
@@ -8,13 +8,20 @@ COMMON_VAULT_PATH="secret/dsde/terra/kernel/$ENV/common"
 VAULT_COMMAND="vault read"
 
 SERVICE_OUTPUT_LOCATION="$(dirname "$0")/service/src/main/resources/rendered"
+SECRET_ENV_VARS_LOCATION="${SERVICE_OUTPUT_LOCATION}/secrets.env"
 INTEGRATION_OUTPUT_LOCATION="$(dirname "$0")/integration/src/main/resources/rendered"
 
 if ! [ -x "$(command -v vault)" ]; then
   VAULT_COMMAND="docker run --rm -e VAULT_TOKEN=$VAULT_TOKEN -e VAULT_ADDR=$VAULT_ADDR vault:1.7.3 $VAULT_COMMAND"
 fi
 
-$VAULT_COMMAND -field=providers "$ECM_VAULT_PATH/providers" >"$SERVICE_OUTPUT_LOCATION/providers.yaml"
+{
+  echo export RAS_CLIENT_ID="$($VAULT_COMMAND -field=ras_client_id "$ECM_VAULT_PATH/providers")"
+  echo export RAS_CLIENT_SECRET="$($VAULT_COMMAND -field=ras_client_secret "$ECM_VAULT_PATH/providers")"
+  echo export GITHUB_CLIENT_ID="$($VAULT_COMMAND -field=github_client_id "$ECM_VAULT_PATH/providers")"
+  echo export GITHUB_CLIENT_SECRET="$($VAULT_COMMAND -field=github_client_secret "$ECM_VAULT_PATH/providers")"
+} >> "${SECRET_ENV_VARS_LOCATION}"
+
 $VAULT_COMMAND -field=swagger-client-id "$ECM_VAULT_PATH/swagger-client-id" >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
 
 $VAULT_COMMAND -field=data -format=json "secret/dsde/firecloud/$ENV/common/firecloud-account.json" >"$INTEGRATION_OUTPUT_LOCATION/user-delegated-sa.json"

--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -6,8 +6,8 @@ import jakarta.annotation.Nullable;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -15,7 +15,7 @@ import org.immutables.value.Value;
 @PropertiesInterfaceStyle
 public interface ExternalCredsConfigInterface {
 
-  Map<Provider, ProviderProperties> getProviders();
+  EnumMap<Provider, ProviderProperties> getProviders();
 
   @Value.Derived
   default ProviderProperties getProviderProperties(Provider provider) {

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -15,6 +15,31 @@ externalcreds:
     key-id: ${KMS_KEY_ID:ecm-dev-kms-symmetric-key-for-ssh-key-encrypt-decrypt}
     key-ring-location: ${kMS_KEY_LOCATION:us-central1}
     ssh-key-pair-refresh-duration: ${KMS_KEY_REFRESH_DURATION:90d}
+  providers:
+    ras:
+      clientId: "${RAS_CLIENT_ID}"
+      clientSecret: "${RAS_CLIENT_SECRET}"
+      externalIdClaim: "preferred_username"
+      scopes: [ "openid","email","ga4gh_passport_v1","profile" ]
+      linkLifespan: "15d"
+      issuer: "https://stsstg.nih.gov"
+      revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke?token_type_hint=refresh_token&token=%s"
+      userInfoEndpoint: "${externalcreds.providers.ras.issuer}/openid/connect/v1.1/userinfo"
+      validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback"]
+    github:
+      clientId: "${GITHUB_CLIENT_ID}"
+      clientSecret: "${GITHUB_CLIENT_SECRET}"
+      externalIdClaim: "login",
+      issuer: "https://github.com"
+      linkLifespan: "15d"
+      scopes: ""
+      userNameAttributeName: "login"
+      revokeEndpoint: "https://api.github.com/installation/token"
+      userInfoEndpoint: "https://api.github.com/user"
+      authorizationEndpoint: "${externalcreds.providers.github.issuer}/login/oauth/authorize"
+      tokenEndpoint: "${externalcreds.providers.github.issuer}/login/oauth/access_token"
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}
@@ -69,7 +94,7 @@ spring:
   application.name: externalcreds
   application.version: ${externalcreds.version.gitHash:unknown}
 
-  config.import: optional:classpath:rendered/providers.yaml;classpath:rendered/version.properties;optional:classpath:rendered/allowed_jwks.yaml;optional:classpath:rendered/allowed_jwt_issuers.yaml
+  config.import: optional:classpath:rendered/version.properties;optional:classpath:rendered/allowed_jwks.yaml;optional:classpath:rendered/allowed_jwt_issuers.yaml
 
   datasource:
     hikari:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -28,7 +28,7 @@ externalcreds:
       userInfoEndpoint: "https://api.github.com/user"
       authorizationEndpoint: "${externalcreds.providers.github.issuer}/login/oauth/authorize"
       tokenEndpoint: "${externalcreds.providers.github.issuer}/login/oauth/access_token"
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
+      allowedRedirectUriPatterns: [ "${GITHUB_ALLOWED_REDIRECT_URI}:https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}
@@ -133,4 +133,4 @@ externalcreds:
       revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke?token_type_hint=refresh_token&token=%s"
       userInfoEndpoint: "${externalcreds.providers.ras.issuer}/openid/connect/v1.1/userinfo"
       validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback" ]
+      allowedRedirectUriPatterns: [ "${RAS_ALLOWED_REDIRECT_URI:https://bvdp-saturn-dev.appspot.com/ecm-callback}" ]

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -16,17 +16,6 @@ externalcreds:
     key-ring-location: ${kMS_KEY_LOCATION:us-central1}
     ssh-key-pair-refresh-duration: ${KMS_KEY_REFRESH_DURATION:90d}
   providers:
-    ras:
-      clientId: "${RAS_CLIENT_ID}"
-      clientSecret: "${RAS_CLIENT_SECRET}"
-      externalIdClaim: "preferred_username"
-      scopes: [ "openid","email","ga4gh_passport_v1","profile" ]
-      linkLifespan: "15d"
-      issuer: "https://stsstg.nih.gov"
-      revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke?token_type_hint=refresh_token&token=%s"
-      userInfoEndpoint: "${externalcreds.providers.ras.issuer}/openid/connect/v1.1/userinfo"
-      validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback"]
     github:
       clientId: "${GITHUB_CLIENT_ID}"
       clientSecret: "${GITHUB_CLIENT_SECRET}"
@@ -110,6 +99,9 @@ spring:
 
   main.banner-mode: off
 
+  profiles.include:
+    - ${DEPLOY_ENV:dev}
+
   web:
     resources:
       cache:
@@ -125,3 +117,20 @@ terra.common:
       enabled: ${CLOUD_TRACE_ENABLED:false}
   tracing:
     samplingRatio: ${SAMPLING_PROBABILITY:0}
+
+---
+#non-prod environments
+spring.config.activate.on-profile: '!prod'
+externalcreds:
+  providers:
+    ras:
+      clientId: "${RAS_CLIENT_ID}"
+      clientSecret: "${RAS_CLIENT_SECRET}"
+      externalIdClaim: "preferred_username"
+      scopes: [ "openid","email","ga4gh_passport_v1","profile" ]
+      linkLifespan: "15d"
+      issuer: "https://stsstg.nih.gov"
+      revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke?token_type_hint=refresh_token&token=%s"
+      userInfoEndpoint: "${externalcreds.providers.ras.issuer}/openid/connect/v1.1/userinfo"
+      validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback" ]

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -30,7 +30,7 @@ externalcreds:
     github:
       clientId: "${GITHUB_CLIENT_ID}"
       clientSecret: "${GITHUB_CLIENT_SECRET}"
-      externalIdClaim: "login",
+      externalIdClaim: "login"
       issuer: "https://github.com"
       linkLifespan: "15d"
       scopes: ""

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -28,7 +28,6 @@ externalcreds:
       userInfoEndpoint: "https://api.github.com/user"
       authorizationEndpoint: "${externalcreds.providers.github.issuer}/login/oauth/authorize"
       tokenEndpoint: "${externalcreds.providers.github.issuer}/login/oauth/access_token"
-      allowedRedirectUriPatterns: [ "${GITHUB_ALLOWED_REDIRECT_URI}:https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}
@@ -133,4 +132,28 @@ externalcreds:
       revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke?token_type_hint=refresh_token&token=%s"
       userInfoEndpoint: "${externalcreds.providers.ras.issuer}/openid/connect/v1.1/userinfo"
       validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
-      allowedRedirectUriPatterns: [ "${RAS_ALLOWED_REDIRECT_URI:https://bvdp-saturn-dev.appspot.com/ecm-callback}" ]
+
+---
+spring.config.activate.on-profile: 'dev'
+externalcreds:
+  providers:
+    ras:
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback" ]
+    github:
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
+---
+spring.config.activate.on-profile: 'staging'
+externalcreds:
+  providers:
+    ras:
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/ecm-callback" ]
+    github:
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/oauth_callback" ]
+---
+spring.config.activate.on-profile: 'prod'
+externalcreds:
+  providers:
+    ras:
+      allowedRedirectUriPatterns: [ "https://app.terra.bio/ecm-callback" ]
+    github:
+      allowedRedirectUriPatterns: [ "https://app.terra.bio/oauth_callback" ]

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
@@ -1,41 +1,29 @@
 package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
-import bio.terra.externalcreds.config.ProviderProperties;
 import bio.terra.externalcreds.generated.model.Provider;
-import java.util.Map;
 import java.util.regex.Pattern;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.*;
 
 class ProviderOAuthClientCacheTest extends BaseTest {
 
-  private ProviderOAuthClientCache providerOAuthClientCache;
-  private ExternalCredsConfig externalCredsConfig;
-
-  @BeforeEach
-  void setUp() {
-    externalCredsConfig =
-        ExternalCredsConfig.create()
-            .setProviders(
-                Map.of(
-                    Provider.GITHUB,
-                    TestUtils.createRandomProvider(),
-                    Provider.RAS,
-                    TestUtils.createRandomProvider()));
-    providerOAuthClientCache = new ProviderOAuthClientCache(externalCredsConfig);
-  }
+  @Autowired private ProviderOAuthClientCache providerOAuthClientCache;
+  @MockBean private ExternalCredsConfig externalCredsConfig;
 
   @Test
   void testGitHubBuildClientRegistration() {
     Provider provider = Provider.GITHUB;
-    ProviderProperties providerInfo = externalCredsConfig.getProviderProperties(provider);
+    var providerInfo = TestUtils.createRandomProvider();
+    when(externalCredsConfig.getProviderProperties(provider)).thenReturn(providerInfo);
     String redirectUri =
         providerInfo.getAllowedRedirectUriPatterns().stream()
             .map(Pattern::toString)

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
@@ -1,41 +1,29 @@
 package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
-import bio.terra.externalcreds.config.ProviderProperties;
 import bio.terra.externalcreds.generated.model.Provider;
-import java.util.Map;
 import java.util.regex.Pattern;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.*;
 
 class ProviderTokenClientCacheTest extends BaseTest {
 
-  private ProviderTokenClientCache providerTokenClientCache;
-  private ExternalCredsConfig externalCredsConfig;
-
-  @BeforeEach
-  void setUp() {
-    externalCredsConfig =
-        ExternalCredsConfig.create()
-            .setProviders(
-                Map.of(
-                    Provider.GITHUB,
-                    TestUtils.createRandomProvider(),
-                    Provider.RAS,
-                    TestUtils.createRandomProvider()));
-    providerTokenClientCache = new ProviderTokenClientCache(externalCredsConfig);
-  }
+  @Autowired private ProviderTokenClientCache providerTokenClientCache;
+  @MockBean private ExternalCredsConfig externalCredsConfig;
 
   @Test
   void testGitHubBuildClientRegistration() {
     Provider provider = Provider.GITHUB;
-    ProviderProperties providerInfo = externalCredsConfig.getProviderProperties(provider);
+    var providerInfo = TestUtils.createRandomProvider();
+    when(externalCredsConfig.getProviderProperties(provider)).thenReturn(providerInfo);
     String redirectUri =
         providerInfo.getAllowedRedirectUriPatterns().stream()
             .map(Pattern::toString)


### PR DESCRIPTION
**Jira:** https://broadworkbench.atlassian.net/browse/ID-1118

**What:**
Move non-secret provider configuration values into `application.yml`

**Why:**
It is easier to view and update the provider configs in `application.yml` vs. in vault.

**How:**
- Add keys for each provider client_id and client_secret to vault
- Add remaining provider config values to `application.yml`.
- Update `./render_config`.sh to create a `secrets.env` file to export those values (instead of writing a `providers.yaml` file)

Note: This will need to be merged after [updating terra-helmfile](https://github.com/broadinstitute/terra-helmfile/pull/5226) to add environment-specific overrides. The only values that differ between environments at the moment are the `client_id`, `client_secret` and `allowedRedirectUriPatterns` for each provider.