### PR TITLE
ID-1130 Store NIH Username in ECM

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -4,6 +4,85 @@ info:
   description: A manager for external credentials
   version: 0.0.1
 paths:
+  /api/nih/v1/account:
+    get:
+      summary: Get the NIH account for the user
+      tags: [ nihAccount ]
+      operationId: getNihAccount
+      responses:
+        '200':
+          description: The user's NIH account
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NihAccountModel'
+        '404':
+          description: User does not have a linked NIH account
+        '500':
+          $ref: '#/components/responses/ServerError'
+    put:
+      summary: Link the user's NIH account
+      tags: [ nihAccount ]
+      operationId: linkNihAccount
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/NihAccountModel'
+      responses:
+          '202':
+            description: NIH account linked
+          '400':
+            $ref: '#/components/responses/BadRequest'
+          '403':
+            $ref: '#/components/responses/PermissionDenied'
+          '500':
+            $ref: '#/components/responses/ServerError'
+  /api/admin/nih/v1/userForUsername/{nih_username}:
+    parameters:
+      - name: nih_username
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Get the NIH Account for the NIH username
+      tags: [ nihAccount ]
+      operationId: getNihAccountForUsername
+      responses:
+        '200':
+          description: The NIH Account for the NIH username
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NihAccountModel'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          description: User not found for the NIH username
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/admin/nih/v1/activeAccounts:
+    get:
+      summary: Get all active NIH Accounts
+      tags: [ nihAccount ]
+      operationId: getActiveNihAccounts
+      responses:
+        '200':
+          description: The user for the NIH username
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NihAccountModel'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          description: User not found for the NIH username
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/oauth/v1/providers:
     get:
       summary: Lists the available OAuth providers.
@@ -418,6 +497,18 @@ components:
             $ref: '#/components/schemas/ErrorReport'
 
   schemas:
+    NihAccountModel:
+        type: object
+        description: NIH account for a user
+        required: [ userId, linkedNihUsername, linkExpireTime ]
+        properties:
+            userId:
+              type: string
+            linkedNihUsername:
+              type: string
+            linkExpireTime:
+              type: string
+              format: date-time
     PassportProvider:
       description: Enum containing valid passport providers.
       type: string

--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -67,4 +67,6 @@ public interface ExternalCredsConfigInterface {
   default DistributedLockConfiguration getDistributedLockConfiguration() {
     return DistributedLockConfiguration.create().setLockTimeout(Duration.ofSeconds(30));
   }
+
+  Collection<String> getAuthorizedAdmins();
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/NihAccountApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/NihAccountApiController.java
@@ -1,0 +1,58 @@
+package bio.terra.externalcreds.controllers;
+
+import bio.terra.common.exception.ForbiddenException;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.generated.api.NihAccountApi;
+import bio.terra.externalcreds.generated.model.NihAccountModel;
+import bio.terra.externalcreds.services.NihAccountService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+
+@Controller
+public record NihAccountApiController(
+    HttpServletRequest request,
+    ObjectMapper mapper,
+    NihAccountService nihAccountService,
+    ExternalCredsSamUserFactory samUserFactory,
+    ExternalCredsConfig externalCredsConfig)
+    implements NihAccountApi {
+
+  @Override
+  public ResponseEntity<NihAccountModel> getNihAccount() {
+    var samUser = samUserFactory.from(request);
+    var nihAccount = nihAccountService.getNihAccountForUser(samUser.getSubjectId());
+    return ResponseEntity.of(nihAccount.map(OpenApiConverters.Output::convert));
+  }
+
+  @Override
+  public ResponseEntity<Void> linkNihAccount(NihAccountModel nihAccountModel) {
+    requireAdmin();
+    nihAccountService.upsertNihAccount(OpenApiConverters.Input.convert(nihAccountModel));
+    return ResponseEntity.accepted().build();
+  }
+
+  @Override
+  public ResponseEntity<NihAccountModel> getNihAccountForUsername(String nihUsername) {
+    requireAdmin();
+    var nihAccount = nihAccountService.getLinkedAccountForUsername(nihUsername);
+    return ResponseEntity.of(nihAccount.map(OpenApiConverters.Output::convert));
+  }
+
+  @Override
+  public ResponseEntity<List<NihAccountModel>> getActiveNihAccounts() {
+    requireAdmin();
+    var activeNihAccounts = nihAccountService.getActiveNihAccounts();
+    return ResponseEntity.ok(
+        activeNihAccounts.stream().map(OpenApiConverters.Output::convert).toList());
+  }
+
+  private void requireAdmin() {
+    var samUser = samUserFactory.from(request);
+    if (!externalCredsConfig.getAuthorizedAdmins().contains(samUser.getEmail())) {
+      throw new ForbiddenException("Admin permissions required");
+    }
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
@@ -3,14 +3,17 @@ package bio.terra.externalcreds.controllers;
 import bio.terra.common.exception.BadRequestException;
 import bio.terra.externalcreds.ExternalCredsException;
 import bio.terra.externalcreds.generated.model.LinkInfo;
+import bio.terra.externalcreds.generated.model.NihAccountModel;
 import bio.terra.externalcreds.generated.model.OneOfValidatePassportRequestCriteriaItems;
 import bio.terra.externalcreds.generated.model.OneOfValidatePassportResultMatchedCriterion;
 import bio.terra.externalcreds.generated.model.RASv1Dot1VisaCriterion;
 import bio.terra.externalcreds.generated.model.ValidatePassportResult;
 import bio.terra.externalcreds.models.LinkedAccount;
+import bio.terra.externalcreds.models.NihAccount;
 import bio.terra.externalcreds.models.ValidatePassportResultInternal;
 import bio.terra.externalcreds.visaComparators.RASv1Dot1VisaCriterionInternal;
 import bio.terra.externalcreds.visaComparators.VisaCriterionInternal;
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -38,6 +41,14 @@ public class OpenApiConverters {
                 }
               })
           .collect(Collectors.toList());
+    }
+
+    public static NihAccount convert(NihAccountModel nihAccountModel) {
+      return new NihAccount.Builder()
+          .nihUsername(nihAccountModel.getLinkedNihUsername())
+          .userId(nihAccountModel.getUserId())
+          .expires(Timestamp.from(nihAccountModel.getLinkExpireTime().toInstant()))
+          .build();
     }
   }
 
