### PR TITLE
ID-1199 Include proper scopes in token retrieval

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/services/FenceKeyRetriever.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/FenceKeyRetriever.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataAccessException;
@@ -129,7 +130,9 @@ public class FenceKeyRetriever {
     var providerProperties = externalCredsConfig.getProviderProperties(linkedAccount.getProvider());
     var accessToken =
         accessTokenCacheService.getLinkedAccountAccessToken(
-            linkedAccount, new AuditLogEvent.Builder());
+            linkedAccount,
+            new HashSet<>(providerProperties.getScopes()),
+            new AuditLogEvent.Builder());
     var keyEndpoint = providerProperties.getKeyEndpoint();
     if (keyEndpoint.isEmpty()) {
       throw new IllegalArgumentException(

--- a/service/src/main/java/bio/terra/externalcreds/services/OAuth2Service.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/OAuth2Service.java
@@ -117,7 +117,7 @@ public class OAuth2Service {
    *     token in this response it should replace the original refresh token which is likely invalid
    */
   public OAuth2AccessTokenResponse authorizeWithRefreshToken(
-      ClientRegistration providerClient, OAuth2RefreshToken refreshToken) {
+      ClientRegistration providerClient, OAuth2RefreshToken refreshToken, Set<String> scopes) {
     // the OAuth2RefreshTokenGrantRequest requires an access token to be specified but
     // it does not have to be a valid one so create a dummy
     var dummyAccessToken =
@@ -125,7 +125,7 @@ public class OAuth2Service {
             OAuth2AccessToken.TokenType.BEARER, "dummy", Instant.EPOCH, Instant.now());
 
     var refreshTokenGrantRequest =
-        new OAuth2RefreshTokenGrantRequest(providerClient, dummyAccessToken, refreshToken);
+        new OAuth2RefreshTokenGrantRequest(providerClient, dummyAccessToken, refreshToken, scopes);
 
     var refreshTokenTokenResponseClient = new DefaultRefreshTokenTokenResponseClient();
 

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportProviderService.java
@@ -207,7 +207,9 @@ public class PassportProviderService extends ProviderService {
         providerOAuthClientCache.getProviderClient(linkedAccount.getProvider());
     var accessTokenResponse =
         oAuth2Service.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            Collections.emptySet());
 
     // save the linked account with the new refresh token and extracted passport
     var linkedAccountWithRefreshToken =

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
@@ -280,7 +281,9 @@ public class ProviderService {
     var providerClient = providerOAuthClientCache.getProviderClient(linkedAccount.getProvider());
     var accessToken =
         oAuth2Service.authorizeWithRefreshToken(
-            providerClient, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null));
+            providerClient,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            Collections.emptySet());
     var keyEndpoint = providerProperties.getKeyEndpoint();
     if (keyEndpoint.isEmpty()) {
       throw new IllegalArgumentException(

--- a/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/TokenProviderService.java
@@ -104,6 +104,8 @@ public class TokenProviderService extends ProviderService {
                                 + "Please go to the Terra Profile page External Identities tab "
                                 + "to link your account for this provider.",
                             userId, provider)));
-    return accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+    var providerProperties = externalCredsConfig.getProviderProperties(provider);
+    return accessTokenCacheService.getLinkedAccountAccessToken(
+        linkedAccount, new HashSet<>(providerProperties.getScopes()), auditLogEventBuilder);
   }
 }

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -16,7 +16,7 @@ externalcreds:
       clientId: "${FENCE_CLIENT_ID}"
       clientSecret: "${FENCE_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid", "user" ]
+      scopes: [ "openid", "user", "google_credentials" ]
       externalIdClaim: "username"
       issuer: "${FENCE_BASE_URL:https://staging.gen3.biodatacatalyst.nhlbi.nih.gov/user}"
       revokeEndpoint: "${externalcreds.providers.fence.issuer}/oauth2/revoke"
@@ -28,7 +28,7 @@ externalcreds:
       clientId: "${DCF_FENCE_CLIENT_ID}"
       clientSecret: "${DCF_FENCE_CLIENT_SECRET}"
       linkLifespan: "15d"
-      scopes: [ "openid", "user" ]
+      scopes: [ "openid", "user", "google_credentials" ]
       externalIdClaim: "username"
       issuer: "${DCF_FENCE_BASE_URL:https://nci-crdc-staging.datacommons.io/user}"
       revokeEndpoint: "${externalcreds.providers.dcf-fence.issuer}/oauth2/revoke"
@@ -40,7 +40,7 @@ externalcreds:
       clientId: "${KIDS_FIRST_CLIENT_ID}"
       clientSecret: "${KIDS_FIRST_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid", "user" ]
+      scopes: [ "openid", "user", "google_credentials" ]
       externalIdClaim: "username"
       issuer: "${KIDS_FIRST_BASE_URL:https://gen3staging.kidsfirstdrc.org/user}"
       revokeEndpoint: "${externalcreds.providers.kids-first.issuer}/oauth2/revoke"
