### PR TITLE
ID-1330 Orchestration can PUT eRA Commons accounts

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -4,7 +4,29 @@ info:
   description: A manager for external credentials
   version: 0.0.1
 paths:
-  /api/admin/{provider}/v1/userForExternalId/{externalId}:
+  /api/admin/v1/{provider}:
+    parameters:
+      - $ref: '#/components/parameters/providerParam'
+    put:
+      summary: Link a user to an external account with a fake refresh token
+      tags: [ admin ]
+      operationId: putLinkedAccountWithFakeToken
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AdminLinkInfo'
+        required: true
+      responses:
+        '204':
+          description: Linked Account Created
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+  /api/admin/v1/{provider}/userForExternalId/{externalId}:
     parameters:
       - $ref: '#/components/parameters/providerParam'
       - $ref: '#/components/parameters/externalIdParam'
@@ -25,7 +47,7 @@ paths:
           description: User not found for the External ID
         '500':
           $ref: '#/components/responses/ServerError'
-  /api/admin/{provider}/v1/activeAccounts:
+  /api/admin/v1/{provider}/activeAccounts:
     parameters:
       - $ref: '#/components/parameters/providerParam'
     get:

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -89,7 +89,7 @@ public record OauthApiController(
               yield OpenApiConverters.Output.convert(
                   linkedAccountWithPassportAndVisas.getLinkedAccount());
             }
-            case GITHUB, ERA_COMMONS -> {
+            case GITHUB -> {
               var linkedAccount =
                   tokenProviderService.createLink(
                       provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
@@ -101,6 +101,8 @@ public record OauthApiController(
                       provider, samUser.getSubjectId(), oauthcode, state, auditLogEventBuilder);
               yield OpenApiConverters.Output.convert(linkedAccount);
             }
+            case ERA_COMMONS -> throw new UnsupportedOperationException(
+                "eRA Commons is not supported for link creation (yet)");
           };
       return ResponseEntity.ok(linkInfo);
     } catch (Exception e) {

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
@@ -36,8 +36,7 @@ public class ProviderOAuthClientCache {
 
     ClientRegistration.Builder builder =
         switch (provider) {
-          case RAS, ERA_COMMONS -> ClientRegistrations.fromOidcIssuerLocation(
-                  providerInfo.getIssuer())
+          case RAS -> ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
               .clientId(providerInfo.getClientId())
               .clientSecret(providerInfo.getClientSecret())
               .issuerUri(providerInfo.getIssuer());
@@ -61,6 +60,8 @@ public class ProviderOAuthClientCache {
               .clientSecret(providerInfo.getClientSecret())
               .issuerUri(providerInfo.getIssuer())
               .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS);
+          case ERA_COMMONS -> throw new UnsupportedOperationException(
+              "eRA Commons does not support OAuth (yet)");
         };
 
     // set optional overrides

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderTokenClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderTokenClientCache.java
@@ -37,8 +37,7 @@ public class ProviderTokenClientCache {
 
     ClientRegistration.Builder builder =
         switch (provider) {
-          case RAS, ERA_COMMONS -> ClientRegistrations.fromOidcIssuerLocation(
-                  providerInfo.getIssuer())
+          case RAS -> ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
               .clientId(providerInfo.getClientId())
               .clientSecret(providerInfo.getClientSecret())
               .issuerUri(providerInfo.getIssuer());
@@ -61,6 +60,8 @@ public class ProviderTokenClientCache {
               .clientId(providerInfo.getClientId())
               .clientSecret(providerInfo.getClientSecret())
               .issuerUri(providerInfo.getIssuer());
+          case ERA_COMMONS -> throw new UnsupportedOperationException(
+              "eRA Commons does not support OAuth (yet)");
         };
 
     // set optional overrides

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
@@ -1,6 +1,7 @@
 package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import bio.terra.externalcreds.BaseTest;
@@ -95,14 +96,9 @@ class ProviderOAuthClientCacheTest extends BaseTest {
                   .withContentType(MediaType.APPLICATION_JSON)
                   .withBody(ProviderTestUtil.wellKnownResponse(url)));
 
-      var providerInfo = externalCredsConfig.getProviderProperties(provider);
-
-      ClientRegistration eraCommonsClient = providerOAuthClientCache.getProviderClient(provider);
-
-      assertEquals(
-          AuthorizationGrantType.AUTHORIZATION_CODE, eraCommonsClient.getAuthorizationGrantType());
-      assertEquals(providerInfo.getClientId(), eraCommonsClient.getClientId());
-      assertEquals(providerInfo.getClientSecret(), eraCommonsClient.getClientSecret());
+      assertThrows(
+          UnsupportedOperationException.class,
+          () -> providerOAuthClientCache.getProviderClient(provider));
     }
   }
 

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
@@ -1,6 +1,7 @@
 package bio.terra.externalcreds.services;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import bio.terra.externalcreds.BaseTest;
@@ -94,14 +95,9 @@ class ProviderTokenClientCacheTest extends BaseTest {
                   .withContentType(MediaType.APPLICATION_JSON)
                   .withBody(ProviderTestUtil.wellKnownResponse(url)));
 
-      var providerInfo = externalCredsConfig.getProviderProperties(provider);
-
-      ClientRegistration eraCommonsClient = providerTokenClientCache.getProviderClient(provider);
-
-      assertEquals(
-          AuthorizationGrantType.AUTHORIZATION_CODE, eraCommonsClient.getAuthorizationGrantType());
-      assertEquals(providerInfo.getClientId(), eraCommonsClient.getClientId());
-      assertEquals(providerInfo.getClientSecret(), eraCommonsClient.getClientSecret());
+      assertThrows(
+          UnsupportedOperationException.class,
+          () -> providerTokenClientCache.getProviderClient(provider));
     }
   }
 


### PR DESCRIPTION
Jira:  https://broadworkbench.atlassian.net/browse/ID-1330

Since RAS is on the slow-end of getting us the correct redirects for OAuth login with eRA Commons credentials, we should just have ECM store the result of the SAML handshake. This PR lets Orch `PUT` a linked account for eRA Commons. It also makes getting a token from a linked eRA Account throw an `UnsupportedOperationException`, since we don't have a real refresh token to get an access token with.
