### PR TITLE
Do not hand out a token if a user's linked account is expired.

### DIFF
--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -13,6 +13,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -22,8 +23,8 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 
 public class TestUtils {
 
-  public static Timestamp getRandomTimestamp() {
-    return new Timestamp(System.currentTimeMillis());
+  public static Timestamp getFutureTimestamp() {
+    return Timestamp.from(Instant.now().plusSeconds(60));
   }
 
   public static LinkedAccount createRandomLinkedAccount() {
@@ -36,7 +37,7 @@ public class TestUtils {
 
   public static LinkedAccount createRandomLinkedAccount(Provider provider) {
     return new LinkedAccount.Builder()
-        .expires(getRandomTimestamp())
+        .expires(getFutureTimestamp())
         .provider(provider)
         .refreshToken(UUID.randomUUID().toString())
         .userId(UUID.randomUUID().toString())
@@ -48,7 +49,7 @@ public class TestUtils {
   public static GA4GHPassport createRandomPassport() {
     return new GA4GHPassport.Builder()
         .jwt(UUID.randomUUID().toString())
-        .expires(getRandomTimestamp())
+        .expires(getFutureTimestamp())
         .jwtId(UUID.randomUUID().toString())
         .build();
   }
@@ -57,10 +58,10 @@ public class TestUtils {
     return new GA4GHVisa.Builder()
         .visaType(UUID.randomUUID().toString())
         .tokenType(TokenTypeEnum.access_token)
-        .expires(getRandomTimestamp())
+        .expires(getFutureTimestamp())
         .issuer(UUID.randomUUID().toString())
         .jwt(UUID.randomUUID().toString())
-        .lastValidated(getRandomTimestamp())
+        .lastValidated(getFutureTimestamp())
         .build();
   }
 
@@ -68,7 +69,7 @@ public class TestUtils {
     return new FenceAccountKey.Builder()
         .linkedAccountId(1)
         .keyJson("{\"key\": \"value\", \"private_key_id\": \"12345\"}")
-        .expiresAt(getRandomTimestamp().toInstant())
+        .expiresAt(getFutureTimestamp().toInstant())
         .build();
   }
 
@@ -76,7 +77,7 @@ public class TestUtils {
     return new AccessTokenCacheEntry.Builder()
         .linkedAccountId(1)
         .accessToken(UUID.randomUUID().toString())
-        .expiresAt(getRandomTimestamp().toInstant())
+        .expiresAt(getFutureTimestamp().toInstant())
         .build();
   }
 

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -13,7 +13,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.sql.Timestamp;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -24,7 +23,7 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 public class TestUtils {
 
   public static Timestamp getFutureTimestamp() {
-    return Timestamp.from(Instant.now().plusSeconds(60 * 5));
+    return new Timestamp(System.currentTimeMillis() + 60 * 1000);
   }
 
   public static LinkedAccount createRandomLinkedAccount() {

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -24,7 +24,7 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 public class TestUtils {
 
   public static Timestamp getFutureTimestamp() {
-    return Timestamp.from(Instant.now().plusSeconds(60));
+    return Timestamp.from(Instant.now().plusSeconds(60 * 5));
   }
 
   public static LinkedAccount createRandomLinkedAccount() {

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/DistributedLockDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/DistributedLockDAOTest.java
@@ -20,7 +20,7 @@ class DistributedLockDAOTest extends BaseTest {
       new DistributedLock.Builder()
           .lockName(testLockName)
           .userId(UUID.randomUUID().toString())
-          .expiresAt(TestUtils.getRandomTimestamp().toInstant())
+          .expiresAt(TestUtils.getFutureTimestamp().toInstant())
           .build();
 
   @Test


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1269

What/Why/How:
If a user's linked account is expired, they were still able to get a valid provider access token from ECM. Now, ECM will throw an error when they try to get a provider access token.