@@ -70,6 +81,13 @@ public class OpenApiConverters {
           .externalUserId(linkedAccount.getExternalUserId())
           .expirationTimestamp(linkedAccount.getExpires())
           .authenticated(linkedAccount.isAuthenticated());
+    }
+
+    public static NihAccountModel convert(NihAccount nihAccount) {
+      return new NihAccountModel()
+          .linkedNihUsername(nihAccount.getNihUsername())
+          .linkExpireTime(nihAccount.getExpires())
+          .userId(nihAccount.getUserId());
     }
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
@@ -37,7 +37,8 @@ public class NihAccountDAO {
   @WithSpan
   public Optional<NihAccount> getNihAccount(String userId) {
     var namedParameters = new MapSqlParameterSource().addValue("userId", userId);
-    var query = "SELECT * FROM nih_account WHERE user_id = :userId";
+    var query =
+        "SELECT na.id, na.user_id, na.nih_username, na.expires FROM nih_account na WHERE na.user_id = :userId";
     return Optional.ofNullable(
         DataAccessUtils.singleResult(
             jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER)));
@@ -46,7 +47,8 @@ public class NihAccountDAO {
   @WithSpan
   public Optional<NihAccount> getNihAccountForUsername(String nihUsername) {
     var namedParameters = new MapSqlParameterSource().addValue("nihUsername", nihUsername);
-    var query = "SELECT * FROM nih_account WHERE nih_username = :nihUsername";
+    var query =
+        "SELECT na.id, na.user_id, na.nih_username, na.expires FROM nih_account na WHERE na.nih_username = :nihUsername";
     return Optional.ofNullable(
         DataAccessUtils.singleResult(
             jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER)));
@@ -57,8 +59,9 @@ public class NihAccountDAO {
     var namedParameters =
         new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
     var query =
-        "SELECT DISTINCT na.* FROM nih_account na"
-            + " WHERE na.expires < :expirationCutoff ORDER BY id asc";
+        "SELECT na.id, na.user_id, na.nih_username, na.expires FROM nih_account na"
+            + " WHERE na.expires < :expirationCutoff"
+            + " ORDER BY na.id asc";
     return jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER);
   }
 
@@ -67,8 +70,9 @@ public class NihAccountDAO {
     var namedParameters =
         new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
     var query =
-        "SELECT DISTINCT na.* FROM nih_account na"
-            + " WHERE na.expires > :expirationCutoff ORDER BY id asc";
+        "SELECT na.id, na.user_id, na.nih_username, na.expires FROM nih_account na"
+            + " WHERE na.expires > :expirationCutoff"
+            + " ORDER BY na.id asc";
     return jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER);
   }
 
@@ -102,7 +106,7 @@ public class NihAccountDAO {
    */
   @WithSpan
   public boolean deleteNihAccountIfExists(String userId) {
-    var query = "DELETE FROM nih_account WHERE user_id = :userId";
+    var query = "DELETE FROM nih_account na WHERE na.user_id = :userId";
     var namedParameters = new MapSqlParameterSource().addValue("userId", userId);
 
     return jdbcTemplate.update(query, namedParameters) > 0;

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
@@ -44,17 +44,16 @@ public class NihAccountDAO {
   }
 
   @WithSpan
-  public Optional<String> getUserIdForNihUsername(String nihUsername) {
+  public Optional<NihAccount> getNihAccountForUsername(String nihUsername) {
     var namedParameters = new MapSqlParameterSource().addValue("nihUsername", nihUsername);
     var query = "SELECT * FROM nih_account WHERE nih_username = :nihUsername";
     return Optional.ofNullable(
-            DataAccessUtils.singleResult(
-                jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER)))
-        .map(NihAccount::getUserId);
+        DataAccessUtils.singleResult(
+            jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER)));
   }
 
   @WithSpan
