### PR TITLE
ID-1126 Access Token Cache

### DIFF
--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -57,13 +57,13 @@ jobs:
           -Djib.console=plain
       - name: Push GCR image
         run: 'docker push ${{ steps.image-name.outputs.name }}'
-    report-to-sherlock:
-      # Report new ECM version to Broad DevOps
-      uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
-      needs: publish-branch-image-job
-      with:
-        new-version: ${{ needs.publish-branch-image-job.outputs.tag }}
-        chart-name: 'externalcreds'
-      permissions:
-        contents: 'read'
-        id-token: 'write'
+  report-to-sherlock:
+    # Report new ECM version to Broad DevOps
+    uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+    needs: publish-branch-image-job
+    with:
+      new-version: ${{ needs.publish-branch-image-job.outputs.tag }}
+      chart-name: 'externalcreds'
+    permissions:
+      contents: 'read'
+      id-token: 'write'

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -44,7 +44,13 @@ jobs:
       - name: Construct docker image name and tag
         id: image-name
         run: echo name=gcr.io/${GOOGLE_PROJECT}/${SERVICE_NAME}:${{ steps.tag.outputs.tag }} >> $GITHUB_OUTPUT
+      - name: Add Google Cloud Profiler to Docker Image
+        run: docker build ./service -t externalcreds:local
       - name: Build image locally with jib
-        run: './gradlew :service:jibDockerBuild --image=${{ steps.image-name.outputs.name }} -Djib.console=plain'
+        # build the docker image to make sure it does not error
+        run: |
+          ./gradlew --build-cache :service:jibDockerBuild \
+          -Djib.from.image=docker://externalcreds:local \
+          -Djib.console=plain
       - name: Push GCR image
         run: 'docker push ${{ steps.image-name.outputs.name }}'

--- a/.github/workflows/publish-branch-image.yml
+++ b/.github/workflows/publish-branch-image.yml
@@ -8,6 +8,8 @@ env:
 jobs:
   publish-branch-image-job:
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -51,6 +53,17 @@ jobs:
         run: |
           ./gradlew --build-cache :service:jibDockerBuild \
           -Djib.from.image=docker://externalcreds:local \
+          --image=${{ steps.image-name.outputs.name }} \
           -Djib.console=plain
       - name: Push GCR image
         run: 'docker push ${{ steps.image-name.outputs.name }}'
+    report-to-sherlock:
+      # Report new ECM version to Broad DevOps
+      uses: broadinstitute/sherlock/.github/workflows/client-report-app-version.yaml@main
+      needs: publish-branch-image-job
+      with:
+        new-version: ${{ needs.publish-branch-image-job.outputs.tag }}
+        chart-name: 'externalcreds'
+      permissions:
+        contents: 'read'
+        id-token: 'write'

