### PR TITLE
ID-1121 ID-1122 ID-1123 ID-1124 Fix Fence Account Linking

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
@@ -58,7 +58,8 @@ public class ProviderOAuthClientCache {
                   providerInfo.getIssuer())
               .clientId(providerInfo.getClientId())
               .clientSecret(providerInfo.getClientSecret())
-              .issuerUri(providerInfo.getIssuer());
+              .issuerUri(providerInfo.getIssuer())
+              .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS);
         };
 
     // set optional overrides

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -16,7 +16,8 @@ externalcreds:
       clientId: "${FENCE_CLIENT_ID}"
       clientSecret: "${FENCE_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid","google_credentials" ]
+      scopes: [ "openid", "user" ]
+      externalIdClaim: "username"
       issuer: "${FENCE_BASE_URL:https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/user}"
       revokeEndpoint: "${externalcreds.providers.fence.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.fence.issuer}/user"
@@ -26,7 +27,8 @@ externalcreds:
       clientId: "${DCF_FENCE_CLIENT_ID}"
       clientSecret: "${DCF_FENCE_CLIENT_SECRET}"
       linkLifespan: "15d"
-      scopes: [ "openid","google_credentials" ]
+      scopes: [ "openid", "user" ]
+      externalIdClaim: "username"
       issuer: "${DCF_FENCE_BASE_URL:https://nci-crdc-staging.datacommons.io/user}"
       revokeEndpoint: "${externalcreds.providers.dcf-fence.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.dcf-fence.issuer}/user"
@@ -36,7 +38,8 @@ externalcreds:
       clientId: "${KIDS_FIRST_CLIENT_ID}"
       clientSecret: "${KIDS_FIRST_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid","google_credentials" ]
+      scopes: [ "openid", "user" ]
+      externalIdClaim: "username"
       issuer: "${KIDS_FIRST_BASE_URL:https://gen3staging.kidsfirstdrc.org/user}"
       revokeEndpoint: "${externalcreds.providers.kids-first.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.kids-first.issuer}/user"
@@ -46,7 +49,8 @@ externalcreds:
       clientId: "${ANVIL_CLIENT_ID}"
       clientSecret: "${ANVIL_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid","google_credentials" ]
+      scopes: [ "openid", "user" ]
+      externalIdClaim: "username"
       issuer: "${ANVIL_BASE_URL:https://staging.theanvil.io/user}"
       revokeEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.anvil.issuer}/user"

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
@@ -100,7 +100,7 @@ class ProviderOAuthClientCacheTest extends BaseTest {
       ClientRegistration fenceClient = providerOAuthClientCache.getProviderClient(provider);
 
       assertEquals(
-          AuthorizationGrantType.AUTHORIZATION_CODE, fenceClient.getAuthorizationGrantType());
+          AuthorizationGrantType.CLIENT_CREDENTIALS, fenceClient.getAuthorizationGrantType());
       assertEquals(providerInfo.getClientId(), fenceClient.getClientId());
       assertEquals(providerInfo.getClientSecret(), fenceClient.getClientSecret());
     }


### PR DESCRIPTION
Jira: 
https://broadworkbench.atlassian.net/browse/ID-1121
https://broadworkbench.atlassian.net/browse/ID-1122
https://broadworkbench.atlassian.net/browse/ID-1123
https://broadworkbench.atlassian.net/browse/ID-1124

What:

A few fixes to make ECM able to communicate with Fence providers and retrieve refresh tokens. There were just a few tweaks that needed to be made, but ECM is now able to communicate with Fence providers without involving Bond at all!
  