-  public List<NihAccount> getExpiringNihAccounts() {
+  public List<NihAccount> getExpiredNihAccounts() {
     var namedParameters =
         new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
     var query =

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
@@ -1,0 +1,109 @@
+package bio.terra.externalcreds.dataAccess;
+
+import bio.terra.externalcreds.models.NihAccount;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.support.DataAccessUtils;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@Slf4j
+public class NihAccountDAO {
+
+  private static final RowMapper<NihAccount> NIH_ACCOUNT_ROW_MAPPER =
+      ((rs, rowNum) ->
+          new NihAccount.Builder()
+              .id(rs.getInt("id"))
+              .userId(rs.getString("user_id"))
+              .nihUsername(rs.getString("nih_username"))
+              .expires(rs.getTimestamp("expires"))
+              .build());
+
+  final NamedParameterJdbcTemplate jdbcTemplate;
+
+  public NihAccountDAO(NamedParameterJdbcTemplate jdbcTemplate) {
+    this.jdbcTemplate = jdbcTemplate;
+  }
+
+  @WithSpan
+  public Optional<NihAccount> getNihAccount(String userId) {
+    var namedParameters = new MapSqlParameterSource().addValue("userId", userId);
+    var query = "SELECT * FROM nih_account WHERE user_id = :userId";
+    return Optional.ofNullable(
+        DataAccessUtils.singleResult(
+            jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER)));
+  }
+
+  @WithSpan
+  public Optional<String> getUserIdForNihUsername(String nihUsername) {
+    var namedParameters = new MapSqlParameterSource().addValue("nihUsername", nihUsername);
+    var query = "SELECT * FROM nih_account WHERE nih_username = :nihUsername";
+    return Optional.ofNullable(
+            DataAccessUtils.singleResult(
+                jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER)))
+        .map(NihAccount::getUserId);
+  }
+
+  @WithSpan
+  public List<NihAccount> getExpiringNihAccounts() {
+    var namedParameters =
+        new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
+    var query =
+        "SELECT DISTINCT na.* FROM nih_account na" + " WHERE na.expires < :expirationCutoff";
+    return jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER);
+  }
+
+  @WithSpan
+  public List<NihAccount> getActiveNihAccounts() {
+    var namedParameters =
+        new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
+    var query =
+        "SELECT DISTINCT na.* FROM nih_account na" + " WHERE na.expires > :expirationCutoff";
+    return jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER);
+  }
+
+  @WithSpan
+  public NihAccount upsertNihAccount(NihAccount nihAccount) {
+    var query =
+        "INSERT INTO nih_account (user_id, nih_username, expires)"
+            + " VALUES (:userId, :nihUsername, :expires)"
+            + " ON CONFLICT (user_id) DO UPDATE SET"
+            + " nih_username = excluded.nih_username,"
+            + " expires = excluded.expires"
+            + " RETURNING id";
+
+    var namedParameters =
+        new MapSqlParameterSource()
+            .addValue("userId", nihAccount.getUserId())
+            .addValue("nihUsername", nihAccount.getNihUsername())
+            .addValue("expires", nihAccount.getExpires());
+
+    // generatedKeyHolder will hold the id returned by the query as specified by the RETURNING
+    // clause
+    var generatedKeyHolder = new GeneratedKeyHolder();
+    jdbcTemplate.update(query, namedParameters, generatedKeyHolder);
+
+    return nihAccount.withId(Objects.requireNonNull(generatedKeyHolder.getKey()).intValue());
+  }
+
+  /**
+   * @param userId
+   * @return boolean whether or not an account was found and deleted
+   */
+  @WithSpan
+  public boolean deleteNihAccountIfExists(String userId) {
+    var query = "DELETE FROM nih_account WHERE user_id = :userId";
+    var namedParameters = new MapSqlParameterSource().addValue("userId", userId);
+
+    return jdbcTemplate.update(query, namedParameters) > 0;
+  }
+}

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/NihAccountDAO.java
@@ -57,7 +57,8 @@ public class NihAccountDAO {
     var namedParameters =
         new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
     var query =
-        "SELECT DISTINCT na.* FROM nih_account na" + " WHERE na.expires < :expirationCutoff";
+        "SELECT DISTINCT na.* FROM nih_account na"
+            + " WHERE na.expires < :expirationCutoff ORDER BY id asc";
     return jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER);
   }
 
