### PR TITLE
ID-1126 ECM Retrieves Fence Keys

### DIFF
--- a/render_config.sh
+++ b/render_config.sh
@@ -28,9 +28,6 @@ fi
   echo export DCF_FENCE_CLIENT_SECRET="$($VAULT_COMMAND -field=dcf-fence-client-secret "$ECM_VAULT_PATH/fence")"
   echo export KIDS_FIRST_CLIENT_ID="$($VAULT_COMMAND -field=kids-first-client-id "$ECM_VAULT_PATH/fence")"
   echo export KIDS_FIRST_CLIENT_SECRET="$($VAULT_COMMAND -field=kids-first-client-secret "$ECM_VAULT_PATH/fence")"
-  echo export DATABASE_USER_PASSWORD="$($VAULT_COMMAND -field=password "$ECM_VAULT_PATH/postgres/db-creds")"
-  echo export DATABASE_NAME="$($VAULT_COMMAND -field=db "$ECM_VAULT_PATH/postgres/db-creds")"
-  echo export DATABASE_USER="$($VAULT_COMMAND -field=username "$ECM_VAULT_PATH/postgres/db-creds")"
 } >> "${SECRET_ENV_VARS_LOCATION}"
 
 $VAULT_COMMAND -field=swagger-client-id "$ECM_VAULT_PATH/swagger-client-id" >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"

--- a/render_config.sh
+++ b/render_config.sh
@@ -28,6 +28,9 @@ fi
   echo export DCF_FENCE_CLIENT_SECRET="$($VAULT_COMMAND -field=dcf-fence-client-secret "$ECM_VAULT_PATH/fence")"
   echo export KIDS_FIRST_CLIENT_ID="$($VAULT_COMMAND -field=kids-first-client-id "$ECM_VAULT_PATH/fence")"
   echo export KIDS_FIRST_CLIENT_SECRET="$($VAULT_COMMAND -field=kids-first-client-secret "$ECM_VAULT_PATH/fence")"
+  echo export DATABASE_USER_PASSWORD="$($VAULT_COMMAND -field=password "$ECM_VAULT_PATH/postgres/db-creds")"
+  echo export DATABASE_NAME="$($VAULT_COMMAND -field=db "$ECM_VAULT_PATH/postgres/db-creds")"
+  echo export DATABASE_USER="$($VAULT_COMMAND -field=username "$ECM_VAULT_PATH/postgres/db-creds")"
 } >> "${SECRET_ENV_VARS_LOCATION}"
 
 $VAULT_COMMAND -field=swagger-client-id "$ECM_VAULT_PATH/swagger-client-id" >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"

--- a/service/src/main/java/bio/terra/externalcreds/controllers/FenceAccountKeyController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/FenceAccountKeyController.java
@@ -6,8 +6,7 @@ import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.api.FenceAccountKeyApi;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.FenceAccountKey;
-import bio.terra.externalcreds.services.FenceAccountKeyService;
-import bio.terra.externalcreds.services.LinkedAccountService;
+import bio.terra.externalcreds.services.FenceProviderService;
 import jakarta.servlet.http.HttpServletRequest;
 import java.time.Instant;
 import java.util.Optional;