@@ -52,7 +52,7 @@ externalcreds:
       clientId: "${ANVIL_CLIENT_ID}"
       clientSecret: "${ANVIL_CLIENT_SECRET}"
       linkLifespan: "30d"
-      scopes: [ "openid", "user" ]
+      scopes: [ "openid", "user", "google_credentials" ]
       externalIdClaim: "username"
       issuer: "${ANVIL_BASE_URL:https://staging.theanvil.io/user}"
       revokeEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/revoke"

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -93,7 +93,8 @@ public class TestUtils {
           .setTokenEndpoint("http://token")
           .setExternalIdClaim("preferred_username")
           .setUserNameAttributeName("username")
-          .setUserInfoEndpoint("http://userinfo");
+          .setUserInfoEndpoint("http://userinfo")
+          .setScopes(List.of("scope1", "scope2"));
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }

--- a/service/src/test/java/bio/terra/externalcreds/services/AccessTokenCacheServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AccessTokenCacheServiceTest.java
@@ -18,6 +18,7 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,6 +54,7 @@ class AccessTokenCacheServiceTest extends BaseTest {
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(clientRegistration);
 
+    var scopes = Set.of("scope1", "scope2");
     var accessToken = "tokenValue";
     var updatedRefreshToken = "newRefreshToken";
     var oAuth2TokenResponse =
@@ -61,7 +63,9 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .tokenType(OAuth2AccessToken.TokenType.BEARER)
             .build();
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            scopes))
         .thenReturn(oAuth2TokenResponse);
     var updatedLinkedAccount =
         linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
@@ -74,7 +78,8 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .userId(linkedAccount.getUserId())
             .clientIP(clientIP);
     String response =
-        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+        accessTokenCacheService.getLinkedAccountAccessToken(
+            linkedAccount, scopes, auditLogEventBuilder);
     assertEquals(response, accessToken);
     verify(auditLoggerMock)
         .logEvent(
@@ -99,6 +104,7 @@ class AccessTokenCacheServiceTest extends BaseTest {
     when(accessTokenCacheDAO.upsertAccessTokenCacheEntry(any()))
         .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
 
+    var scopes = Set.of("scope1", "scope2");
     var accessToken = "tokenValue";
     var updatedRefreshToken = "newRefreshToken";
     var oAuth2TokenResponse =
@@ -107,7 +113,9 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .tokenType(OAuth2AccessToken.TokenType.BEARER)
             .build();
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            scopes))
         .thenReturn(oAuth2TokenResponse);
     var updatedLinkedAccount =
         linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
@@ -120,7 +128,8 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .userId(linkedAccount.getUserId())
             .clientIP(clientIP);
     String response =
-        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+        accessTokenCacheService.getLinkedAccountAccessToken(
+            linkedAccount, scopes, auditLogEventBuilder);
     assertEquals(response, accessToken);
     verify(oAuth2ServiceMock, never())
         .authorizationCodeExchange(any(), any(), any(), any(), any(), any());
@@ -142,6 +151,7 @@ class AccessTokenCacheServiceTest extends BaseTest {
     var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
     var accessToken = UUID.randomUUID().toString();
     var tokenExpiresAt = Instant.now().plus(1, ChronoUnit.HOURS);
+    var scopes = Set.of("scope1", "scope2");
 
     when(accessTokenCacheDAO.getAccessTokenCacheEntry(linkedAccount))
         .thenReturn(
@@ -162,7 +172,8 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .userId(linkedAccount.getUserId())
             .clientIP(clientIP);
     String response =
-        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+        accessTokenCacheService.getLinkedAccountAccessToken(
+            linkedAccount, scopes, auditLogEventBuilder);
     assertEquals(response, accessToken);
     verify(auditLoggerMock, never()).logEvent(any());
   }
@@ -188,6 +199,7 @@ class AccessTokenCacheServiceTest extends BaseTest {
     when(accessTokenCacheDAO.upsertAccessTokenCacheEntry(any()))
         .thenAnswer(invocation -> invocation.getArgument(0, AccessTokenCacheEntry.class));
 
+    var scopes = Set.of("scope1", "scope2");
     var updatedRefreshToken = "newRefreshToken";
     var oAuth2TokenResponse =
         OAuth2AccessTokenResponse.withToken(accessToken)
@@ -195,7 +207,9 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .tokenType(OAuth2AccessToken.TokenType.BEARER)
             .build();
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            clientRegistration,
+            new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null),
+            scopes))
         .thenReturn(oAuth2TokenResponse);
     var updatedLinkedAccount =
         linkedAccount.withRefreshToken(oAuth2TokenResponse.getRefreshToken().getTokenValue());
