### PR TITLE
ID-1156 Add repo Scope to GitHub Token Requests

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
@@ -24,7 +24,9 @@ public interface ProviderPropertiesInterface {
 
   Collection<Pattern> getAllowedRedirectUriPatterns();
 
-  Collection<String> getScopes();
+  Collection<String> getAuthorizationScopes();
+
+  Collection<String> getTokenScopes();
 
   String getExternalIdClaim();
 

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
@@ -104,7 +104,7 @@ public class FenceProviderService extends ProviderService {
                   userId,
                   authorizationCode,
                   oAuth2State.getRedirectUri(),
-                  new HashSet<>(providerInfo.getScopes()),
+                  new HashSet<>(providerInfo.getAuthorizationScopes()),
                   encodedState,
                   providerClient)
               .getLeft();

--- a/service/src/main/java/bio/terra/externalcreds/services/OAuth2Service.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/OAuth2Service.java
@@ -1,5 +1,6 @@
 package bio.terra.externalcreds.services;
 
+import jakarta.annotation.Nullable;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Set;
@@ -108,16 +109,24 @@ public class OAuth2Service {
     return tokenResponseClient.getTokenResponse(codeGrantRequest);
   }
 
+  public OAuth2AccessTokenResponse authorizeWithRefreshToken(
+      ClientRegistration providerClient, OAuth2RefreshToken refreshToken) {
+    return authorizeWithRefreshToken(providerClient, refreshToken, null);
+  }
+
   /**
    * Given a refresh token, get an access token
    *
    * @param providerClient identity provider client, see {@link ProviderOAuthClientCache}
    * @param refreshToken
+   * @param scopes scopes requested for the refresh token
    * @return token response containing access and refresh tokens, note that if there is a refresh
    *     token in this response it should replace the original refresh token which is likely invalid
    */
   public OAuth2AccessTokenResponse authorizeWithRefreshToken(
-      ClientRegistration providerClient, OAuth2RefreshToken refreshToken) {
+      ClientRegistration providerClient,
+      OAuth2RefreshToken refreshToken,
+      @Nullable Set<String> scopes) {
     // the OAuth2RefreshTokenGrantRequest requires an access token to be specified but
     // it does not have to be a valid one so create a dummy
     var dummyAccessToken =
@@ -125,7 +134,7 @@ public class OAuth2Service {
             OAuth2AccessToken.TokenType.BEARER, "dummy", Instant.EPOCH, Instant.now());
 
     var refreshTokenGrantRequest =
-        new OAuth2RefreshTokenGrantRequest(providerClient, dummyAccessToken, refreshToken);
+        new OAuth2RefreshTokenGrantRequest(providerClient, dummyAccessToken, refreshToken, scopes);
 
     var refreshTokenTokenResponseClient = new DefaultRefreshTokenTokenResponseClient();
 

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
@@ -70,7 +70,7 @@ public class PassportProviderService extends ProviderService {
               userId,
               authorizationCode,
               oAuth2State.getRedirectUri(),
-              new HashSet<>(providerInfo.getScopes()),
+              new HashSet<>(providerInfo.getAuthorizationScopes()),
               encodedState,
               providerClient);
       var linkedAccountWithPassportAndVisas =

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -106,7 +106,7 @@ public class ProviderService {
     return oAuth2Service.getAuthorizationRequestUri(
         providerClient,
         redirectUri,
-        new HashSet<>(providerInfo.getScopes()),
+        new HashSet<>(providerInfo.getAuthorizationScopes()),
         oAuth2State.encode(objectMapper),
         providerInfo.getAdditionalAuthorizationParameters());
   }

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -59,7 +59,7 @@ public class TokenProviderService extends ProviderService {
                   userId,
                   authorizationCode,
                   oAuth2State.getRedirectUri(),
-                  new HashSet<>(providerInfo.getScopes()),
+                  new HashSet<>(providerInfo.getAuthorizationScopes()),
                   encodedState,
                   providerClient)
               .getLeft();
@@ -114,11 +114,14 @@ public class TokenProviderService extends ProviderService {
 
     // get client registration from provider client cache
     var clientRegistration = providerTokenClientCache.getProviderClient(provider);
+    var providerInfo = externalCredsConfig.getProviderProperties(provider);
 
     // exchange refresh token for access token
     var accessTokenResponse =
         oAuth2Service.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            new HashSet<>(providerInfo.getTokenScopes()));
 
     // save the linked account with the new refresh token to replace the old one
     var refreshToken = accessTokenResponse.getRefreshToken();

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -6,7 +6,8 @@ externalcreds:
       externalIdClaim: "login"
       issuer: "https://github.com"
       linkLifespan: "15d"
-      scopes: ""
+      authorizationScopes: []
+      tokenScopes: [ "repo" ]
       userNameAttributeName: "login"
       revokeEndpoint: "https://api.github.com/installation/token"
       userInfoEndpoint: "https://api.github.com/user"
@@ -16,7 +17,8 @@ externalcreds:
       clientId: "${FENCE_CLIENT_ID}"
       clientSecret: "${FENCE_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid","google_credentials" ]
+      authorizationScopes: [ "openid","google_credentials" ]
+      tokenScopes: [ ]
       issuer: "${FENCE_BASE_URL:https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/user}"
       revokeEndpoint: "${externalcreds.providers.fence.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.fence.issuer}/user"
@@ -26,7 +28,8 @@ externalcreds:
       clientId: "${DCF_FENCE_CLIENT_ID}"
       clientSecret: "${DCF_FENCE_CLIENT_SECRET}"
       linkLifespan: "15d"
-      scopes: [ "openid","google_credentials" ]
+      authorizationScopes: [ "openid","google_credentials" ]
+      tokenScopes: [ ]
       issuer: "${DCF_FENCE_BASE_URL:https://nci-crdc-staging.datacommons.io/user}"
       revokeEndpoint: "${externalcreds.providers.dcf-fence.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.dcf-fence.issuer}/user"
@@ -36,7 +39,8 @@ externalcreds:
       clientId: "${KIDS_FIRST_CLIENT_ID}"
       clientSecret: "${KIDS_FIRST_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid","google_credentials" ]