@@ -66,7 +67,8 @@ public class NihAccountDAO {
     var namedParameters =
         new MapSqlParameterSource("expirationCutoff", Timestamp.from(Instant.now()));
     var query =
-        "SELECT DISTINCT na.* FROM nih_account na" + " WHERE na.expires > :expirationCutoff";
+        "SELECT DISTINCT na.* FROM nih_account na"
+            + " WHERE na.expires > :expirationCutoff ORDER BY id asc";
     return jdbcTemplate.query(query, namedParameters, NIH_ACCOUNT_ROW_MAPPER);
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/models/NihAccount.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/NihAccount.java
@@ -1,0 +1,23 @@
+package bio.terra.externalcreds.models;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface NihAccount extends WithNihAccount {
+  Optional<Integer> getId();
+
+  String getUserId();
+
+  String getNihUsername();
+
+  Timestamp getExpires();
+
+  default boolean isExpired() {
+    return getExpires().toInstant().isBefore(Instant.now());
+  }
+
+  class Builder extends ImmutableNihAccount.Builder {}
+}

--- a/service/src/main/java/bio/terra/externalcreds/services/NihAccountService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/NihAccountService.java
@@ -15,7 +15,7 @@ public class NihAccountService {
 
   private final NihAccountDAO nihAccountDAO;
 
-  public NihAccountService(NihAccountDAO nihAccountDAO, EventPublisher eventPublisher) {
+  public NihAccountService(NihAccountDAO nihAccountDAO) {
     this.nihAccountDAO = nihAccountDAO;
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/services/NihAccountService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/NihAccountService.java
@@ -1,0 +1,51 @@
+package bio.terra.externalcreds.services;
+
+import bio.terra.common.db.ReadTransaction;
+import bio.terra.common.db.WriteTransaction;
+import bio.terra.externalcreds.dataAccess.NihAccountDAO;
+import bio.terra.externalcreds.models.NihAccount;
+import java.util.List;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+public class NihAccountService {
+
+  private final NihAccountDAO nihAccountDAO;
+
+  public NihAccountService(NihAccountDAO nihAccountDAO, EventPublisher eventPublisher) {
+    this.nihAccountDAO = nihAccountDAO;
+  }
+
+  @ReadTransaction
+  public Optional<NihAccount> getNihAccountForUser(String userId) {
+    return nihAccountDAO.getNihAccount(userId);
+  }
+
+  @ReadTransaction
+  public Optional<NihAccount> getLinkedAccountForUsername(String nihUsername) {
+    return nihAccountDAO.getNihAccountForUsername(nihUsername);
+  }
+
+  @WriteTransaction
+  public NihAccount upsertNihAccount(NihAccount nihAccount) {
+    return nihAccountDAO.upsertNihAccount(nihAccount);
+  }
+
+  @WriteTransaction
+  public boolean deleteNihAccount(String userId) {
+    return nihAccountDAO.deleteNihAccountIfExists(userId);
+  }
+
+  @ReadTransaction
+  public List<NihAccount> getExpiredNihAccounts() {
+    return nihAccountDAO.getExpiredNihAccounts();
+  }
+
+  @ReadTransaction
+  public List<NihAccount> getActiveNihAccounts() {
+    return nihAccountDAO.getActiveNihAccounts();
+  }
+}

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -12,6 +12,8 @@ externalcreds:
   distributed-lock-configuration:
     lock-timeout: 30s
   access-token-expiration-buffer: 5m
+  authorized-admins:
+    - ${FIRECLOUD_ACCOUNT_EMAIL:firecloud-dev@broad-dsde-prod.iam.gserviceaccount.com}
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}

--- a/service/src/main/resources/db/changelog/changesets/20240711_add_nih_account_table.yaml
+++ b/service/src/main/resources/db/changelog/changesets/20240711_add_nih_account_table.yaml
@@ -29,3 +29,10 @@ databaseChangeLog:
                   type: timestamp
                   constraints:
                     nullable: false
+        - createIndex:
+            columns:
+              - column:
+                  descending: true
+                  name: nih_username
+            indexName: idx_nih_username
+            tableName: nih_account

--- a/service/src/main/resources/db/changelog/changesets/20240711_add_nih_account_table.yaml
+++ b/service/src/main/resources/db/changelog/changesets/20240711_add_nih_account_table.yaml
@@ -1,0 +1,31 @@
+databaseChangeLog:
+  - changeSet:
+      id: "add_nih_account_table"
+      author: tlangs
+      changes:
+        - createTable:
+            tableName: nih_account
+            columns:
+              - column:
+                  name: id
+                  type: int
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: user_id
+                  type: text
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: nih_username
+                  type: text
+                  constraints:
+                    nullable: false
+              - column:
+                  name: expires
+                  type: timestamp
+                  constraints:
+                    nullable: false

--- a/service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -44,3 +44,6 @@ databaseChangeLog:
   - include:
         file: changesets/20240515_drop_ssh_key_pair.yaml
         relativeToChangelogFile: true
+  - include:
+        file: changesets/20240711_add_nih_account_table.yaml
+        relativeToChangelogFile: true

--- a/service/src/test/java/bio/terra/externalcreds/TestUtils.java
+++ b/service/src/test/java/bio/terra/externalcreds/TestUtils.java
@@ -7,6 +7,7 @@ import bio.terra.externalcreds.models.FenceAccountKey;
 import bio.terra.externalcreds.models.GA4GHPassport;
 import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.LinkedAccount;
+import bio.terra.externalcreds.models.NihAccount;
 import bio.terra.externalcreds.models.TokenTypeEnum;
 import bio.terra.externalcreds.models.VisaVerificationDetails;
 import java.security.NoSuchAlgorithmException;
@@ -106,6 +107,14 @@ public class TestUtils {
         .linkedAccountId(42)
         .provider(Provider.RAS)
         .visaJwt(UUID.randomUUID().toString())
+        .build();
+  }
+
+  public static NihAccount createRandomNihAccount() {
+    return new NihAccount.Builder()
+        .expires(getFutureTimestamp())
+        .userId(UUID.randomUUID().toString())
+        .nihUsername(UUID.randomUUID().toString())
         .build();
   }
 

--- a/service/src/test/java/bio/terra/externalcreds/controllers/NihAccountApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/NihAccountApiControllerTest.java
@@ -1,0 +1,190 @@
+package bio.terra.externalcreds.controllers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import bio.terra.common.iam.BearerToken;
+import bio.terra.common.iam.SamUser;
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
+import bio.terra.externalcreds.services.NihAccountService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc
+class NihAccountApiControllerTest extends BaseTest {
+
+  @Autowired private ObjectMapper mapper;
+  @Autowired private MockMvc mvc;
+  @Autowired private ExternalCredsConfig externalCredsConfig;
+
+  @MockBean private NihAccountService nihAccountService;
+  @MockBean private ExternalCredsSamUserFactory samUserFactoryMock;
+
+  @Nested
+  class GetNihAccount {
+
+    @Test
+    void testGetNihAccount() throws Exception {
+      var inputNihAccount = TestUtils.createRandomNihAccount();
+      var accessToken = mockSamUser(inputNihAccount.getUserId());
+
+      when(nihAccountService.getNihAccountForUser(inputNihAccount.getUserId()))
+          .thenReturn(Optional.of(inputNihAccount));
+
+      mvc.perform(get("/api/nih/v1/account").header("authorization", "Bearer " + accessToken))
+          .andExpect(
+              content()
+                  .json(
+                      mapper.writeValueAsString(
+                          OpenApiConverters.Output.convert(inputNihAccount))));
+    }
+
+    @Test
+    void testGetNihAccountNotFound() throws Exception {
+      var inputNihAccount = TestUtils.createRandomNihAccount();
+      var accessToken = mockSamUser(inputNihAccount.getUserId());
+
+      when(nihAccountService.getNihAccountForUser(inputNihAccount.getUserId()))
+          .thenReturn(Optional.empty());
+
+      mvc.perform(get("/api/nih/v1/account").header("authorization", "Bearer " + accessToken))
+          .andExpect(status().isNotFound());
+    }
+  }
+
+  @Nested
+  class LinkNihAccount {
+
+    @Test
+    void testLinkNihAccountAdmin() throws Exception {
+      var accessToken = mockAdminSamUser();
+      var inputNihAccount = TestUtils.createRandomNihAccount();
+
+      when(nihAccountService.upsertNihAccount(inputNihAccount))
+          .thenReturn(inputNihAccount.withId(1));
+
+      mvc.perform(
+              put("/api/nih/v1/account")
+                  .header("authorization", "Bearer " + accessToken)
+                  .contentType("application/json")
+                  .content(
+                      mapper.writeValueAsString(OpenApiConverters.Output.convert(inputNihAccount))))
+          .andExpect(status().isAccepted());
+    }
+
+    @Test
+    void testLinkNihAccountNonAdmin() throws Exception {
+      var accessToken = mockSamUser("userId");
+      var inputNihAccount = TestUtils.createRandomNihAccount();
+
+      mvc.perform(
+              put("/api/nih/v1/account")
+                  .header("authorization", "Bearer " + accessToken)
+                  .contentType("application/json")
+                  .content(
+                      mapper.writeValueAsString(OpenApiConverters.Output.convert(inputNihAccount))))
+          .andExpect(status().isForbidden());
+    }
+  }
+
+  @Nested
+  class GetNihAccountForUsername {
+
+    @Test
+    void testGetNihAccountForUsernameAdmin() throws Exception {
+      var accessToken = mockAdminSamUser();
+      var inputNihAccount = TestUtils.createRandomNihAccount();
+
+      when(nihAccountService.getLinkedAccountForUsername(inputNihAccount.getNihUsername()))
+          .thenReturn(Optional.of(inputNihAccount));
+
+      mvc.perform(
+              get("/api/admin/nih/v1/userForUsername/" + inputNihAccount.getNihUsername())
+                  .header("authorization", "Bearer " + accessToken))
+          .andExpect(
+              content()
+                  .json(
+                      mapper.writeValueAsString(
+                          OpenApiConverters.Output.convert(inputNihAccount))));
+    }
+
+    @Test
+    void testGetNihAccountForUsernameNonAdmin() throws Exception {
+      var accessToken = mockSamUser("userId");
+      var inputNihAccount = TestUtils.createRandomNihAccount();
+
+      mvc.perform(
+              get("/api/admin/nih/v1/userForUsername/" + inputNihAccount.getNihUsername())
+                  .header("authorization", "Bearer " + accessToken))
+          .andExpect(status().isForbidden());
+    }
+  }
+
+  @Nested
+  class GetActiveNihAccounts {
+
+    @Test
+    void testGetActiveNihAccountsAdmin() throws Exception {
+      var accessToken = mockAdminSamUser();
+      var inputNihAccount1 = TestUtils.createRandomNihAccount();
+      var inputNihAccount2 = TestUtils.createRandomNihAccount();
+
+      when(nihAccountService.getActiveNihAccounts())
+          .thenReturn(List.of(inputNihAccount1, inputNihAccount2));
+
+      mvc.perform(
+              get("/api/admin/nih/v1/activeAccounts")
+                  .header("authorization", "Bearer " + accessToken))
+          .andExpect(
+              content()
+                  .json(
+                      mapper.writeValueAsString(
+                          List.of(
+                              OpenApiConverters.Output.convert(inputNihAccount1),
+                              OpenApiConverters.Output.convert(inputNihAccount2)))));
+    }
+
+    @Test
+    void testGetActiveNihAccountsNonAdmin() throws Exception {
+      var accessToken = mockSamUser("userId");
+
+      mvc.perform(
+              get("/api/admin/nih/v1/activeAccounts")
+                  .header("authorization", "Bearer " + accessToken))
+          .andExpect(status().isForbidden());
+    }
+  }
+
+  private String mockSamUser(String userId) {
+    var accessToken = UUID.randomUUID().toString();
+    when(samUserFactoryMock.from(any(HttpServletRequest.class)))
+        .thenReturn(new SamUser("foo@bar.com", userId, new BearerToken(accessToken)));
+    return accessToken;
+  }
+
+  private String mockAdminSamUser() {
+    var accessToken = UUID.randomUUID().toString();
+    when(samUserFactoryMock.from(any(HttpServletRequest.class)))
+        .thenReturn(
+            new SamUser(
+                externalCredsConfig.getAuthorizedAdmins().iterator().next(),
+                "userId",
+                new BearerToken(accessToken)));
+    return accessToken;
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
@@ -10,7 +10,6 @@ import bio.terra.externalcreds.TestUtils;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -134,8 +133,7 @@ class NihAccountDAOTest extends BaseTest {
 
       // Assert that only the non-expired nih accounts are returned
       assertEquals(
-          new HashSet<>(List.of(savedNihAccount, savedNihAccount2)),
-          new HashSet<>(nihAccountDAO.getActiveNihAccounts()));
+          List.of(savedNihAccount, savedNihAccount2), nihAccountDAO.getActiveNihAccounts());
     }
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
@@ -10,6 +10,7 @@ import bio.terra.externalcreds.TestUtils;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -133,7 +134,8 @@ class NihAccountDAOTest extends BaseTest {
 
       // Assert that only the non-expired nih accounts are returned
       assertEquals(
-          List.of(savedNihAccount, savedNihAccount2), nihAccountDAO.getActiveNihAccounts());
+          new HashSet<>(List.of(savedNihAccount, savedNihAccount2)),
+          new HashSet<>(nihAccountDAO.getActiveNihAccounts()));
     }
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
@@ -94,7 +94,7 @@ class NihAccountDAOTest extends BaseTest {
       var savedExpiredNihAccount = nihAccountDAO.upsertNihAccount(expiredNihAccount);
 
       // Assert that only the expired nih account is returned
-      assertEquals(List.of(savedExpiredNihAccount), nihAccountDAO.getExpiringNihAccounts());
+      assertEquals(List.of(savedExpiredNihAccount), nihAccountDAO.getExpiredNihAccounts());
 
       assertEquals(List.of(savedNihAccount), nihAccountDAO.getActiveNihAccounts());
     }
@@ -109,10 +109,11 @@ class NihAccountDAOTest extends BaseTest {
       nihAccountDAO.upsertNihAccount(
           TestUtils.createRandomNihAccount()); // To make sure we get the right one.
       var savedNihAccount = nihAccountDAO.upsertNihAccount(nihAccount);
-      var loadedUserId = nihAccountDAO.getUserIdForNihUsername(savedNihAccount.getNihUsername());
+      var loadedNihAccount =
+          nihAccountDAO.getNihAccountForUsername(savedNihAccount.getNihUsername());
 
       // Assert that only the user_id for the username we supplied
-      assertEquals(nihAccount.getUserId(), loadedUserId.get());
+      assertEquals(nihAccount.getUserId(), loadedNihAccount.get().getUserId());
     }
 
     @Test

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/NihAccountDAOTest.java
@@ -1,0 +1,138 @@
+package bio.terra.externalcreds.dataAccess;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class NihAccountDAOTest extends BaseTest {
+
+  @Autowired private NihAccountDAO nihAccountDAO;
+
+  @Test
+  void testGetMissingNihAccount() {
+    var shouldBeEmpty = nihAccountDAO.getNihAccount("missing_user_id");
+    assertEmpty(shouldBeEmpty);
+  }
+
+  @Test
+  void testGetNihAccountById() {
+    var nihAccount = TestUtils.createRandomNihAccount();
+    var savedNihAccount = nihAccountDAO.upsertNihAccount(nihAccount);
+    var loadedNihAccount = nihAccountDAO.getNihAccount(savedNihAccount.getUserId());
+
+    // test that retrieved account matches saved account
+    assertEquals(
+        Optional.of(savedNihAccount.withId(loadedNihAccount.get().getId())), loadedNihAccount);
+  }
+
+  @Test
+  void testUpsertUpdatedNihAccount() {
+    var nihAccount = TestUtils.createRandomNihAccount();
+    var createdNihAccount = nihAccountDAO.upsertNihAccount(nihAccount);
+
+    var updatedNihAccount =
+        nihAccountDAO.upsertNihAccount(
+            nihAccount.withExpires(
+                Timestamp.from(nihAccount.getExpires().toInstant().plus(Duration.ofDays(1)))));
+
+    assertEquals(createdNihAccount.getId(), updatedNihAccount.getId());
+    assertNotEquals(createdNihAccount.getExpires(), updatedNihAccount.getExpires());
+    assertEquals(createdNihAccount.getNihUsername(), updatedNihAccount.getNihUsername());
+
+    var loadedNihAccount = nihAccountDAO.getNihAccount(nihAccount.getUserId());
+    assertEquals(Optional.of(updatedNihAccount), loadedNihAccount);
+  }
+
+  @Nested
+  class DeleteNihAccount {
+
+    @Test
+    void testDeleteNihAccountIfExists() {
+      var createdNihAccount = nihAccountDAO.upsertNihAccount(TestUtils.createRandomNihAccount());
+      var deletionSucceeded = nihAccountDAO.deleteNihAccountIfExists(createdNihAccount.getUserId());
+      assertTrue(deletionSucceeded);
+      assertEmpty(nihAccountDAO.getNihAccount(createdNihAccount.getUserId()));
+    }
+
+    @Test
+    void testDeleteNonexistentNihAccount() {
+      var userId = UUID.randomUUID().toString();
+      var deletionSucceeded = nihAccountDAO.deleteNihAccountIfExists(userId);
+      assertEmpty(nihAccountDAO.getNihAccount(userId));
+      assertFalse(deletionSucceeded);
+    }
+  }
+
+  @Nested
+  class GetExpiringNihAccounts {
+
+    @Test
+    void testGetsOnlyExpiredNihAccounts() {
+      // Create a non-expired nih account
+      var nihAccount = TestUtils.createRandomNihAccount();
+
+      var savedNihAccount = nihAccountDAO.upsertNihAccount(nihAccount);
+
+      // Create an expired nih account
+      var expiredNihAccount =
+          TestUtils.createRandomNihAccount()
+              .withExpires(Timestamp.from(Instant.now().minus(Duration.ofMinutes(1))));
+
+      var savedExpiredNihAccount = nihAccountDAO.upsertNihAccount(expiredNihAccount);
+
+      // Assert that only the expired nih account is returned
+      assertEquals(List.of(savedExpiredNihAccount), nihAccountDAO.getExpiringNihAccounts());
+
+      assertEquals(List.of(savedNihAccount), nihAccountDAO.getActiveNihAccounts());
+    }
+  }
+
+  @Nested
+  class GetNihAccountAdminFunctionality {
+
+    @Test
+    void testGetsNihAccountByUsername() {
+      var nihAccount = TestUtils.createRandomNihAccount();
+      nihAccountDAO.upsertNihAccount(
+          TestUtils.createRandomNihAccount()); // To make sure we get the right one.
+      var savedNihAccount = nihAccountDAO.upsertNihAccount(nihAccount);
+      var loadedUserId = nihAccountDAO.getUserIdForNihUsername(savedNihAccount.getNihUsername());
+
+      // Assert that only the user_id for the username we supplied
+      assertEquals(nihAccount.getUserId(), loadedUserId.get());
+    }
+
+    @Test
+    void testGetsAllActiveNihAccounts() {
+      // Create a non-expired nih account
+      var nihAccount = TestUtils.createRandomNihAccount();
+      var nihAccount2 = TestUtils.createRandomNihAccount();
+
+      var savedNihAccount = nihAccountDAO.upsertNihAccount(nihAccount);
+      var savedNihAccount2 = nihAccountDAO.upsertNihAccount(nihAccount2);
+
+      // Create an expired nih account
+      var expiredNihAccount =
+          TestUtils.createRandomNihAccount()
+              .withExpires(Timestamp.from(Instant.now().minus(Duration.ofMinutes(1))));
+      nihAccountDAO.upsertNihAccount(expiredNihAccount);
+
+      // Assert that only the non-expired nih accounts are returned
+      assertEquals(
+          List.of(savedNihAccount, savedNihAccount2), nihAccountDAO.getActiveNihAccounts());
+    }
+  }
+}

--- a/service/src/test/java/bio/terra/externalcreds/services/NihAccountServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/NihAccountServiceTest.java
@@ -1,0 +1,91 @@
+package bio.terra.externalcreds.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import bio.terra.externalcreds.BaseTest;
+import bio.terra.externalcreds.TestUtils;
+import bio.terra.externalcreds.dataAccess.NihAccountDAO;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+class NihAccountServiceTest extends BaseTest {
+
+  @Autowired private NihAccountService nihAccountService;
+  @MockBean private NihAccountDAO nihAccountDAO;
+
+  @Test
+  void getNihAccountForUser() {
+    when(nihAccountDAO.getNihAccount("userId"))
+        .thenReturn(
+            Optional.of(
+                TestUtils.createRandomNihAccount()
+                    .withNihUsername("nihUsername")
+                    .withUserId("userId")));
+    when(nihAccountDAO.getNihAccount("nonExistentUserId")).thenReturn(Optional.empty());
+    assertEmpty(nihAccountService.getNihAccountForUser("nonExistentUserId"));
+    var nihAccount = nihAccountService.getNihAccountForUser("userId");
+    assertPresent(nihAccount);
+    assertEquals("nihUsername", nihAccount.get().getNihUsername());
+  }
+
+  @Test
+  void getLinkedAccountForUsername() {
+    when(nihAccountDAO.getNihAccountForUsername("nihUsername"))
+        .thenReturn(
+            Optional.of(
+                TestUtils.createRandomNihAccount()
+                    .withNihUsername("nihUsername")
+                    .withUserId("userId")));
+    when(nihAccountDAO.getNihAccountForUsername("nonExistentUsername"))
+        .thenReturn(Optional.empty());
+    assertEmpty(nihAccountService.getLinkedAccountForUsername("nonExistentUsername"));
+    var nihAccount = nihAccountService.getLinkedAccountForUsername("nihUsername");
+    assertPresent(nihAccount);
+    assertEquals("userId", nihAccount.get().getUserId());
+  }
+
+  @Test
+  void upsertNihAccount() {
+    var nihAccount = TestUtils.createRandomNihAccount();
+    when(nihAccountDAO.upsertNihAccount(nihAccount)).thenReturn(nihAccount.withId(1));
+
+    var upsertedNihAccount = nihAccountService.upsertNihAccount(nihAccount);
+    assertEquals(nihAccount.withId(1), upsertedNihAccount);
+  }
+
+  @Test
+  void deleteNihAccount() {
+    when(nihAccountDAO.deleteNihAccountIfExists("userId")).thenReturn(true);
+    when(nihAccountDAO.deleteNihAccountIfExists("nonExistentUserId")).thenReturn(false);
+    assertTrue(nihAccountService.deleteNihAccount("userId"));
+    assertFalse(nihAccountService.deleteNihAccount("nonExistentUserId"));
+  }
+
+  @Test
+  void getExpiredNihAccounts() {
+    var expiredNihAccount =
+        TestUtils.createRandomNihAccount()
+            .withId(1)
+            .withExpires(Timestamp.from(Instant.now().minus(Duration.ofDays(1))));
+    when(nihAccountDAO.getExpiredNihAccounts()).thenReturn(List.of(expiredNihAccount));
+
+    var expiredNihAccounts = nihAccountService.getExpiredNihAccounts();
+    assertEquals(List.of(expiredNihAccount), expiredNihAccounts);
+  }
+
+  @Test
+  void getActiveNihAccounts() {
+    var nonExpiredNihAccount = TestUtils.createRandomNihAccount().withId(1);
+    when(nihAccountDAO.getActiveNihAccounts()).thenReturn(List.of(nonExpiredNihAccount));
+
+    var activeNihAccounts = nihAccountService.getActiveNihAccounts();
+    assertEquals(List.of(nonExpiredNihAccount), activeNihAccounts);
+  }
+}


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1330

We're starting to move away from Thurloe! One of the things Thurloe stores is the user's NIH username. This will be migrated to ECM in the future when Shibboleth is retired in favor of OAuth2, but for now, we can make Orchestration talk to ECM instead of Thurloe. 

This PR introduces the NIH Account table, which just stores NIH Usernames and link expiration times. API endpoints have been added to support Orch's functionality, as outlined [here](https://docs.google.com/document/d/1cdrALm4o1NZvFg4iE2eqDepKpwL2HPfY2N33A3j2--k/edit#heading=h.naxdnn42df8w).
  