--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -39,6 +39,8 @@ public interface ExternalCredsConfigInterface {
 
   Duration getVisaAndPassportRefreshDuration();
 
+  Duration getAccessTokenExpirationBuffer();
+
   /** List of algorithms that are allowable in JWT headers */
   @Value.Default
   default Collection<String> getAllowedJwtAlgorithms() {

--- a/service/src/main/java/bio/terra/externalcreds/controllers/ExternalCredsSamUserFactory.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/ExternalCredsSamUserFactory.java
@@ -1,16 +1,42 @@
 package bio.terra.externalcreds.controllers;
 
+import bio.terra.common.iam.BearerTokenFactory;
 import bio.terra.common.iam.SamUser;
 import bio.terra.common.iam.SamUserFactory;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections4.map.PassiveExpiringMap;
 import org.springframework.stereotype.Component;
 
 @Component
-public record ExternalCredsSamUserFactory(
-    SamUserFactory samUserFactory, ExternalCredsConfig externalCredsConfig) {
+public class ExternalCredsSamUserFactory {
+
+  private SamUserFactory samUserFactory;
+  private ExternalCredsConfig externalCredsConfig;
+
+  private BearerTokenFactory bearerTokenFactory;
+
+  // This is per-pod cache, not shared across pods.
+  // This is just to keep ECM from hitting Sam too much given the bursty loads ECM handles.
+  private final Map<Integer, SamUser> samUserCache =
+      Collections.synchronizedMap(new PassiveExpiringMap<>(1, TimeUnit.MINUTES));
+
+  public ExternalCredsSamUserFactory(
+      SamUserFactory samUserFactory,
+      BearerTokenFactory bearerTokenFactory,
+      ExternalCredsConfig externalCredsConfig) {
+    this.samUserFactory = samUserFactory;
+    this.bearerTokenFactory = bearerTokenFactory;
+    this.externalCredsConfig = externalCredsConfig;
+  }
 
   public SamUser from(HttpServletRequest request) {
-    return samUserFactory.from(request, externalCredsConfig.getSamBasePath());
+    var bearerToken = bearerTokenFactory.from(request);
+    return samUserCache.computeIfAbsent(
+        bearerToken.hashCode(),
+        hash -> samUserFactory.from(request, externalCredsConfig.getSamBasePath()));
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -73,7 +73,7 @@ public record OauthApiController(
     var accessToken =
         tokenProviderService.getProviderAccessToken(
             samUser.getSubjectId(), provider, auditLogEventBuilder);
-    return ResponseEntity.of(accessToken);
+    return ResponseEntity.ok(accessToken);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAO.java
@@ -43,7 +43,7 @@ public class AccessTokenCacheDAO {
               var query =
                   "SELECT token.linked_account_id, token.access_token, token.expires_at "
                       + "  FROM access_token_cache token"
-                      + "  WHERE fence.linked_account_id = :linkedAccountId";
+                      + "  WHERE token.linked_account_id = :linkedAccountId";
               return Optional.ofNullable(
                   DataAccessUtils.singleResult(
                       jdbcTemplate.query(query, namedParameters, ACCESS_TOKEN_CACHE_ROW_MAPPER)));
@@ -76,9 +76,8 @@ public class AccessTokenCacheDAO {
             + " VALUES (:linkedAccountId, :accessToken, :expiresAt)"
             + " ON CONFLICT (linked_account_id) DO UPDATE SET"
             + " linked_account_id = excluded.linked_account_id,"
-            + " key_json = excluded.key_json::jsonb,"
-            + " expires_at = excluded.expires_at"
-            + " RETURNING id";
+            + " access_token = excluded.access_token,"
+            + " expires_at = excluded.expires_at";
 
     var namedParameters =
         new MapSqlParameterSource()
@@ -99,7 +98,7 @@ public class AccessTokenCacheDAO {
 
   /**
    * @param linkedAccountId id of the linked account
-   * @return boolean whether a fence account key was deleted
+   * @return boolean whether a access token cache entry was deleted
    */
   @WithSpan
   public boolean deleteAccessTokenCacheEntry(int linkedAccountId) {

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAO.java
@@ -1,0 +1,110 @@
+package bio.terra.externalcreds.dataAccess;
+
+import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.models.AccessTokenCacheEntry;
+import bio.terra.externalcreds.models.LinkedAccount;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.sql.Timestamp;
+import java.util.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Slf4j
+public class AccessTokenCacheDAO {
+
+  private static final RowMapper<AccessTokenCacheEntry> ACCESS_TOKEN_CACHE_ROW_MAPPER =
+      ((rs, rowNum) ->
+          new AccessTokenCacheEntry.Builder()
+              .linkedAccountId(rs.getInt("linked_account_id"))
+              .accessToken(rs.getString("access_token"))
+              .expiresAt(rs.getTimestamp("expires_at").toInstant())
+              .build());
+
+  final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public AccessTokenCacheDAO(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @WithSpan
+  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(LinkedAccount linkedAccount) {
+    return linkedAccount
+        .getId()
+        .flatMap(
+            linkedAccountId -> {
+              var namedParameters =
+                  new MapSqlParameterSource().addValue("linkedAccountId", linkedAccountId);
+              var query =
+                  "SELECT token.linked_account_id, token.access_token, token.expires_at "
+                      + "  FROM access_token_cache token"
+                      + "  WHERE fence.linked_account_id = :linkedAccountId";
+              return Optional.ofNullable(
+                  DataAccessUtils.singleResult(
+                      jdbcTemplate.query(query, namedParameters, ACCESS_TOKEN_CACHE_ROW_MAPPER)));
+            });
+  }
+
+  @WithSpan
+  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(
+      String userId, Provider provider) {
+    var namedParameters =
+        new MapSqlParameterSource()
+            .addValue("userId", userId)
+            .addValue("provider", provider.name());
+    var query =
+        "SELECT token.linked_account_id, token.access_token, token.expires_at"
+            + " FROM access_token_cache token"
+            + " INNER JOIN linked_account la ON la.id = token.linked_account_id"
+            + " WHERE la.user_id = :userId"
+            + " AND la.provider = :provider::provider_enum";
+    return Optional.ofNullable(
+        DataAccessUtils.singleResult(
+            jdbcTemplate.query(query, namedParameters, ACCESS_TOKEN_CACHE_ROW_MAPPER)));
+  }
+
+  @WithSpan
+  public AccessTokenCacheEntry upsertAccessTokenCacheEntry(
+      AccessTokenCacheEntry accessTokenCacheEntry) {
+    var query =
+        "INSERT INTO access_token_cache (linked_account_id, access_token, expires_at)"
+            + " VALUES (:linkedAccountId, :accessToken, :expiresAt)"
+            + " ON CONFLICT (linked_account_id) DO UPDATE SET"
+            + " linked_account_id = excluded.linked_account_id,"
+            + " key_json = excluded.key_json::jsonb,"
+            + " expires_at = excluded.expires_at"
+            + " RETURNING id";
+
+    var namedParameters =
+        new MapSqlParameterSource()
+            .addValue("linkedAccountId", accessTokenCacheEntry.getLinkedAccountId())
+            .addValue("accessToken", accessTokenCacheEntry.getAccessToken())
+            .addValue("expiresAt", Timestamp.from(accessTokenCacheEntry.getExpiresAt()));
+
+    // generatedKeyHolder will hold the id returned by the query as specified by the RETURNING
+    // clause
+    var generatedKeyHolder = new GeneratedKeyHolder();
+    var numUpdated = jdbcTemplate.update(query, namedParameters, generatedKeyHolder);
+    if (numUpdated == 1) {
+      return accessTokenCacheEntry;
+    } else {
+      throw new RuntimeException("Failed to upsert access token cache entry");
+    }
+  }
+
+  /**
+   * @param linkedAccountId id of the linked account
+   * @return boolean whether a fence account key was deleted
+   */
+  @WithSpan
+  public boolean deleteAccessTokenCacheEntry(int linkedAccountId) {
+    var namedParameters = new MapSqlParameterSource("linkedAccountId", linkedAccountId);
+    var query = "DELETE FROM access_token_cache WHERE linked_account_id = :linkedAccountId";
+    return jdbcTemplate.update(query, namedParameters) > 0;
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAO.java
@@ -1,6 +1,5 @@
 package bio.terra.externalcreds.dataAccess;
 
-import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.AccessTokenCacheEntry;
 import bio.terra.externalcreds.models.LinkedAccount;
 import io.opentelemetry.instrumentation.annotations.WithSpan;
@@ -51,24 +50,6 @@ public class AccessTokenCacheDAO {
   }
 
   @WithSpan
-  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(
-      String userId, Provider provider) {
-    var namedParameters =
-        new MapSqlParameterSource()
-            .addValue("userId", userId)
-            .addValue("provider", provider.name());
-    var query =
-        "SELECT token.linked_account_id, token.access_token, token.expires_at"
-            + " FROM access_token_cache token"
-            + " INNER JOIN linked_account la ON la.id = token.linked_account_id"
-            + " WHERE la.user_id = :userId"
-            + " AND la.provider = :provider::provider_enum";
-    return Optional.ofNullable(
-        DataAccessUtils.singleResult(
-            jdbcTemplate.query(query, namedParameters, ACCESS_TOKEN_CACHE_ROW_MAPPER)));
-  }
-
-  @WithSpan
   public AccessTokenCacheEntry upsertAccessTokenCacheEntry(
       AccessTokenCacheEntry accessTokenCacheEntry) {
     var query =
@@ -92,7 +73,10 @@ public class AccessTokenCacheDAO {
     if (numUpdated == 1) {
       return accessTokenCacheEntry;
     } else {
-      throw new RuntimeException("Failed to upsert access token cache entry");
+      throw new RuntimeException(
+          "Failed to upsert access token cache entry, 'numUpdated' was "
+              + numUpdated
+              + " instead of 1.");
     }
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/models/AccessTokenCacheEntry.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/AccessTokenCacheEntry.java
@@ -1,0 +1,16 @@
+package bio.terra.externalcreds.models;
+
+import java.time.Instant;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface AccessTokenCacheEntry extends WithAccessTokenCacheEntry {
+
+  Integer getLinkedAccountId();
+
+  String getAccessToken();
+
+  Instant getExpiresAt();
+
+  class Builder extends ImmutableAccessTokenCacheEntry.Builder {}
+}

--- a/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
@@ -1,32 +1,111 @@
 package bio.terra.externalcreds.services;
 
-import bio.terra.common.db.ReadTransaction;
 import bio.terra.common.db.WriteTransaction;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.AccessTokenCacheDAO;
-import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.AccessTokenCacheEntry;
+import bio.terra.externalcreds.models.LinkedAccount;
+import java.time.Instant;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
 public class AccessTokenCacheService {
+
+  private final ProviderTokenClientCache providerTokenClientCache;
+  private final LinkedAccountService linkedAccountService;
+  private final OAuth2Service oAuth2Service;
   private final AccessTokenCacheDAO accessTokenCacheDAO;
+  private final ExternalCredsConfig externalCredsConfig;
+  private final AuditLogger auditLogger;
 
-  public AccessTokenCacheService(AccessTokenCacheDAO accessTokenCacheDAO) {
+  public AccessTokenCacheService(
+      ProviderTokenClientCache providerTokenClientCache,
+      LinkedAccountService linkedAccountService,
+      OAuth2Service oAuth2Service,
+      AccessTokenCacheDAO accessTokenCacheDAO,
+      ExternalCredsConfig externalCredsConfig,
+      AuditLogger auditLogger) {
+    this.providerTokenClientCache = providerTokenClientCache;
+    this.linkedAccountService = linkedAccountService;
+    this.oAuth2Service = oAuth2Service;
     this.accessTokenCacheDAO = accessTokenCacheDAO;
-  }
-
-  @ReadTransaction
-  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(
-      String userId, Provider provider) {
-    return accessTokenCacheDAO.getAccessTokenCacheEntry(userId, provider);
+    this.externalCredsConfig = externalCredsConfig;
+    this.auditLogger = auditLogger;
   }
 
   @WriteTransaction
-  public AccessTokenCacheEntry upsertAccessTokenCacheEntry(
+  public String getLinkedAccountAccessToken(
+      LinkedAccount linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+    var tokenCacheEntry =
+        getAccessTokenCacheEntry(linkedAccount)
+            .flatMap(
+                tokenEntry -> {
+                  if (tokenEntry
+                      .getExpiresAt()
+                      .isAfter(
+                          Instant.now()
+                              .plus(externalCredsConfig.getAccessTokenExpirationBuffer()))) {
+                    return Optional.of(tokenEntry.getAccessToken());
+                  }
+                  return Optional.empty();
+                });
+
+    return tokenCacheEntry.orElseGet(
+        () -> getNewProviderAccessToken(linkedAccount, auditLogEventBuilder));
+  }
+
+  private String getNewProviderAccessToken(
+      LinkedAccount linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+    // get client registration from provider client cache
+    var clientRegistration =
+        providerTokenClientCache.getProviderClient(linkedAccount.getProvider());
+
+    // exchange refresh token for access token
+    var accessTokenResponse =
+        oAuth2Service.authorizeWithRefreshToken(
+            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
+
+    // save the linked account with the new refresh token to replace the old one
+    var refreshToken = accessTokenResponse.getRefreshToken();
+    if (refreshToken != null) {
+      linkedAccountService.upsertLinkedAccount(
+          linkedAccount.withRefreshToken(refreshToken.getTokenValue()));
+    }
+    logGetProviderAccessToken(linkedAccount, auditLogEventBuilder);
+
+    return upsertAccessTokenCacheEntry(
+            new AccessTokenCacheEntry.Builder()
+                .linkedAccountId(linkedAccount.getId().orElseThrow())
+                .accessToken(accessTokenResponse.getAccessToken().getTokenValue())
+                .expiresAt(accessTokenResponse.getAccessToken().getExpiresAt())
+                .build())
+        .getAccessToken();
+  }
+
+  private Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(LinkedAccount linkedAccount) {
+    return accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount);
+  }
+
+  private AccessTokenCacheEntry upsertAccessTokenCacheEntry(
       AccessTokenCacheEntry accessTokenCacheEntry) {
     return accessTokenCacheDAO.upsertAccessTokenCacheEntry(accessTokenCacheEntry);
+  }
+
+  public void logGetProviderAccessToken(
+      LinkedAccount linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+    auditLogger.logEvent(
+        auditLogEventBuilder
+            .externalUserId(linkedAccount.getExternalUserId())
+            .userId(linkedAccount.getUserId())
+            .provider(linkedAccount.getProvider())
+            .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
+            .build());
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
@@ -1,0 +1,38 @@
+package bio.terra.externalcreds.services;
+
+import bio.terra.common.db.ReadTransaction;
+import bio.terra.common.db.WriteTransaction;
+import bio.terra.externalcreds.dataAccess.AccessTokenCacheDAO;
+import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.models.AccessTokenCacheEntry;
+import bio.terra.externalcreds.models.LinkedAccount;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class AccessTokenCacheService {
+  private final AccessTokenCacheDAO accessTokenCacheDAO;
+
+  public AccessTokenCacheService(AccessTokenCacheDAO accessTokenCacheDAO) {
+    this.accessTokenCacheDAO = accessTokenCacheDAO;
+  }
+
+  @ReadTransaction
+  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(
+      String userId, Provider provider) {
+    return accessTokenCacheDAO.getAccessTokenCacheEntry(userId, provider);
+  }
+
+  @ReadTransaction
+  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(LinkedAccount linkedAccount) {
+    return accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount);
+  }
+
+  @WriteTransaction
+  public AccessTokenCacheEntry upsertAccessTokenCacheEntry(
+      AccessTokenCacheEntry accessTokenCacheEntry) {
+    return accessTokenCacheDAO.upsertAccessTokenCacheEntry(accessTokenCacheEntry);
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
@@ -5,7 +5,6 @@ import bio.terra.common.db.WriteTransaction;
 import bio.terra.externalcreds.dataAccess.AccessTokenCacheDAO;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.AccessTokenCacheEntry;
-import bio.terra.externalcreds.models.LinkedAccount;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,11 +22,6 @@ public class AccessTokenCacheService {
   public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(
       String userId, Provider provider) {
     return accessTokenCacheDAO.getAccessTokenCacheEntry(userId, provider);
-  }
-
-  @ReadTransaction
-  public Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(LinkedAccount linkedAccount) {
-    return accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount);
   }
 
   @WriteTransaction

--- a/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceProviderService.java
@@ -10,10 +10,6 @@ import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.FenceAccountKey;
 import bio.terra.externalcreds.models.LinkedAccount;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.HashSet;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -67,22 +63,6 @@ public class FenceProviderService extends ProviderService {
     }
     // ECM is out of date. Port the Bond data into the ECM and return the new ECM Linked Account
     return bondLinkedAccount.map(this::updateEcmWithBondInfo).orElse(ecmLinkedAccount);
-  }
-
-  public Optional<String> getLinkedFenceAccountToken(String userId, Provider provider) {
-    var linkedAccount = getLinkedFenceAccount(userId, provider);
-    var fenceAccountKey = linkedAccount.flatMap(this::getFenceAccountKey);
-    var fenceAccountKeyJson = fenceAccountKey.map(FenceAccountKey::getKeyJson);
-    var creds =
-        fenceAccountKeyJson.map(
-            (json) -> {
-              try {
-                return GoogleCredentials.fromStream(new ByteArrayInputStream(json.getBytes()));
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            });
-    return creds.map(GoogleCredentials::getAccessToken).map(AccessToken::getTokenValue);
   }
 
   private Optional<LinkedAccount> updateEcmWithBondInfo(LinkedAccount bondLinkedAccount) {

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -122,7 +122,7 @@ public class TokenProviderService extends ProviderService {
                 tokenEntry -> {
                   if (tokenEntry
                       .getExpiresAt()
-                      .isBefore(Instant.now().plus(1, ChronoUnit.MINUTES))) {
+                      .isAfter(Instant.now().plus(1, ChronoUnit.MINUTES))) {
                     logGetProviderAccessToken(userId, provider, auditLogEventBuilder);
                     return Optional.of(tokenEntry.getAccessToken());
                   }

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -11,7 +11,6 @@ import bio.terra.externalcreds.models.AccessTokenCacheEntry;
 import bio.terra.externalcreds.models.LinkedAccount;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
@@ -122,7 +121,9 @@ public class TokenProviderService extends ProviderService {
                 tokenEntry -> {
                   if (tokenEntry
                       .getExpiresAt()
-                      .isAfter(Instant.now().plus(1, ChronoUnit.MINUTES))) {
+                      .isAfter(
+                          Instant.now()
+                              .plus(externalCredsConfig.getAccessTokenExpirationBuffer()))) {
                     logGetProviderAccessToken(userId, provider, auditLogEventBuilder);
                     return Optional.of(tokenEntry.getAccessToken());
                   }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -20,6 +20,7 @@ externalcreds:
     datastore-database-id: ${BOND_DATASTORE_DATABASE_ID:}
   distributed-lock-configuration:
     lock-timeout: 30s
+  access-token-expiration-buffer: 5m
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}

--- a/service/src/main/resources/db/changelog/changesets/20240402_add_access_token_cache_table.yaml
+++ b/service/src/main/resources/db/changelog/changesets/20240402_add_access_token_cache_table.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add_access_token_cache_table"
+      author: tlangs
+      changes:
+        - createTable:
+            tableName: access_token_cache
+            columns:
+              - column:
+                  name: linked_account_id
+                  type: int
+                  constraints:
+                    nullable: false
+                    unique: true
+                    references: linked_account(id)
+                    foreignKeyName: fk_linked_account_id
+                    deleteCascade: true
+              - column:
+                  name: access_token
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires_at
+                  type: timestamp
+                  constraints:
+                    nullable: false

--- a/service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -38,3 +38,6 @@ databaseChangeLog:
   - include:
         file: changesets/20240307_add_fence_providers_to_enum.yaml
         relativeToChangelogFile: true
+  - include:
+        file: changesets/20240402_add_access_token_cache_table.yaml
+        relativeToChangelogFile: true

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -2,6 +2,7 @@ package bio.terra.externalcreds;
 
 import bio.terra.externalcreds.config.ProviderProperties;
 import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.models.AccessTokenCacheEntry;
 import bio.terra.externalcreds.models.FenceAccountKey;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
@@ -65,6 +66,14 @@ public class TestUtils {
     return new FenceAccountKey.Builder()
         .linkedAccountId(1)
         .keyJson("{\"key\": \"value\", \"private_key_id\": \"12345\"}")
+        .expiresAt(getRandomTimestamp().toInstant())
+        .build();
+  }
+
+  public static AccessTokenCacheEntry createRandomAccessTokenCacheEntry() {
+    return new AccessTokenCacheEntry.Builder()
+        .linkedAccountId(1)
+        .accessToken(UUID.randomUUID().toString())
         .expiresAt(getRandomTimestamp().toInstant())
         .build();
   }

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -17,6 +17,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.regex.Pattern;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
 
 public class TestUtils {
 
@@ -114,5 +116,11 @@ public class TestUtils {
       rootCause = rootCause.getCause();
     }
     return rootCause;
+  }
+
+  public static ClientRegistration createClientRegistration(Provider provider) {
+    return ClientRegistration.withRegistrationId(provider.toString())
+        .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+        .build();
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/FenceAccountKeyApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/FenceAccountKeyApiControllerTest.java
@@ -8,7 +8,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
-import bio.terra.common.iam.SamUserFactory;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.auditLogging.AuditLogEvent;
@@ -35,7 +34,7 @@ class FenceAccountKeyApiControllerTest extends BaseTest {
 
   @MockBean private FenceProviderService fenceProviderServiceMock;
 
-  @MockBean private SamUserFactory samUserFactoryMock;
+  @MockBean private ExternalCredsSamUserFactory samUserFactoryMock;
   @MockBean private FenceAccountKeyService fenceAccountKeyServiceMock;
   @MockBean private AuditLogger auditLoggerMock;
   private Provider provider = Provider.FENCE;
@@ -111,7 +110,7 @@ class FenceAccountKeyApiControllerTest extends BaseTest {
   }
 
   private void mockSamUser(String userId, String accessToken) {
-    when(samUserFactoryMock.from(any(HttpServletRequest.class), any(String.class)))
+    when(samUserFactoryMock.from(any(HttpServletRequest.class)))
         .thenReturn(new SamUser("email", userId, new BearerToken(accessToken)));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -397,7 +397,7 @@ class OauthApiControllerTest extends BaseTest {
       mockSamUser(userId, accessToken);
 
       when(tokenProviderServiceMock.getProviderAccessToken(any(), eq(provider), any()))
-          .thenReturn(Optional.of(githubAccessToken));
+          .thenReturn(githubAccessToken);
 
       mvc.perform(
               get("/api/oauth/v1/{provider}/access-token", provider)
@@ -414,7 +414,7 @@ class OauthApiControllerTest extends BaseTest {
       mockSamUser(userId, accessToken);
 
       when(tokenProviderServiceMock.getProviderAccessToken(any(), eq(provider), any()))
-          .thenReturn(Optional.empty());
+          .thenThrow(new NotFoundException("not found"));
 
       mvc.perform(
               get("/api/oauth/v1/{provider}/access-token", provider)

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -10,7 +10,6 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
-import bio.terra.common.iam.SamUserFactory;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.ExternalCredsException;
 import bio.terra.externalcreds.TestUtils;
@@ -64,7 +63,7 @@ class OauthApiControllerTest extends BaseTest {
   @Qualifier("fenceProviderService")
   private FenceProviderService fenceProviderServiceMock;
 
-  @MockBean private SamUserFactory samUserFactoryMock;
+  @MockBean private ExternalCredsSamUserFactory samUserFactoryMock;
   @MockBean private AuditLogger auditLoggerMock;
 
   private Provider provider = Provider.RAS;
@@ -442,7 +441,7 @@ class OauthApiControllerTest extends BaseTest {
   }
 
   private void mockSamUser(String userId, String accessToken) {
-    when(samUserFactoryMock.from(any(HttpServletRequest.class), any(String.class)))
+    when(samUserFactoryMock.from(any(HttpServletRequest.class)))
         .thenReturn(new SamUser("email", userId, new BearerToken(accessToken)));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -15,7 +15,6 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.common.exception.NotFoundException;
 import bio.terra.common.iam.BearerToken;
 import bio.terra.common.iam.SamUser;
-import bio.terra.common.iam.SamUserFactory;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.ExternalCredsException;
 import bio.terra.externalcreds.TestUtils;
@@ -62,7 +61,7 @@ class OidcApiControllerTest extends BaseTest {
   @Qualifier("passportProviderService")
   private PassportProviderService passportProviderServiceMock;
 
-  @MockBean private SamUserFactory samUserFactoryMock;
+  @MockBean private ExternalCredsSamUserFactory samUserFactoryMock;
   @MockBean private PassportService passportServiceMock;
   @MockBean private AuditLogger auditLoggerMock;
   private Provider provider = Provider.RAS;
@@ -383,7 +382,7 @@ class OidcApiControllerTest extends BaseTest {
   }
 
   private void mockSamUser(String userId, String accessToken) {
-    when(samUserFactoryMock.from(any(HttpServletRequest.class), any(String.class)))
+    when(samUserFactoryMock.from(any(HttpServletRequest.class)))
         .thenReturn(new SamUser("email", userId, new BearerToken(accessToken)));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAOTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
-import bio.terra.externalcreds.generated.model.Provider;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
@@ -21,7 +20,7 @@ class AccessTokenCacheDAOTest extends BaseTest {
   @Test
   void testGetMissingAccessTokenCacheEntry() {
     var shouldBeEmpty =
-        accessTokenCacheDAO.getAccessTokenCacheEntry("nonexistent_user_id", Provider.RAS);
+        accessTokenCacheDAO.getAccessTokenCacheEntry(TestUtils.createRandomLinkedAccount());
     assertEmpty(shouldBeEmpty);
   }
 
@@ -42,9 +41,7 @@ class AccessTokenCacheDAOTest extends BaseTest {
 
       assertEquals(accessTokenCacheEntry, savedAccessTokenCacheEntry);
 
-      var loadedAccessTokenCacheEntry =
-          accessTokenCacheDAO.getAccessTokenCacheEntry(
-              savedAccount.getUserId(), savedAccount.getProvider());
+      var loadedAccessTokenCacheEntry = accessTokenCacheDAO.getAccessTokenCacheEntry(savedAccount);
       assertEquals(Optional.of(savedAccessTokenCacheEntry), loadedAccessTokenCacheEntry);
 
       var loadedByLinkedAccount = accessTokenCacheDAO.getAccessTokenCacheEntry(savedAccount);
@@ -91,13 +88,9 @@ class AccessTokenCacheDAOTest extends BaseTest {
           TestUtils.createRandomAccessTokenCacheEntry()
               .withLinkedAccountId(savedAccount.getId().get()));
 
-      assertPresent(
-          accessTokenCacheDAO.getAccessTokenCacheEntry(
-              savedAccount.getUserId(), savedAccount.getProvider()));
+      assertPresent(accessTokenCacheDAO.getAccessTokenCacheEntry(savedAccount));
       assertTrue(accessTokenCacheDAO.deleteAccessTokenCacheEntry(savedAccount.getId().get()));
-      assertEmpty(
-          accessTokenCacheDAO.getAccessTokenCacheEntry(
-              savedAccount.getUserId(), savedAccount.getProvider()));
+      assertEmpty(accessTokenCacheDAO.getAccessTokenCacheEntry(savedAccount));
     }
 
     @Test

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/AccessTokenCacheDAOTest.java
@@ -1,0 +1,108 @@
+package bio.terra.externalcreds.dataAccess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.generated.model.Provider;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class AccessTokenCacheDAOTest extends BaseTest {
+
+  @Autowired private LinkedAccountDAO linkedAccountDAO;
+  @Autowired private AccessTokenCacheDAO accessTokenCacheDAO;
+
+  @Test
+  void testGetMissingAccessTokenCacheEntry() {
+    var shouldBeEmpty =
+        accessTokenCacheDAO.getAccessTokenCacheEntry("nonexistent_user_id", Provider.RAS);
+    assertEmpty(shouldBeEmpty);
+  }
+
+  @Nested
+  class CreateAccessTokenCacheEntry {
+
+    @Test
+    void testCreateAndGetAccessTokenCacheEntry() {
+      var savedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      assertPresent(savedAccount.getId());
+
+      var accessTokenCacheEntry =
+          TestUtils.createRandomAccessTokenCacheEntry()
+              .withLinkedAccountId(savedAccount.getId().get());
+      var savedAccessTokenCacheEntry =
+          accessTokenCacheDAO.upsertAccessTokenCacheEntry(accessTokenCacheEntry);
+
+      assertEquals(accessTokenCacheEntry, savedAccessTokenCacheEntry);
+
+      var loadedAccessTokenCacheEntry =
+          accessTokenCacheDAO.getAccessTokenCacheEntry(
+              savedAccount.getUserId(), savedAccount.getProvider());
+      assertEquals(Optional.of(savedAccessTokenCacheEntry), loadedAccessTokenCacheEntry);
+
+      var loadedByLinkedAccount = accessTokenCacheDAO.getAccessTokenCacheEntry(savedAccount);
+      assertEquals(Optional.of(savedAccessTokenCacheEntry), loadedByLinkedAccount);
+    }
+
+    @Test
+    void testUpsertAccessTokenCacheEntry() {
+      var savedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      assertPresent(savedAccount.getId());
+
+      var accessTokenCacheEntry =
+          TestUtils.createRandomAccessTokenCacheEntry()
+              .withLinkedAccountId(savedAccount.getId().get());
+      var savedAccessTokenCacheEntry =
+          accessTokenCacheDAO.upsertAccessTokenCacheEntry(accessTokenCacheEntry);
+
+      assertEquals(accessTokenCacheEntry, savedAccessTokenCacheEntry);
+
+      var newToken = UUID.randomUUID().toString();
+      var newExpiresAt = accessTokenCacheEntry.getExpiresAt().plusSeconds(1);
+
+      accessTokenCacheDAO.upsertAccessTokenCacheEntry(
+          accessTokenCacheEntry.withAccessToken(newToken).withExpiresAt(newExpiresAt));
+
+      var updatedAccessTokenCacheEntry = accessTokenCacheDAO.getAccessTokenCacheEntry(savedAccount);
+      assertPresent(updatedAccessTokenCacheEntry);
+      assertEquals(
+          accessTokenCacheEntry.withAccessToken(newToken).withExpiresAt(newExpiresAt),
+          updatedAccessTokenCacheEntry.get());
+    }
+  }
+
+  @Nested
+  class DeleteAccessTokenCacheEntry {
+
+    @Test
+    void testDeleteAccessTokenCacheEntry() {
+      var savedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      assertPresent(savedAccount.getId());
+      accessTokenCacheDAO.upsertAccessTokenCacheEntry(
+          TestUtils.createRandomAccessTokenCacheEntry()
+              .withLinkedAccountId(savedAccount.getId().get()));
+
+      assertPresent(
+          accessTokenCacheDAO.getAccessTokenCacheEntry(
+              savedAccount.getUserId(), savedAccount.getProvider()));
+      assertTrue(accessTokenCacheDAO.deleteAccessTokenCacheEntry(savedAccount.getId().get()));
+      assertEmpty(
+          accessTokenCacheDAO.getAccessTokenCacheEntry(
+              savedAccount.getUserId(), savedAccount.getProvider()));
+    }
+
+    @Test
+    void testDeleteNonexistentAccessTokenCacheEntry() {
+      assertFalse(accessTokenCacheDAO.deleteAccessTokenCacheEntry(-1));
+    }
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/services/AccessTokenCacheServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AccessTokenCacheServiceTest.java
@@ -1,0 +1,223 @@
+package bio.terra.externalcreds.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.auditLogging.AuditLogEvent;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.dataAccess.AccessTokenCacheDAO;
+import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.models.AccessTokenCacheEntry;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+
+class AccessTokenCacheServiceTest extends BaseTest {
+
+  @Autowired private AccessTokenCacheService accessTokenCacheService;
+
+  @MockBean private LinkedAccountService linkedAccountService;
+  @MockBean private ProviderTokenClientCache providerTokenClientCacheMock;
+  @MockBean private OAuth2Service oAuth2ServiceMock;
+  @MockBean private AccessTokenCacheDAO accessTokenCacheDAO;
+  @MockBean private AuditLogger auditLoggerMock;
+
+  private final String clientIP = "127.0.0.1";
+  private final Random random = new Random();
+
+  @Test
+  void testGetProviderAccessTokenSuccess() {
+    var provider = Provider.GITHUB;
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
+    var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
+
+    when(linkedAccountService.getLinkedAccount(linkedAccount.getUserId(), provider))
+        .thenReturn(Optional.of(linkedAccount));
+    when(accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount)).thenReturn(Optional.empty());
+    when(accessTokenCacheDAO.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
+    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(clientRegistration);
+
+    var accessToken = "tokenValue";
+    var updatedRefreshToken = "newRefreshToken";
+    var oAuth2TokenResponse =
+        OAuth2AccessTokenResponse.withToken(accessToken)
+            .refreshToken(updatedRefreshToken)
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .build();
+    when(oAuth2ServiceMock.authorizeWithRefreshToken(
+            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+        .thenReturn(oAuth2TokenResponse);
+    var updatedLinkedAccount =
+        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
+    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
+        .thenReturn(updatedLinkedAccount);
+
+    var auditLogEventBuilder =
+        new AuditLogEvent.Builder()
+            .provider(provider)
+            .userId(linkedAccount.getUserId())
+            .clientIP(clientIP);
+    String response =
+        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+    assertEquals(response, accessToken);
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
+                .provider(provider)
+                .userId(linkedAccount.getUserId())
+                .clientIP(clientIP)
+                .externalUserId(linkedAccount.getExternalUserId())
+                .build());
+  }
+
+  @Test
+  void testGetFenceProviderAccessTokenSuccess() {
+    var provider = Provider.FENCE;
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
+    var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
+
+    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(clientRegistration);
+    when(accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount)).thenReturn(Optional.empty());
+    when(accessTokenCacheDAO.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
+
+    var accessToken = "tokenValue";
+    var updatedRefreshToken = "newRefreshToken";
+    var oAuth2TokenResponse =
+        OAuth2AccessTokenResponse.withToken(accessToken)
+            .refreshToken(updatedRefreshToken)
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .build();
+    when(oAuth2ServiceMock.authorizeWithRefreshToken(
+            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+        .thenReturn(oAuth2TokenResponse);
+    var updatedLinkedAccount =
+        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
+    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
+        .thenReturn(updatedLinkedAccount);
+
+    var auditLogEventBuilder =
+        new AuditLogEvent.Builder()
+            .provider(provider)
+            .userId(linkedAccount.getUserId())
+            .clientIP(clientIP);
+    String response =
+        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+    assertEquals(response, accessToken);
+    verify(oAuth2ServiceMock, never())
+        .authorizationCodeExchange(any(), any(), any(), any(), any(), any());
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
+                .provider(provider)
+                .userId(linkedAccount.getUserId())
+                .clientIP(clientIP)
+                .externalUserId(linkedAccount.getExternalUserId())
+                .build());
+  }
+
+  @Test
+  void testGetFenceProviderAccessTokenCacheSuccess() {
+    var provider = Provider.FENCE;
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
+    var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
+    var accessToken = UUID.randomUUID().toString();
+    var tokenExpiresAt = Instant.now().plus(1, ChronoUnit.HOURS);
+
+    when(accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount))
+        .thenReturn(
+            Optional.of(
+                new AccessTokenCacheEntry.Builder()
+                    .linkedAccountId(linkedAccount.getId().get())
+                    .accessToken(accessToken)
+                    .expiresAt(tokenExpiresAt)
+                    .build()));
+    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(clientRegistration);
+    when(accessTokenCacheDAO.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
+
+    var auditLogEventBuilder =
+        new AuditLogEvent.Builder()
+            .provider(provider)
+            .userId(linkedAccount.getUserId())
+            .clientIP(clientIP);
+    String response =
+        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+    assertEquals(response, accessToken);
+    verify(auditLoggerMock, never()).logEvent(any());
+  }
+
+  @Test
+  void testGetFenceProviderAccessTokenCacheExpired() {
+    var provider = Provider.FENCE;
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
+    var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
+    var accessToken = UUID.randomUUID().toString();
+    var tokenExpiresAt = Instant.now().minus(1, ChronoUnit.HOURS);
+
+    when(accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount))
+        .thenReturn(
+            Optional.of(
+                new AccessTokenCacheEntry.Builder()
+                    .linkedAccountId(linkedAccount.getId().get())
+                    .accessToken(accessToken)
+                    .expiresAt(tokenExpiresAt)
+                    .build()));
+    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(clientRegistration);
+    when(accessTokenCacheDAO.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
+
+    var updatedRefreshToken = "newRefreshToken";
+    var oAuth2TokenResponse =
+        OAuth2AccessTokenResponse.withToken(accessToken)
+            .refreshToken(updatedRefreshToken)
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .build();
+    when(oAuth2ServiceMock.authorizeWithRefreshToken(
+            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+        .thenReturn(oAuth2TokenResponse);
+    var updatedLinkedAccount =
+        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
+    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
+        .thenReturn(updatedLinkedAccount);
+
+    var auditLogEventBuilder =
+        new AuditLogEvent.Builder()
+            .provider(provider)
+            .userId(linkedAccount.getUserId())
+            .clientIP(clientIP);
+    String response =
+        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+    assertEquals(response, accessToken);
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
+                .provider(provider)
+                .userId(linkedAccount.getUserId())
+                .clientIP(clientIP)
+                .externalUserId(linkedAccount.getExternalUserId())
+                .build());
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
@@ -1,9 +1,6 @@
 package bio.terra.externalcreds.services;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,29 +12,22 @@ import bio.terra.externalcreds.auditLogging.AuditLogEvent.Builder;
 import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.model.Provider;
-import bio.terra.externalcreds.models.AccessTokenCacheEntry;
 import bio.terra.externalcreds.models.LinkedAccount;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.*;
-import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
 
 public class TokenProviderServiceTest extends BaseTest {
 
   @Autowired private TokenProviderService tokenProviderService;
   @MockBean private AuditLogger auditLoggerMock;
   @MockBean private LinkedAccountService linkedAccountService;
-  @MockBean private FenceProviderService fenceProviderService;
   @MockBean private ProviderTokenClientCache providerTokenClientCacheMock;
   @MockBean private OAuth2Service oAuth2ServiceMock;
-  @MockBean private AccessTokenCacheService accessTokenCacheService;
 
   private final Provider provider = Provider.GITHUB;
   private final String userId = UUID.randomUUID().toString();
@@ -78,198 +68,6 @@ public class TokenProviderServiceTest extends BaseTest {
   }
 
   @Test
-  void testGetProviderAccessTokenSuccess() {
-    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
-    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
-
-    when(linkedAccountService.getLinkedAccount(linkedAccount.getUserId(), provider))
-        .thenReturn(Optional.of(linkedAccount));
-    when(accessTokenCacheService.getAccessTokenCacheEntry(
-            linkedAccount.getUserId(), linkedAccount.getProvider()))
-        .thenReturn(Optional.empty());
-    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
-        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
-    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-        .thenReturn(clientRegistration);
-
-    var accessToken = "tokenValue";
-    var updatedRefreshToken = "newRefreshToken";
-    var oAuth2TokenResponse =
-        OAuth2AccessTokenResponse.withToken(accessToken)
-            .refreshToken(updatedRefreshToken)
-            .tokenType(OAuth2AccessToken.TokenType.BEARER)
-            .build();
-    when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
-        .thenReturn(oAuth2TokenResponse);
-    var updatedLinkedAccount =
-        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
-    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
-        .thenReturn(updatedLinkedAccount);
-
-    var auditLogEventBuilder =
-        new Builder().provider(provider).userId(linkedAccount.getUserId()).clientIP(clientIP);
-    Optional<String> response =
-        tokenProviderService.getProviderAccessToken(
-            linkedAccount.getUserId(), provider, auditLogEventBuilder);
-    assertEquals(response.get(), accessToken);
-    verify(auditLoggerMock)
-        .logEvent(
-            new AuditLogEvent.Builder()
-                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
-                .provider(provider)
-                .userId(linkedAccount.getUserId())
-                .clientIP(clientIP)
-                .externalUserId(linkedAccount.getExternalUserId())
-                .build());
-  }
-
-  @Test
-  void testGetFenceProviderAccessTokenSuccess() {
-    var provider = Provider.FENCE;
-    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
-    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
-
-    when(fenceProviderService.getLinkedFenceAccount(linkedAccount.getUserId(), provider))
-        .thenReturn(Optional.of(linkedAccount));
-    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-        .thenReturn(clientRegistration);
-    when(accessTokenCacheService.getAccessTokenCacheEntry(
-            linkedAccount.getUserId(), linkedAccount.getProvider()))
-        .thenReturn(Optional.empty());
-    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
-        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
-
-    var accessToken = "tokenValue";
-    var updatedRefreshToken = "newRefreshToken";
-    var oAuth2TokenResponse =
-        OAuth2AccessTokenResponse.withToken(accessToken)
-            .refreshToken(updatedRefreshToken)
-            .tokenType(OAuth2AccessToken.TokenType.BEARER)
-            .build();
-    when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
-        .thenReturn(oAuth2TokenResponse);
-    var updatedLinkedAccount =
-        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
-    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
-        .thenReturn(updatedLinkedAccount);
-
-    var auditLogEventBuilder =
-        new Builder().provider(provider).userId(linkedAccount.getUserId()).clientIP(clientIP);
-    Optional<String> response =
-        tokenProviderService.getProviderAccessToken(
-            linkedAccount.getUserId(), provider, auditLogEventBuilder);
-    assertEquals(response.get(), accessToken);
-    verify(oAuth2ServiceMock, never())
-        .authorizationCodeExchange(any(), any(), any(), any(), any(), any());
-    verify(auditLoggerMock)
-        .logEvent(
-            new AuditLogEvent.Builder()
-                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
-                .provider(provider)
-                .userId(linkedAccount.getUserId())
-                .clientIP(clientIP)
-                .externalUserId(linkedAccount.getExternalUserId())
-                .build());
-  }
-
-  @Test
-  void testGetFenceProviderAccessTokenCacheSuccess() {
-    var provider = Provider.FENCE;
-    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
-    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
-    var accessToken = UUID.randomUUID().toString();
-    var tokenExpiresAt = Instant.now().plus(1, ChronoUnit.HOURS);
-
-    when(fenceProviderService.getLinkedFenceAccount(linkedAccount.getUserId(), provider))
-        .thenReturn(Optional.of(linkedAccount));
-    when(accessTokenCacheService.getAccessTokenCacheEntry(
-            linkedAccount.getUserId(), linkedAccount.getProvider()))
-        .thenReturn(
-            Optional.of(
-                new AccessTokenCacheEntry.Builder()
-                    .linkedAccountId(linkedAccount.getId().get())
-                    .accessToken(accessToken)
-                    .expiresAt(tokenExpiresAt)
-                    .build()));
-    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-        .thenReturn(clientRegistration);
-    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
-        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
-
-    var auditLogEventBuilder =
-        new Builder().provider(provider).userId(linkedAccount.getUserId()).clientIP(clientIP);
-    Optional<String> response =
-        tokenProviderService.getProviderAccessToken(
-            linkedAccount.getUserId(), provider, auditLogEventBuilder);
-    assertEquals(response.get(), accessToken);
-    verify(auditLoggerMock)
-        .logEvent(
-            new AuditLogEvent.Builder()
-                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
-                .provider(provider)
-                .userId(linkedAccount.getUserId())
-                .clientIP(clientIP)
-                .build());
-  }
-
-  @Test
-  void testGetFenceProviderAccessTokenCacheExpired() {
-    var provider = Provider.FENCE;
-    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
-    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
-    var accessToken = UUID.randomUUID().toString();
-    var tokenExpiresAt = Instant.now().minus(1, ChronoUnit.HOURS);
-
-    when(fenceProviderService.getLinkedFenceAccount(linkedAccount.getUserId(), provider))
-        .thenReturn(Optional.of(linkedAccount));
-    when(accessTokenCacheService.getAccessTokenCacheEntry(
-            linkedAccount.getUserId(), linkedAccount.getProvider()))
-        .thenReturn(
-            Optional.of(
-                new AccessTokenCacheEntry.Builder()
-                    .linkedAccountId(linkedAccount.getId().get())
-                    .accessToken(accessToken)
-                    .expiresAt(tokenExpiresAt)
-                    .build()));
-    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
-        .thenReturn(clientRegistration);
-    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
-        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
-
-    var updatedRefreshToken = "newRefreshToken";
-    var oAuth2TokenResponse =
-        OAuth2AccessTokenResponse.withToken(accessToken)
-            .refreshToken(updatedRefreshToken)
-            .tokenType(OAuth2AccessToken.TokenType.BEARER)
-            .build();
-    when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
-        .thenReturn(oAuth2TokenResponse);
-    var updatedLinkedAccount =
-        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
-    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
-        .thenReturn(updatedLinkedAccount);
-
-    var auditLogEventBuilder =
-        new Builder().provider(provider).userId(linkedAccount.getUserId()).clientIP(clientIP);
-    Optional<String> response =
-        tokenProviderService.getProviderAccessToken(
-            linkedAccount.getUserId(), provider, auditLogEventBuilder);
-    assertEquals(response.get(), accessToken);
-    verify(auditLoggerMock)
-        .logEvent(
-            new AuditLogEvent.Builder()
-                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
-                .provider(provider)
-                .userId(linkedAccount.getUserId())
-                .clientIP(clientIP)
-                .externalUserId(linkedAccount.getExternalUserId())
-                .build());
-  }
-
-  @Test
   void testGetProviderAccessTokenNoLinkedAccount() {
     var userId = "fakeUserId";
     var provider = Provider.GITHUB;
@@ -292,7 +90,7 @@ public class TokenProviderServiceTest extends BaseTest {
   @Test
   void testGetProviderAccessTokenUnauthorized() {
     var linkedAccount = TestUtils.createRandomLinkedAccount(provider);
-    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
+    var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
 
     when(linkedAccountService.getLinkedAccount(linkedAccount.getUserId(), provider))
         .thenReturn(Optional.of(linkedAccount));
@@ -308,11 +106,5 @@ public class TokenProviderServiceTest extends BaseTest {
         () ->
             tokenProviderService.getProviderAccessToken(
                 linkedAccount.getUserId(), provider, auditLogEventBuilder));
-  }
-
-  private ClientRegistration createClientRegistration(Provider provider) {
-    return ClientRegistration.withRegistrationId(provider.toString())
-        .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
-        .build();
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
@@ -2,6 +2,8 @@ package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,8 +15,12 @@ import bio.terra.externalcreds.auditLogging.AuditLogEvent.Builder;
 import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
 import bio.terra.externalcreds.generated.model.Provider;
+import bio.terra.externalcreds.models.AccessTokenCacheEntry;
 import bio.terra.externalcreds.models.LinkedAccount;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
+import java.util.Random;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,12 +37,15 @@ public class TokenProviderServiceTest extends BaseTest {
   @MockBean private FenceProviderService fenceProviderService;
   @MockBean private ProviderTokenClientCache providerTokenClientCacheMock;
   @MockBean private OAuth2Service oAuth2ServiceMock;
+  @MockBean private AccessTokenCacheService accessTokenCacheService;
 
   private final Provider provider = Provider.GITHUB;
   private final String userId = UUID.randomUUID().toString();
   private final String clientIP = "127.0.0.1";
   private final AuditLogEvent.Builder auditLogEventBuilder =
       new Builder().provider(provider).userId(userId).clientIP(clientIP);
+
+  private Random random = new Random();
 
   @Test
   void testLogLinkCreateSuccess() {
@@ -70,11 +79,16 @@ public class TokenProviderServiceTest extends BaseTest {
 
   @Test
   void testGetProviderAccessTokenSuccess() {
-    var linkedAccount = TestUtils.createRandomLinkedAccount(provider);
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
     var clientRegistration = createClientRegistration(linkedAccount.getProvider());
 
     when(linkedAccountService.getLinkedAccount(linkedAccount.getUserId(), provider))
         .thenReturn(Optional.of(linkedAccount));
+    when(accessTokenCacheService.getAccessTokenCacheEntry(
+            linkedAccount.getUserId(), linkedAccount.getProvider()))
+        .thenReturn(Optional.empty());
+    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(clientRegistration);
 
@@ -113,15 +127,117 @@ public class TokenProviderServiceTest extends BaseTest {
   @Test
   void testGetFenceProviderAccessTokenSuccess() {
     var provider = Provider.FENCE;
-    var linkedAccount = TestUtils.createRandomLinkedAccount(provider);
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
     var clientRegistration = createClientRegistration(linkedAccount.getProvider());
 
     when(fenceProviderService.getLinkedFenceAccount(linkedAccount.getUserId(), provider))
         .thenReturn(Optional.of(linkedAccount));
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(clientRegistration);
+    when(accessTokenCacheService.getAccessTokenCacheEntry(
+            linkedAccount.getUserId(), linkedAccount.getProvider()))
+        .thenReturn(Optional.empty());
+    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
 
     var accessToken = "tokenValue";
+    var updatedRefreshToken = "newRefreshToken";
+    var oAuth2TokenResponse =
+        OAuth2AccessTokenResponse.withToken(accessToken)
+            .refreshToken(updatedRefreshToken)
+            .tokenType(OAuth2AccessToken.TokenType.BEARER)
+            .build();
+    when(oAuth2ServiceMock.authorizeWithRefreshToken(
+            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+        .thenReturn(oAuth2TokenResponse);
+    var updatedLinkedAccount =
+        linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
+    when(linkedAccountService.upsertLinkedAccount(updatedLinkedAccount))
+        .thenReturn(updatedLinkedAccount);
+
+    var auditLogEventBuilder =
+        new Builder().provider(provider).userId(linkedAccount.getUserId()).clientIP(clientIP);
+    Optional<String> response =
+        tokenProviderService.getProviderAccessToken(
+            linkedAccount.getUserId(), provider, auditLogEventBuilder);
+    assertEquals(response.get(), accessToken);
+    verify(oAuth2ServiceMock, never())
+        .authorizationCodeExchange(any(), any(), any(), any(), any(), any());
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
+                .provider(provider)
+                .userId(linkedAccount.getUserId())
+                .clientIP(clientIP)
+                .externalUserId(linkedAccount.getExternalUserId())
+                .build());
+  }
+
+  @Test
+  void testGetFenceProviderAccessTokenCacheSuccess() {
+    var provider = Provider.FENCE;
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
+    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
+    var accessToken = UUID.randomUUID().toString();
+    var tokenExpiresAt = Instant.now().plus(1, ChronoUnit.HOURS);
+
+    when(fenceProviderService.getLinkedFenceAccount(linkedAccount.getUserId(), provider))
+        .thenReturn(Optional.of(linkedAccount));
+    when(accessTokenCacheService.getAccessTokenCacheEntry(
+            linkedAccount.getUserId(), linkedAccount.getProvider()))
+        .thenReturn(
+            Optional.of(
+                new AccessTokenCacheEntry.Builder()
+                    .linkedAccountId(linkedAccount.getId().get())
+                    .accessToken(accessToken)
+                    .expiresAt(tokenExpiresAt)
+                    .build()));
+    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(clientRegistration);
+    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
+
+    var auditLogEventBuilder =
+        new Builder().provider(provider).userId(linkedAccount.getUserId()).clientIP(clientIP);
+    Optional<String> response =
+        tokenProviderService.getProviderAccessToken(
+            linkedAccount.getUserId(), provider, auditLogEventBuilder);
+    assertEquals(response.get(), accessToken);
+    verify(auditLoggerMock)
+        .logEvent(
+            new AuditLogEvent.Builder()
+                .auditLogEventType(AuditLogEventType.GetProviderAccessToken)
+                .provider(provider)
+                .userId(linkedAccount.getUserId())
+                .clientIP(clientIP)
+                .build());
+  }
+
+  @Test
+  void testGetFenceProviderAccessTokenCacheExpired() {
+    var provider = Provider.FENCE;
+    var linkedAccount = TestUtils.createRandomLinkedAccount(provider).withId(random.nextInt());
+    var clientRegistration = createClientRegistration(linkedAccount.getProvider());
+    var accessToken = UUID.randomUUID().toString();
+    var tokenExpiresAt = Instant.now().minus(1, ChronoUnit.HOURS);
+
+    when(fenceProviderService.getLinkedFenceAccount(linkedAccount.getUserId(), provider))
+        .thenReturn(Optional.of(linkedAccount));
+    when(accessTokenCacheService.getAccessTokenCacheEntry(
+            linkedAccount.getUserId(), linkedAccount.getProvider()))
+        .thenReturn(
+            Optional.of(
+                new AccessTokenCacheEntry.Builder()
+                    .linkedAccountId(linkedAccount.getId().get())
+                    .accessToken(accessToken)
+                    .expiresAt(tokenExpiresAt)
+                    .build()));
+    when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+        .thenReturn(clientRegistration);
+    when(accessTokenCacheService.upsertAccessTokenCacheEntry(any()))
+        .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
+
     var updatedRefreshToken = "newRefreshToken";
     var oAuth2TokenResponse =
         OAuth2AccessTokenResponse.withToken(accessToken)


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1126

What:

ECM _MUST_ cache access tokens. Getting an access token from fence providers for every request _tanks_ fence provider performance. Glad we caught this in pre-prod testing!

  