+      authorizationScopes: [ "openid","google_credentials" ]
+      tokenScopes: [ ]
       issuer: "${KIDS_FIRST_BASE_URL:https://gen3staging.kidsfirstdrc.org/user}"
       revokeEndpoint: "${externalcreds.providers.kids-first.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.kids-first.issuer}/user"
@@ -46,7 +50,8 @@ externalcreds:
       clientId: "${ANVIL_CLIENT_ID}"
       clientSecret: "${ANVIL_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid","google_credentials" ]
+      authorizationScopes: [ "openid","google_credentials" ]
+      tokenScopes: [ ]
       issuer: "${ANVIL_BASE_URL:https://staging.theanvil.io/user}"
       revokeEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/revoke"
       userInfoEndpoint: "${externalcreds.providers.anvil.issuer}/user"
@@ -62,7 +67,8 @@ externalcreds:
       clientId: "${RAS_CLIENT_ID}"
       clientSecret: "${RAS_CLIENT_SECRET}"
       externalIdClaim: "preferred_username"
-      scopes: [ "openid","email","ga4gh_passport_v1","profile" ]
+      authorizationScopes: [ "openid","email","ga4gh_passport_v1","profile" ]
+      tokenScopes: [ ]
       linkLifespan: "15d"
       issuer: "https://stsstg.nih.gov"
       revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke?token_type_hint=refresh_token&token=%s"

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -122,7 +122,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   @Test
   void testInvalidAuthorizationCode() {
     var linkedAccount = createTestLinkedAccount();
-    var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
+    var providerInfo = TestUtils.createRandomProvider().setAuthorizationScopes(scopes);
     var providerClient =
         ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
@@ -169,7 +169,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   @Test
   void testNoRefreshTokenReturned() {
     var linkedAccount = createTestLinkedAccount();
-    var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
+    var providerInfo = TestUtils.createRandomProvider().setAuthorizationScopes(scopes);
     var providerClient =
         ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
@@ -214,7 +214,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
   @Test
   void testNoExternalUserIdReturned() {
     var linkedAccount = createTestLinkedAccount();
-    var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
+    var providerInfo = TestUtils.createRandomProvider().setAuthorizationScopes(scopes);
     var providerClient =
         ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
@@ -269,7 +269,7 @@ class AuthorizationCodeExchangeTest extends BaseTest {
       Set<String> scopes,
       String state)
       throws URISyntaxException {
-    var providerInfo = TestUtils.createRandomProvider().setScopes(scopes);
+    var providerInfo = TestUtils.createRandomProvider().setAuthorizationScopes(scopes);
     var providerClient =
         ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
             .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)

--- a/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
@@ -39,7 +39,7 @@ public class OAuth2ServiceTest {
     var redirectUri = "http://localhost:9000/fence-callback";
     String state = null;
     ProviderProperties providerProperties = externalCredsConfig.getProviderProperties(provider);
-    var scopes = new HashSet<>(providerProperties.getScopes());
+    var scopes = new HashSet<>(providerProperties.getAuthorizationScopes());
     var authorizationParameters = providerProperties.getAdditionalAuthorizationParameters();
 
     // 1) test getAuthorizationRequestUri

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -706,7 +706,7 @@ public class ProviderServiceTest extends BaseTest {
       var providerProperties =
           ProviderProperties.create()
               .setAllowedRedirectUriPatterns(List.of(Pattern.compile(redirectUri)))
-              .setScopes(scopes);
+              .setAuthorizationScopes(scopes);
 
       when(externalCredsConfigMock.getProviderProperties(linkedAccount.getProvider()))
           .thenReturn(providerProperties);
@@ -878,7 +878,7 @@ public class ProviderServiceTest extends BaseTest {
       var providerProperties =
           ProviderProperties.create()
               .setAllowedRedirectUriPatterns(List.of(Pattern.compile(uriPattern)))
-              .setScopes(scopes);
+              .setAuthorizationScopes(scopes);
 
       when(externalCredsConfigMock.getProviderProperties(linkedAccount.getProvider()))
           .thenReturn(providerProperties);

--- a/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
@@ -15,6 +15,7 @@ import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,6 +34,7 @@ public class TokenProviderServiceTest extends BaseTest {
   @MockBean private OAuth2Service oAuth2ServiceMock;
 
   private final Provider provider = Provider.GITHUB;
+  private final Set<String> tokenScopes = Set.of("repo");
   private final String userId = UUID.randomUUID().toString();
   private final String clientIP = "127.0.0.1";
   private final AuditLogEvent.Builder auditLogEventBuilder =
@@ -86,7 +88,9 @@ public class TokenProviderServiceTest extends BaseTest {
             .tokenType(OAuth2AccessToken.TokenType.BEARER)
             .build();
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            tokenScopes))
         .thenReturn(oAuth2TokenResponse);
     var updatedLinkedAccount =
         linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
@@ -129,7 +133,9 @@ public class TokenProviderServiceTest extends BaseTest {
             .tokenType(OAuth2AccessToken.TokenType.BEARER)
             .build();
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            Set.of()))
         .thenReturn(oAuth2TokenResponse);
     var updatedLinkedAccount =
         linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
@@ -183,7 +189,9 @@ public class TokenProviderServiceTest extends BaseTest {
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(clientRegistration);
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            tokenScopes))
         .thenThrow(
             new OAuth2AuthorizationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN)));
 


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1156

  \<Don't forget to include the ticket number in the PR title.\>

We need to get GitHub Access Tokens with specific scopes, and those scopes are different from those used to create the OAuth2 link. So, I've split up the scopes into `authorizationScopes` and `tokenScopes`. That way, we can provide the correct scopes at the correct time.