@@ -18,19 +17,19 @@ import org.springframework.stereotype.Controller;
 public record FenceAccountKeyController(
     AuditLogger auditLogger,
     ExternalCredsSamUserFactory samUserFactory,
-    FenceAccountKeyService fenceAccountKeyService,
-    HttpServletRequest request,
-    LinkedAccountService linkedAccountService)
+    FenceProviderService fenceProviderService,
+    HttpServletRequest request)
     implements FenceAccountKeyApi {
 
   @Override
   public ResponseEntity<String> getFenceAccountKey(Provider provider) {
     var samUser = samUserFactory.from(request);
-    var auditLogEvenBuilder = new AuditLogEvent.Builder()
-        .auditLogEventType(AuditLogEventType.GetServiceAccountKey)
-        .clientIP(request.getRemoteAddr());
+    var auditLogEvenBuilder =
+        new AuditLogEvent.Builder()
+            .auditLogEventType(AuditLogEventType.GetServiceAccountKey)
+            .clientIP(request.getRemoteAddr());
     var maybeLinkedAccount =
-        linkedAccountService.getLinkedAccount(samUser.getSubjectId(), provider);
+        fenceProviderService.getLinkedFenceAccount(samUser.getSubjectId(), provider);
     Optional<FenceAccountKey> maybeFenceAccountKey =
         maybeLinkedAccount.flatMap(
             linkedAccount -> {
@@ -38,22 +37,21 @@ public record FenceAccountKeyController(
                   .provider(linkedAccount.getProvider())
                   .userId(linkedAccount.getUserId())
                   .externalUserId(linkedAccount.getExternalUserId());
-              return fenceAccountKeyService.getFenceAccountKey(
-                  linkedAccount.getUserId(), linkedAccount.getProvider());
+              return fenceProviderService.getFenceAccountKey(linkedAccount);
             });
-    var response = maybeFenceAccountKey.flatMap(
-        fenceAccountKey -> {
-          // service account key should not be expired but if it is (due to some failure
-          // in ECM)
-          // don't pass that failure on to the caller
-          if (fenceAccountKey.getExpiresAt().isBefore(Instant.now())) {
-            return Optional.empty();
-          } else {
-            auditLogger.logEvent(
-                auditLogEvenBuilder.build());
-            return Optional.of(fenceAccountKey.getKeyJson());
-          }
-        });
+    var response =
+        maybeFenceAccountKey.flatMap(
+            fenceAccountKey -> {
+              // service account key should not be expired but if it is (due to some failure
+              // in ECM)
+              // don't pass that failure on to the caller
+              if (fenceAccountKey.getExpiresAt().isBefore(Instant.now())) {
+                return Optional.empty();
+              } else {
+                auditLogger.logEvent(auditLogEvenBuilder.build());
+                return Optional.of(fenceAccountKey.getKeyJson());
+              }
+            });
     return ResponseEntity.of(response);
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/FenceAccountKeyController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/FenceAccountKeyController.java
@@ -24,7 +24,7 @@ public record FenceAccountKeyController(
   @Override
   public ResponseEntity<String> getFenceAccountKey(Provider provider) {
     var samUser = samUserFactory.from(request);
-    var auditLogEvenBuilder =
+    var auditLogEventBuilder =
         new AuditLogEvent.Builder()
             .auditLogEventType(AuditLogEventType.GetServiceAccountKey)
             .clientIP(request.getRemoteAddr());
@@ -33,7 +33,7 @@ public record FenceAccountKeyController(
     Optional<FenceAccountKey> maybeFenceAccountKey =
         maybeLinkedAccount.flatMap(
             linkedAccount -> {
-              auditLogEvenBuilder
+              auditLogEventBuilder
                   .provider(linkedAccount.getProvider())
                   .userId(linkedAccount.getUserId())
                   .externalUserId(linkedAccount.getExternalUserId());
@@ -48,7 +48,7 @@ public record FenceAccountKeyController(
               if (fenceAccountKey.getExpiresAt().isBefore(Instant.now())) {
                 return Optional.empty();
               } else {
-                auditLogger.logEvent(auditLogEvenBuilder.build());
+                auditLogger.logEvent(auditLogEventBuilder.build());
                 return Optional.of(fenceAccountKey.getKeyJson());
               }
             });

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -124,7 +124,7 @@ public record OauthApiController(
 
     // This can be deleted once there's no longer a dependency on Bond's Datastore
     if (ProviderUtils.isFenceProvider(provider)) {
-      fenceProviderService.deleteFenceLink(samUser.getSubjectId(), provider);
+      fenceProviderService.deleteBondFenceLink(samUser.getSubjectId(), provider);
     }
 
     auditLogger.logEvent(

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceAccountKeyService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceAccountKeyService.java
@@ -1,9 +1,9 @@
 package bio.terra.externalcreds.services;
 
 import bio.terra.common.db.ReadTransaction;
+import bio.terra.common.db.WriteTransaction;
 import bio.terra.externalcreds.dataAccess.FenceAccountKeyDAO;
 import bio.terra.externalcreds.generated.model.Provider;
-import bio.terra.common.db.WriteTransaction;
 import bio.terra.externalcreds.models.FenceAccountKey;
 import bio.terra.externalcreds.models.LinkedAccount;
 import java.util.Optional;
@@ -34,5 +34,4 @@ public class FenceAccountKeyService {
   public FenceAccountKey upsertFenceAccountKey(FenceAccountKey fenceAccountKey) {
     return fenceAccountKeyDAO.upsertFenceAccountKey(fenceAccountKey);
   }
-
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceKeyRetriever.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceKeyRetriever.java
@@ -48,7 +48,7 @@ public class FenceKeyRetriever {
       retryFor = {DistributedLockException.class},
       maxAttemptsExpression = "${retry.getFenceAccountKey.maxAttempts}",
       backoff = @Backoff(delayExpression = "${retry.getFenceAccountKey.delay}"))
-  public Optional<FenceAccountKey> createFenceAccountKey(LinkedAccount linkedAccount) {
+  public Optional<FenceAccountKey> getOrCreateFenceAccountKey(LinkedAccount linkedAccount) {
     var maybeKey = fenceAccountKeyService.getFenceAccountKey(linkedAccount);
     return maybeKey.or(() -> retrieveNewKeyFromFence(linkedAccount));
   }

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
@@ -114,7 +114,11 @@ public class FenceProviderService extends ProviderService {
   }
 
   public void deleteBondFenceLink(String userId, Provider provider) {
-    bondService.deleteBondLinkedAccount(userId, provider);
+    try {
+      bondService.deleteBondLinkedAccount(userId, provider);
+    } catch (Exception ex) {
+      log.warn("Failed to delete Bond linked account", ex);
+    }
   }
 
   public void logLinkCreation(

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
@@ -21,7 +21,6 @@ import org.springframework.stereotype.Service;
 public class FenceProviderService extends ProviderService {
 
   private final BondService bondService;
-  private final FenceAccountKeyService fenceAccountKeyService;
   private final FenceKeyRetriever fenceKeyRetriever;
 
   public FenceProviderService(
@@ -45,7 +44,6 @@ public class FenceProviderService extends ProviderService {
         auditLogger,
         objectMapper);
     this.bondService = bondService;
-    this.fenceAccountKeyService = fenceAccountKeyService;
     this.fenceKeyRetriever = fenceKeyRetriever;
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
@@ -41,6 +41,7 @@ public class FenceProviderService extends ProviderService {
         providerTokenClientCache,
         oAuth2Service,
         linkedAccountService,
+        fenceAccountKeyService,
         auditLogger,
         objectMapper);
     this.bondService = bondService;
@@ -81,11 +82,8 @@ public class FenceProviderService extends ProviderService {
     return Optional.of(linkedAccount);
   }
 
-  public Optional<FenceAccountKey> getFenceAccountKey(String userId, Provider provider) {
-    var linkedAccount = getLinkedFenceAccount(userId, provider);
-    return linkedAccount
-        .flatMap(fenceAccountKeyService::getFenceAccountKey)
-        .or(() -> linkedAccount.flatMap(fenceKeyRetriever::createFenceAccountKey));
+  public Optional<FenceAccountKey> getFenceAccountKey(LinkedAccount linkedAccount) {
+    return fenceKeyRetriever.getOrCreateFenceAccountKey(linkedAccount);
   }
 
   public LinkedAccount createLink(
@@ -117,7 +115,7 @@ public class FenceProviderService extends ProviderService {
     }
   }
 
-  public void deleteFenceLink(String userId, Provider provider) {
+  public void deleteBondFenceLink(String userId, Provider provider) {
     bondService.deleteBondLinkedAccount(userId, provider);
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
@@ -37,6 +37,7 @@ public class PassportProviderService extends ProviderService {
       ProviderTokenClientCache providerTokenClientCache,
       OAuth2Service oAuth2Service,
       LinkedAccountService linkedAccountService,
+      FenceAccountKeyService fenceAccountKeyService,
       PassportService passportService,
       JwtUtils jwtUtils,
       AuditLogger auditLogger,
@@ -47,6 +48,7 @@ public class PassportProviderService extends ProviderService {
         providerTokenClientCache,
         oAuth2Service,
         linkedAccountService,
+        fenceAccountKeyService,
         auditLogger,
         objectMapper);
     this.passportService = passportService;

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -67,6 +67,8 @@ public class ProviderService {
           OAuth2ErrorCodes.UNSUPPORTED_RESPONSE_TYPE,
           OAuth2ErrorCodes.UNSUPPORTED_TOKEN_TYPE);
 
+  private static final String PRIVATE_KEY_ID_FIELD = "private_key_id";
+
   public ProviderService(
       ExternalCredsConfig externalCredsConfig,
       ProviderOAuthClientCache providerOAuthClientCache,
@@ -289,7 +291,7 @@ public class ProviderService {
         fenceAccountKey -> {
           try {
             var privateKeyJson = objectMapper.readTree(fenceAccountKey.getKeyJson());
-            var privateKeyId = privateKeyJson.get("private_key_id").asText();
+            var privateKeyId = privateKeyJson.get(PRIVATE_KEY_ID_FIELD).asText();
             WebClient.ResponseSpec response =
                 WebClient.create(keyEndpoint.get() + "/" + privateKeyId)
                     .delete()

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -13,7 +13,9 @@ import bio.terra.externalcreds.models.CannotDecodeOAuth2State;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
 import bio.terra.externalcreds.models.OAuth2State;
+import bio.terra.externalcreds.util.ProviderUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -31,6 +33,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -44,6 +47,8 @@ public class ProviderService {
   public final ProviderTokenClientCache providerTokenClientCache;
   public final OAuth2Service oAuth2Service;
   public final LinkedAccountService linkedAccountService;
+  public final FenceAccountKeyService fenceAccountKeyService;
+
   public final AuditLogger auditLogger;
   public final SecureRandom secureRandom = new SecureRandom();
   public final ObjectMapper objectMapper;
@@ -68,6 +73,7 @@ public class ProviderService {
       ProviderTokenClientCache providerTokenClientCache,
       OAuth2Service oAuth2Service,
       LinkedAccountService linkedAccountService,
+      FenceAccountKeyService fenceAccountKeyService,
       AuditLogger auditLogger,
       ObjectMapper objectMapper) {
     this.externalCredsConfig = externalCredsConfig;
@@ -75,6 +81,7 @@ public class ProviderService {
     this.providerTokenClientCache = providerTokenClientCache;
     this.oAuth2Service = oAuth2Service;
     this.linkedAccountService = linkedAccountService;
+    this.fenceAccountKeyService = fenceAccountKeyService;
     this.auditLogger = auditLogger;
     this.objectMapper = objectMapper;
   }
@@ -210,6 +217,10 @@ public class ProviderService {
             .getLinkedAccount(userId, provider)
             .orElseThrow(() -> new NotFoundException("Link not found for user"));
 
+    if (ProviderUtils.isFenceProvider(provider)) {
+      revokeKey(providerInfo, linkedAccount);
+    }
+
     revokeAccessToken(providerInfo, linkedAccount);
 
     linkedAccountService.deleteLinkedAccount(userId, provider);
@@ -261,5 +272,44 @@ public class ProviderService {
         linkedAccount.getUserId(),
         linkedAccount.getProvider().toString(),
         responseBody);
+  }
+
+  private void revokeKey(ProviderProperties providerProperties, LinkedAccount linkedAccount) {
+    var providerClient = providerOAuthClientCache.getProviderClient(linkedAccount.getProvider());
+    var accessToken =
+        oAuth2Service.authorizeWithRefreshToken(
+            providerClient, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
+    var keyEndpoint = providerProperties.getKeyEndpoint();
+    if (keyEndpoint.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Provider " + linkedAccount.getProvider() + " does not have a key endpoint");
+    }
+    var key = fenceAccountKeyService.getFenceAccountKey(linkedAccount);
+    key.ifPresent(
+        fenceAccountKey -> {
+          try {
+            var privateKeyJson = objectMapper.readTree(fenceAccountKey.getKeyJson());
+            var privateKeyId = privateKeyJson.get("private_key_id").asText();
+            WebClient.ResponseSpec response =
+                WebClient.create(keyEndpoint.get() + "/" + privateKeyId)
+                    .delete()
+                    .header(
+                        "Authorization", "Bearer " + accessToken.getAccessToken().getTokenValue())
+                    .retrieve();
+            String responseBody =
+                response
+                    .onStatus(HttpStatusCode::isError, clientResponse -> Mono.empty())
+                    .bodyToMono(String.class)
+                    .block(Duration.of(11, ChronoUnit.SECONDS));
+            log.info(
+                "Key revocation request for user [{}], provider [{}] returned with the result: [{}]",
+                linkedAccount.getUserId(),
+                linkedAccount.getProvider().toString(),
+                responseBody);
+          } catch (IOException e) {
+            throw new ExternalCredsException(
+                "Failed to read key for key revocation for user " + linkedAccount.getUserId(), e);
+          }
+        });
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -29,6 +29,7 @@ public class TokenProviderService extends ProviderService {
       OAuth2Service oAuth2Service,
       LinkedAccountService linkedAccountService,
       FenceProviderService fenceProviderService,
+      FenceAccountKeyService fenceAccountKeyService,
       AuditLogger auditLogger,
       ObjectMapper objectMapper) {
     super(
@@ -37,6 +38,7 @@ public class TokenProviderService extends ProviderService {
         providerTokenClientCache,
         oAuth2Service,
         linkedAccountService,
+        fenceAccountKeyService,
         auditLogger,
         objectMapper);
     this.fenceProviderService = fenceProviderService;

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -84,7 +84,7 @@ externalcreds:
     ras:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback" ]
     github:
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback", "http://localhost:3000/oauth_callback" ]
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
     fence:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/#fence-callback" ]
     dcf-fence:

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -23,6 +23,7 @@ externalcreds:
       userInfoEndpoint: "${externalcreds.providers.fence.issuer}/user"
       authorizationEndpoint: "${externalcreds.providers.fence.issuer}/oauth2/authorize"
       tokenEndpoint: "${externalcreds.providers.fence.issuer}/oauth2/token"
+      keyEndpoint: "${externalcreds.providers.fence.issuer}/credentials/google"
     dcf-fence:
       clientId: "${DCF_FENCE_CLIENT_ID}"
       clientSecret: "${DCF_FENCE_CLIENT_SECRET}"
@@ -34,6 +35,7 @@ externalcreds:
       userInfoEndpoint: "${externalcreds.providers.dcf-fence.issuer}/user"
       authorizationEndpoint: "${externalcreds.providers.dcf-fence.issuer}/oauth2/authorize"
       tokenEndpoint: "${externalcreds.providers.dcf-fence.issuer}/oauth2/token"
+      keyEndpoint: "${externalcreds.providers.dcf-fence.issuer}/credentials/google"
     kids-first:
       clientId: "${KIDS_FIRST_CLIENT_ID}"
       clientSecret: "${KIDS_FIRST_CLIENT_SECRET}"
@@ -45,6 +47,7 @@ externalcreds:
       userInfoEndpoint: "${externalcreds.providers.kids-first.issuer}/user"
       authorizationEndpoint: "${externalcreds.providers.kids-first.issuer}/oauth2/authorize"
       tokenEndpoint: "${externalcreds.providers.kids-first.issuer}/oauth2/token"
+      keyEndpoint: "${externalcreds.providers.kids-first.issuer}/credentials/google"
     anvil:
       clientId: "${ANVIL_CLIENT_ID}"
       clientSecret: "${ANVIL_CLIENT_SECRET}"
@@ -56,6 +59,7 @@ externalcreds:
       userInfoEndpoint: "${externalcreds.providers.anvil.issuer}/user"
       authorizationEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/authorize"
       tokenEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/token"
+      keyEndpoint: "${externalcreds.providers.anvil.issuer}/credentials/google"
 
 ---
 #non-prod environments
@@ -80,7 +84,7 @@ externalcreds:
     ras:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback" ]
     github:
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback" ]
+      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/oauth_callback", "http://localhost:3000/oauth_callback" ]
     fence:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/#fence-callback" ]
     dcf-fence:

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -64,7 +64,7 @@ public class TestUtils {
   public static FenceAccountKey createRandomFenceAccountKey() {
     return new FenceAccountKey.Builder()
         .linkedAccountId(1)
-        .keyJson("{\"key\": \"value\"}")
+        .keyJson("{\"key\": \"value\", \"private_key_id\": \"12345\"}")
         .expiresAt(getRandomTimestamp().toInstant())
         .build();
   }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -326,7 +326,7 @@ class OauthApiControllerTest extends BaseTest {
           .andExpect(status().isOk());
 
       verify(providerServiceMock).deleteLink(userId, Provider.FENCE);
-      verify(fenceProviderServiceMock).deleteFenceLink(userId, Provider.FENCE);
+      verify(fenceProviderServiceMock).deleteBondFenceLink(userId, Provider.FENCE);
 
       // check that a log was recorded
       verify(auditLoggerMock)

--- a/service/src/test/java/bio/terra/externalcreds/services/FenceKeyRetrieverTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/FenceKeyRetrieverTest.java
@@ -95,7 +95,7 @@ class FenceKeyRetrieverTest extends BaseTest {
                     .withHeader("Authorization", "Bearer accessToken"))
             .respond(HttpResponse.response().withStatusCode(200).withBody(keyJson));
 
-        var key = fenceKeyRetriever.createFenceAccountKey(linkedAccount);
+        var key = fenceKeyRetriever.getOrCreateFenceAccountKey(linkedAccount);
         assertPresent(key);
         assertEquals(keyJson, key.get().getKeyJson());
       }
@@ -124,7 +124,7 @@ class FenceKeyRetrieverTest extends BaseTest {
 
       assertThrows(
           DistributedLockException.class,
-          () -> fenceKeyRetriever.createFenceAccountKey(linkedAccount));
+          () -> fenceKeyRetriever.getOrCreateFenceAccountKey(linkedAccount));
 
       // Test config is set to 3 retries
       verify(fenceAccountKeyService, times(3)).getFenceAccountKey(linkedAccount);
@@ -152,7 +152,7 @@ class FenceKeyRetrieverTest extends BaseTest {
 
       assertThrows(
           ExternalCredsException.class,
-          () -> fenceKeyRetriever.createFenceAccountKey(linkedAccount));
+          () -> fenceKeyRetriever.getOrCreateFenceAccountKey(linkedAccount));
 
       verify(distributedLockDAO)
           .insertDistributedLock(argThat(lock -> lock.getLockName().equals(lockName)));

--- a/service/src/test/java/bio/terra/externalcreds/services/FenceProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/FenceProviderServiceTest.java
@@ -1,34 +1,54 @@
 package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 
+import bio.terra.common.exception.BadRequestException;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.FenceAccountKey;
 import bio.terra.externalcreds.models.LinkedAccount;
+import bio.terra.externalcreds.models.OAuth2State;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 
 class FenceProviderServiceTest extends BaseTest {
 
   @Autowired private FenceProviderService fenceProviderService;
+  @Autowired private ObjectMapper objectMapper;
 
   @MockBean private LinkedAccountService linkedAccountService;
   @MockBean private BondService bondService;
   @MockBean private FenceAccountKeyService fenceAccountKeyService;
+  @MockBean private ProviderOAuthClientCache providerOAuthClientCache;
+  @MockBean private OAuth2Service oAuth2Service;
+  @MockBean private ExternalCredsConfig externalCredsConfig;
 
   private static final Random random = new Random();
 
@@ -69,6 +89,108 @@ class FenceProviderServiceTest extends BaseTest {
     var actualFenceAccountKey = fenceProviderService.getFenceAccountKey(linkedAccount);
 
     assertPresent(actualFenceAccountKey);
+  }
+
+  @Test
+  void testCreateLink() {
+    var linkedAccountId = random.nextInt();
+    var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.FENCE);
+    when(linkedAccountService.upsertLinkedAccount(any()))
+        .thenReturn(linkedAccount.withId(linkedAccountId));
+    var auditLogEventBuilder = new AuditLogEvent.Builder().userId(linkedAccount.getUserId());
+    var oauth2State =
+        new OAuth2State.Builder()
+            .provider(Provider.FENCE)
+            .random("abcde")
+            .redirectUri("http://localhost:8080/oauth2/callback")
+            .build();
+    var encodedState = oauth2State.encode(objectMapper);
+
+    var providerClient =
+        ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
+            .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+            .build();
+    when(providerOAuthClientCache.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(providerClient);
+    doNothing()
+        .when(linkedAccountService)
+        .validateAndDeleteOAuth2State(linkedAccount.getUserId(), oauth2State);
+
+    var provider = TestUtils.createRandomProvider().setScopes(Set.of("scope"));
+    when(externalCredsConfig.getProviderProperties(linkedAccount.getProvider()))
+        .thenReturn(provider);
+    var accessTokenResponse =
+        OAuth2AccessTokenResponse.withToken("token")
+            .refreshToken("refresh")
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .build();
+    when(oAuth2Service.authorizationCodeExchange(
+            providerClient,
+            "code",
+            "http://localhost:8080/oauth2/callback",
+            Set.copyOf(provider.getScopes()),
+            encodedState,
+            Map.of()))
+        .thenReturn(accessTokenResponse);
+
+    when(oAuth2Service.getUserInfo(providerClient, accessTokenResponse.getAccessToken()))
+        .thenReturn(
+            new DefaultOAuth2User(
+                null,
+                Map.of("foo", "bar", provider.getExternalIdClaim(), "barName"),
+                provider.getExternalIdClaim()));
+
+    fenceProviderService.createLink(
+        linkedAccount.getProvider(),
+        linkedAccount.getUserId(),
+        "code",
+        encodedState,
+        auditLogEventBuilder);
+  }
+
+  @Test
+  void testCreateLinkFails() {
+    var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.FENCE);
+    var auditLogEventBuilder = new AuditLogEvent.Builder().userId(linkedAccount.getUserId());
+    var oauth2State =
+        new OAuth2State.Builder()
+            .provider(Provider.FENCE)
+            .random("abcde")
+            .redirectUri("http://localhost:8080/oauth2/callback")
+            .build();
+    var encodedState = oauth2State.encode(objectMapper);
+
+    var providerClient =
+        ClientRegistration.withRegistrationId(linkedAccount.getProvider().toString())
+            .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+            .build();
+    when(providerOAuthClientCache.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(providerClient);
+    doNothing()
+        .when(linkedAccountService)
+        .validateAndDeleteOAuth2State(linkedAccount.getUserId(), oauth2State);
+
+    var provider = TestUtils.createRandomProvider().setScopes(Set.of("scope"));
+    when(externalCredsConfig.getProviderProperties(linkedAccount.getProvider()))
+        .thenReturn(provider);
+    when(oAuth2Service.authorizationCodeExchange(
+            providerClient,
+            "code",
+            "http://localhost:8080/oauth2/callback",
+            Set.copyOf(provider.getScopes()),
+            encodedState,
+            Map.of()))
+        .thenThrow(new OAuth2AuthorizationException(new OAuth2Error("error")));
+
+    assertThrows(
+        BadRequestException.class,
+        () ->
+            fenceProviderService.createLink(
+                linkedAccount.getProvider(),
+                linkedAccount.getUserId(),
+                "code",
+                encodedState,
+                auditLogEventBuilder));
   }
 
   @Nested
@@ -214,6 +336,14 @@ class FenceProviderServiceTest extends BaseTest {
 
       assertPresent(linkedAccount);
       assertEquals(expectedExpiresAt, linkedAccount.get().getExpires());
+    }
+
+    @Test
+    void testDeleteBondFenceLink() {
+      var userId = UUID.randomUUID().toString();
+      var provider = Provider.FENCE;
+      doNothing().when(bondService).deleteBondLinkedAccount(userId, provider);
+      fenceProviderService.deleteBondFenceLink(userId, provider);
     }
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/services/FenceProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/FenceProviderServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
 import bio.terra.common.exception.BadRequestException;
@@ -343,6 +344,14 @@ class FenceProviderServiceTest extends BaseTest {
       var userId = UUID.randomUUID().toString();
       var provider = Provider.FENCE;
       doNothing().when(bondService).deleteBondLinkedAccount(userId, provider);
+      fenceProviderService.deleteBondFenceLink(userId, provider);
+    }
+
+    @Test
+    void testDeleteBondFenceLinkFailsGracefully() {
+      var userId = UUID.randomUUID().toString();
+      var provider = Provider.FENCE;
+      doThrow(new RuntimeException()).when(bondService).deleteBondLinkedAccount(userId, provider);
       fenceProviderService.deleteBondFenceLink(userId, provider);
     }
   }

--- a/service/src/test/java/bio/terra/externalcreds/services/FenceProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/FenceProviderServiceTest.java
@@ -66,7 +66,7 @@ class FenceProviderServiceTest extends BaseTest {
     when(fenceAccountKeyService.getFenceAccountKey(linkedAccount))
         .thenReturn(Optional.of(fenceAccountKey));
 
-    var actualFenceAccountKey = fenceProviderService.getFenceAccountKey(userId, provider);
+    var actualFenceAccountKey = fenceProviderService.getFenceAccountKey(linkedAccount);
 
     assertPresent(actualFenceAccountKey);
   }
@@ -121,7 +121,7 @@ class FenceProviderServiceTest extends BaseTest {
       when(fenceAccountKeyService.getFenceAccountKey(ecmLinkedAccount))
           .thenReturn(Optional.of(key));
 
-      var fenceKey = fenceProviderService.getFenceAccountKey(userId, provider);
+      var fenceKey = fenceProviderService.getFenceAccountKey(linkedAccount.get());
 
       assertPresent(fenceKey);
     }

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -36,6 +36,7 @@ import bio.terra.externalcreds.models.VisaVerificationDetails;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import java.io.IOException;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Duration;
@@ -56,6 +57,7 @@ import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.mockserver.model.Parameter;
+import org.mockserver.verify.VerificationTimes;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -76,9 +78,13 @@ public class ProviderServiceTest extends BaseTest {
   class DeleteLink {
 
     @Autowired private ProviderService providerService;
+    @Autowired private ObjectMapper objectMapper;
 
     @MockBean private LinkedAccountService linkedAccountServiceMock;
     @MockBean private ExternalCredsConfig externalCredsConfigMock;
+    @MockBean private OAuth2Service oAuth2ServiceMock;
+    @MockBean private ProviderOAuthClientCache providerOAuthClientCacheMock;
+    @MockBean private FenceAccountKeyService fenceAccountKeyServiceMock;
 
     @Test
     void testGetProviders() {
@@ -121,6 +127,72 @@ public class ProviderServiceTest extends BaseTest {
       assertThrows(
           NotFoundException.class,
           () -> providerService.deleteLink(linkedAccount.getUserId(), linkedAccount.getProvider()));
+    }
+
+    @Test
+    void testDeleteFenceLink() throws IOException {
+      try (var mockServer = ClientAndServer.startClientAndServer()) {
+        var revocationPath = "/test/revoke/";
+        var linkedAccount =
+            TestUtils.createRandomLinkedAccount().withId(1).withProvider(Provider.FENCE);
+
+        var key =
+            TestUtils.createRandomFenceAccountKey()
+                .withLinkedAccountId(linkedAccount.getId().get());
+        var privateKeyId = objectMapper.readTree(key.getKeyJson()).get("private_key_id").asText();
+        var keyRevocationPath = "/test/key";
+
+        var providerInfo =
+            TestUtils.createRandomProvider()
+                .setRevokeEndpoint(
+                    "http://localhost:" + mockServer.getPort() + revocationPath + "?token=%s")
+                .setKeyEndpoint("http://localhost:" + mockServer.getPort() + keyRevocationPath);
+
+        var expectedParameters =
+            List.of(
+                new Parameter("token", linkedAccount.getRefreshToken()),
+                new Parameter("client_id", providerInfo.getClientId()),
+                new Parameter("client_secret", providerInfo.getClientSecret()));
+
+        when(externalCredsConfigMock.getProviderProperties(linkedAccount.getProvider()))
+            .thenReturn(providerInfo);
+
+        when(linkedAccountServiceMock.getLinkedAccount(
+                linkedAccount.getUserId(), linkedAccount.getProvider()))
+            .thenReturn(Optional.of(linkedAccount));
+        when(linkedAccountServiceMock.deleteLinkedAccount(
+                linkedAccount.getUserId(), linkedAccount.getProvider()))
+            .thenReturn(true);
+
+        when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+            .thenReturn(createClientRegistration(linkedAccount.getProvider()));
+
+        when(oAuth2ServiceMock.authorizeWithRefreshToken(
+                any(ClientRegistration.class), any(OAuth2RefreshToken.class)))
+            .thenReturn(
+                OAuth2AccessTokenResponse.withToken("token").tokenType(TokenType.BEARER).build());
+        when(fenceAccountKeyServiceMock.getFenceAccountKey(linkedAccount))
+            .thenReturn(Optional.of(key));
+
+        //  Mock the server response
+        mockServer
+            .when(
+                HttpRequest.request(revocationPath)
+                    .withMethod("POST")
+                    .withQueryStringParameters(expectedParameters))
+            .respond(HttpResponse.response().withStatusCode(HttpStatus.OK.value()));
+
+        mockServer
+            .when(HttpRequest.request(keyRevocationPath).withMethod("DELETE"))
+            .respond(HttpResponse.response().withStatusCode(HttpStatus.OK.value()));
+
+        providerService.deleteLink(linkedAccount.getUserId(), linkedAccount.getProvider());
+        verify(linkedAccountServiceMock)
+            .deleteLinkedAccount(linkedAccount.getUserId(), linkedAccount.getProvider());
+        mockServer.verify(
+            HttpRequest.request(keyRevocationPath + "/" + privateKeyId).withMethod("DELETE"),
+            VerificationTimes.exactly(1));
+      }
     }
 
     private void testWithRevokeResponseCode(HttpStatus httpStatus) {


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1126

We didn't wire key-retrieval into the get key endpoint! This fixes that, and also adds code to revoke credentials in the fence provider when a link is deleted. Also added tests for that!
