### PR TITLE
ID-1283 Allow Fence Account Unlinking if Expired

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
@@ -2,6 +2,7 @@ package bio.terra.externalcreds.models;
 
 import bio.terra.externalcreds.generated.model.Provider;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -20,6 +21,10 @@ public interface LinkedAccount extends WithLinkedAccount {
   String getExternalUserId();
 
   boolean isAuthenticated();
+
+  default boolean isExpired() {
+    return getExpires().toInstant().isBefore(Instant.now());
+  }
 
   class Builder extends ImmutableLinkedAccount.Builder {}
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -220,7 +220,7 @@ public class ProviderService {
             .getLinkedAccount(userId, provider)
             .orElseThrow(() -> new NotFoundException("Link not found for user"));
 
-    if (ProviderUtils.isFenceProvider(provider)) {
+    if (ProviderUtils.isFenceProvider(provider) && !linkedAccount.isExpired()) {
       revokeKey(providerInfo, linkedAccount);
     }
 

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -196,6 +196,65 @@ public class ProviderServiceTest extends BaseTest {
     }
 
     @Test
+    void testDeleteExpiredFenceLink() {
+      try (var mockServer = ClientAndServer.startClientAndServer()) {
+        var revocationPath = "/test/revoke/";
+        var linkedAccount =
+            TestUtils.createRandomLinkedAccount()
+                .withId(1)
+                .withProvider(Provider.FENCE)
+                .withExpires(Timestamp.from(Instant.now().minus(Duration.ofMinutes(5))));
+
+        var key =
+            TestUtils.createRandomFenceAccountKey()
+                .withLinkedAccountId(linkedAccount.getId().get());
+
+        var providerInfo =
+            TestUtils.createRandomProvider()
+                .setRevokeEndpoint(
+                    "http://localhost:" + mockServer.getPort() + revocationPath + "?token=%s");
+
+        var expectedParameters =
+            List.of(
+                new Parameter("token", linkedAccount.getRefreshToken()),
+                new Parameter("client_id", providerInfo.getClientId()),
+                new Parameter("client_secret", providerInfo.getClientSecret()));
+
+        when(externalCredsConfigMock.getProviderProperties(linkedAccount.getProvider()))
+            .thenReturn(providerInfo);
+
+        when(linkedAccountServiceMock.getLinkedAccount(
+                linkedAccount.getUserId(), linkedAccount.getProvider()))
+            .thenReturn(Optional.of(linkedAccount));
+        when(linkedAccountServiceMock.deleteLinkedAccount(
+                linkedAccount.getUserId(), linkedAccount.getProvider()))
+            .thenReturn(true);
+
+        when(providerOAuthClientCacheMock.getProviderClient(linkedAccount.getProvider()))
+            .thenReturn(createClientRegistration(linkedAccount.getProvider()));
+
+        when(oAuth2ServiceMock.authorizeWithRefreshToken(
+                any(ClientRegistration.class), any(OAuth2RefreshToken.class), any(Set.class)))
+            .thenReturn(
+                OAuth2AccessTokenResponse.withToken("token").tokenType(TokenType.BEARER).build());
+        when(fenceAccountKeyServiceMock.getFenceAccountKey(linkedAccount))
+            .thenReturn(Optional.of(key));
+
+        //  Mock the server response
+        mockServer
+            .when(
+                HttpRequest.request(revocationPath)
+                    .withMethod("POST")
+                    .withQueryStringParameters(expectedParameters))
+            .respond(HttpResponse.response().withStatusCode(HttpStatus.OK.value()));
+
+        providerService.deleteLink(linkedAccount.getUserId(), linkedAccount.getProvider());
+        verify(linkedAccountServiceMock)
+            .deleteLinkedAccount(linkedAccount.getUserId(), linkedAccount.getProvider());
+      }
+    }
+
+    @Test
     void testDeleteFenceLinkNoKeyEndpoint() throws IOException {
       try (var mockServer = ClientAndServer.startClientAndServer()) {
         var revocationPath = "/test/revoke/";


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1283

There was a bug in ECM which prevented expired Fence accounts from being unlinked. A user would have to re-link their account to be able to unlink it. This is because we were calling the key revocation endpoint with an expired token, which is redundant because the key has already expired. 

Adding a guard to make sure we're not calling the key revocation endpoint for expired linked accounts fixes the issue. Also added a unit test to verify.