@@ -208,7 +222,8 @@ class AccessTokenCacheServiceTest extends BaseTest {
             .userId(linkedAccount.getUserId())
             .clientIP(clientIP);
     String response =
-        accessTokenCacheService.getLinkedAccountAccessToken(linkedAccount, auditLogEventBuilder);
+        accessTokenCacheService.getLinkedAccountAccessToken(
+            linkedAccount, scopes, auditLogEventBuilder);
     assertEquals(response, accessToken);
     verify(auditLoggerMock)
         .logEvent(

--- a/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
@@ -4,6 +4,7 @@ import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.config.ProviderProperties;
 import bio.terra.externalcreds.generated.model.Provider;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Scanner;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +63,7 @@ public class OAuth2ServiceTest {
     // note that oAuth2AccessTokenResponse already has an access token but get another for testing
     var tokenResponse =
         oAuth2Service.authorizeWithRefreshToken(
-            providerClient, oAuth2AccessTokenResponse.getRefreshToken());
+            providerClient, oAuth2AccessTokenResponse.getRefreshToken(), Collections.emptySet());
 
     System.out.println(
         "refresh token:__________" + tokenResponse.getRefreshToken().getTokenValue());

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -168,7 +168,7 @@ public class ProviderServiceTest extends BaseTest {
             .thenReturn(createClientRegistration(linkedAccount.getProvider()));
 
         when(oAuth2ServiceMock.authorizeWithRefreshToken(
-                any(ClientRegistration.class), any(OAuth2RefreshToken.class)))
+                any(ClientRegistration.class), any(OAuth2RefreshToken.class), any(Set.class)))
             .thenReturn(
                 OAuth2AccessTokenResponse.withToken("token").tokenType(TokenType.BEARER).build());
         when(fenceAccountKeyServiceMock.getFenceAccountKey(linkedAccount))
@@ -233,7 +233,7 @@ public class ProviderServiceTest extends BaseTest {
             .thenReturn(createClientRegistration(linkedAccount.getProvider()));
 
         when(oAuth2ServiceMock.authorizeWithRefreshToken(
-                any(ClientRegistration.class), any(OAuth2RefreshToken.class)))
+                any(ClientRegistration.class), any(OAuth2RefreshToken.class), any(Set.class)))
             .thenReturn(
                 OAuth2AccessTokenResponse.withToken("token").tokenType(TokenType.BEARER).build());
         when(fenceAccountKeyServiceMock.getFenceAccountKey(linkedAccount))
@@ -394,8 +394,9 @@ public class ProviderServiceTest extends BaseTest {
 
       // mock the OAuth2AuthorizationException error thrown by the Oath2Service
       when(oAuth2ServiceMock.authorizeWithRefreshToken(
-              clientRegistration,
-              new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)))
+              eq(clientRegistration),
+              eq(new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)),
+              any(Set.class)))
           .thenThrow(
               new OAuth2AuthorizationException(
                   new OAuth2Error(OAuth2ErrorCodes.INSUFFICIENT_SCOPE)));
@@ -436,8 +437,9 @@ public class ProviderServiceTest extends BaseTest {
 
       // mock the OAuth2AuthorizationException error thrown by the Oath2Service
       when(oAuth2ServiceMock.authorizeWithRefreshToken(
-              clientRegistration,
-              new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)))
+              eq(clientRegistration),
+              eq(new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)),
+              any(Set.class)))
           .thenThrow(
               new OAuth2AuthorizationException(new OAuth2Error(OAuth2ErrorCodes.SERVER_ERROR)));
 
@@ -470,8 +472,9 @@ public class ProviderServiceTest extends BaseTest {
 
       // mock the OAuth2AuthorizationException error thrown by the Oath2Service
       when(oAuth2ServiceMock.authorizeWithRefreshToken(
-              clientRegistration,
-              new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)))
+              eq(clientRegistration),
+              eq(new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)),
+              any(Set.class)))
           .thenThrow(
               new OAuth2AuthorizationException(
                   new OAuth2Error(OAuth2ErrorCodes.ACCESS_DENIED),
@@ -514,8 +517,9 @@ public class ProviderServiceTest extends BaseTest {
               .tokenType(TokenType.BEARER)
               .build();
       when(oAuth2ServiceMock.authorizeWithRefreshToken(
-              clientRegistration,
-              new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)))
+              eq(clientRegistration),
+              eq(new OAuth2RefreshToken(savedLinkedAccount.getRefreshToken(), null)),
+              any(Set.class)))
           .thenReturn(oAuth2TokenResponse);
 
       // returning null here because it's passed to another mocked function and isn't worth mocking

--- a/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/TokenProviderServiceTest.java
@@ -1,6 +1,8 @@
 package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +17,7 @@ import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,7 +100,9 @@ public class TokenProviderServiceTest extends BaseTest {
     when(providerTokenClientCacheMock.getProviderClient(linkedAccount.getProvider()))
         .thenReturn(clientRegistration);
     when(oAuth2ServiceMock.authorizeWithRefreshToken(
-            clientRegistration, new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)))
+            eq(clientRegistration),
+            eq(new OAuth2RefreshToken(linkedAccount.getRefreshToken(), null)),
+            any(Set.class)))
         .thenThrow(
             new OAuth2AuthorizationException(new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN)));
 


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1199

In prod, we found out that ECM was not providing the proper `google_credentials` scope when getting a token. We don't know why this issue didn't show up in lower envs, but it reared its ugly head once ECM went to prod

  
