### PR TITLE
[id-1204] add fake empty response from bond

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/BondDatastoreDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/BondDatastoreDAO.java
@@ -22,48 +22,57 @@ public class BondDatastoreDAO {
   }
 
   public Optional<BondRefreshTokenEntity> getRefreshToken(String userId, Provider provider) {
-    var datastore = bondDatastoreProvider.get();
-    var key =
-        datastore
-            .newKeyFactory()
-            .setKind(REFRESH_TOKEN_KIND)
-            .addAncestor(PathElement.of("User", userId))
-            .newKey(provider.toString());
-    var datastoreEntity = Optional.ofNullable(datastore.get(key));
-    return datastoreEntity.map(
-        entity ->
-            new BondRefreshTokenEntity.Builder()
-                .key(key)
-                .issuedAt(
-                    entity.getTimestamp(BondRefreshTokenEntity.issuedAtName).toDate().toInstant())
-                .token(entity.getString(BondRefreshTokenEntity.tokenName))
-                .username(entity.getString(BondRefreshTokenEntity.userNameName))
-                .build());
+    // note: returning a fake empty response from bond
+    // since there seems to be an issue where ECM cannot get info from the datastore correctly
+
+    //    var datastore = bondDatastoreProvider.get();
+    //    var key =
+    //        datastore
+    //            .newKeyFactory()
+    //            .setKind(REFRESH_TOKEN_KIND)
+    //            .addAncestor(PathElement.of("User", userId))
+    //            .newKey(provider.toString());
+    //    var datastoreEntity = Optional.ofNullable(datastore.get(key));
+    //    return datastoreEntity.map(
+    //        entity ->
+    //            new BondRefreshTokenEntity.Builder()
+    //                .key(key)
+    //                .issuedAt(
+    //
+    // entity.getTimestamp(BondRefreshTokenEntity.issuedAtName).toDate().toInstant())
+    //                .token(entity.getString(BondRefreshTokenEntity.tokenName))
+    //                .username(entity.getString(BondRefreshTokenEntity.userNameName))
+    //                .build());
+    return Optional.empty();
   }
 
   public Optional<BondFenceServiceAccountEntity> getFenceServiceAccountKey(
       String userId, Provider provider) {
-    var datastore = bondDatastoreProvider.get();
-    var key =
-        datastore
-            .newKeyFactory()
-            .setKind(FENCE_SERVICE_ACCOUNT_KIND)
-            .addAncestor(PathElement.of("User", userId))
-            .newKey(provider.toString());
-    var datastoreEntity = Optional.ofNullable(datastore.get(key));
-    return datastoreEntity.map(
-        entity ->
-            new BondFenceServiceAccountEntity.Builder()
-                .key(key)
-                .expiresAt(
-                    entity
-                        .getTimestamp(BondFenceServiceAccountEntity.expiresAtName)
-                        .toDate()
-                        .toInstant())
-                .keyJson(entity.getString(BondFenceServiceAccountEntity.keyJsonName))
-                .updateLockTimeout(
-                    entity.getString(BondFenceServiceAccountEntity.updateLockTimeoutName))
-                .build());
+    // note: returning a fake empty response from bond
+    // since there seems to be an issue where ECM cannot get info from the datastore correctly
+
+    //    var datastore = bondDatastoreProvider.get();
+    //    var key =
+    //        datastore
+    //            .newKeyFactory()
+    //            .setKind(FENCE_SERVICE_ACCOUNT_KIND)
+    //            .addAncestor(PathElement.of("User", userId))
+    //            .newKey(provider.toString());
+    //    var datastoreEntity = Optional.ofNullable(datastore.get(key));
+    //    return datastoreEntity.map(
+    //        entity ->
+    //            new BondFenceServiceAccountEntity.Builder()
+    //                .key(key)
+    //                .expiresAt(
+    //                    entity
+    //                        .getTimestamp(BondFenceServiceAccountEntity.expiresAtName)
+    //                        .toDate()
+    //                        .toInstant())
+    //                .keyJson(entity.getString(BondFenceServiceAccountEntity.keyJsonName))
+    //                .updateLockTimeout(
+    //                    entity.getString(BondFenceServiceAccountEntity.updateLockTimeoutName))
+    //                .build());
+    return Optional.empty();
   }
 
   public void deleteRefreshToken(String userId, Provider provider) {

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/BondDatastoreDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/BondDatastoreDAOTest.java
@@ -42,34 +42,7 @@ class BondDatastoreDAOTest extends BaseTest {
 
     when(bondDatastore.newKeyFactory()).thenReturn(keyFactory);
   }
-
-  @Test
-  void testGetRefreshToken() {
-    var userId = UUID.randomUUID().toString();
-    var provider = Provider.FENCE;
-    var issuedAt = Timestamp.now();
-    var token = "TestToken";
-    var userName = userId + "-name";
-
-    when(bondDatastore.get(any(Key.class)))
-        .thenAnswer(
-            (Answer<Entity>)
-                invocation -> {
-                  var key = (Key) invocation.getArgument(0, Key.class);
-                  return Entity.newBuilder(key)
-                      .set(BondRefreshTokenEntity.issuedAtName, issuedAt)
-                      .set(BondRefreshTokenEntity.tokenName, token)
-                      .set(BondRefreshTokenEntity.userNameName, userName)
-                      .build();
-                });
-
-    var actualEntity = bondDatastoreDAO.getRefreshToken(userId, provider);
-
-    assertEquals(issuedAt.toDate().toInstant(), actualEntity.get().getIssuedAt());
-    assertEquals(token, actualEntity.get().getToken());
-    assertEquals(userName, actualEntity.get().getUsername());
-  }
-
+  
   @Test
   void testGetRefreshTokenDoesNotExist() {
     var userId = UUID.randomUUID().toString();

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/BondDatastoreDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/BondDatastoreDAOTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.generated.model.Provider;
-import bio.terra.externalcreds.models.BondFenceServiceAccountEntity;
 import bio.terra.externalcreds.models.BondRefreshTokenEntity;
 import com.google.cloud.Timestamp;
 import com.google.cloud.datastore.Datastore;
@@ -88,26 +87,12 @@ class BondDatastoreDAOTest extends BaseTest {
     var userId = UUID.randomUUID().toString();
     var provider = Provider.FENCE;
     var expiresAt = Timestamp.now();
-    var keyJson = "TestKeyJson";
-    var updateLockTimeout = "TestUpdateLockTimeout";
 
-    when(bondDatastore.get(any(Key.class)))
-        .thenAnswer(
-            (Answer<Entity>)
-                invocation -> {
-                  var key = (Key) invocation.getArgument(0, Key.class);
-                  return Entity.newBuilder(key)
-                      .set(BondFenceServiceAccountEntity.expiresAtName, expiresAt)
-                      .set(BondFenceServiceAccountEntity.keyJsonName, keyJson)
-                      .set(BondFenceServiceAccountEntity.updateLockTimeoutName, updateLockTimeout)
-                      .build();
-                });
+    when(bondDatastore.get(any(Key.class))).thenReturn(null);
 
     var actualEntity = bondDatastoreDAO.getFenceServiceAccountKey(userId, provider);
 
-    assertEquals(expiresAt.toDate().toInstant(), actualEntity.get().getExpiresAt());
-    assertEquals(keyJson, actualEntity.get().getKeyJson());
-    assertEquals(updateLockTimeout, actualEntity.get().getUpdateLockTimeout());
+    assertTrue(actualEntity.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
Jira: \<Link to Jira ticket\>

https://broadworkbench.atlassian.net/browse/ID-1204

What:

quick fix for an issue where ecm doesn't seem able to get fence tokens from the bond datastore, so just letting ecm get them itself by adding an artificial empty response from bond. 

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>
  
