### PR TITLE
ID-1330 Orch can DELETE linked eRA COmmons accounts

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -8,7 +8,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/providerParam'
     put:
-      summary: Link a user to an external account with a fake refresh token
+      summary: Link a user to an external account with a fake refresh token. For eRA Commons only.
       tags: [ admin ]
       operationId: putLinkedAccountWithFakeToken
       requestBody:
@@ -26,6 +26,28 @@ paths:
           $ref: '#/components/responses/PermissionDenied'
         '500':
           $ref: '#/components/responses/ServerError'
+    delete:
+      summary: Unlink a user from an external account
+      tags: [ admin ]
+      operationId: adminDeleteLinkedAccount
+      requestBody:
+        content:
+          text/plain:
+            schema:
+              type: string
+              description: The Sam User Id for a user
+
+        required: true
+      responses:
+        '204':
+          description: Linked Account Deleted
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/admin/v1/{provider}/userForExternalId/{externalId}:
     parameters:
       - $ref: '#/components/parameters/providerParam'


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/ID-1330

Forgot to add the DELETE ability. Also, added a guard so that _only_ eRA Commons accounts can be linked with a fake token. We shouldn't even allow an admin to make a link for any other provider, since they all support OAuth.
  
