### PR TITLE
CORE-108: Add local DUOS url with port

### DIFF
--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -99,6 +99,7 @@ externalcreds:
     era-commons:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback",
                                     "https://localhost.dsde-dev.broadinstitute.org/",
+                                    "https://localhost.dsde-dev.broadinstitute.org:3000/",
                                     "https://duos-k8s.dsde-dev.broadinstitute.org/"]
     github:
       allowedRedirectUriPatterns: [ "https://[A-Za-z0-9-]*bvdp-saturn-dev.appspot.com/oauth_callback",


### PR DESCRIPTION
**Jira**: https://broadworkbench.atlassian.net/browse/CORE-108

**What**: Add local version of DUOS to list of allowed era-commons redirect URIs.

**Why**: Arbitrary redirect uris are not allowed due to security considerations. When the oauth provider does the redirect it includes information to allow the user to link their account and retrieve an access token. Note that this is related to https://github.com/DataBiosphere/terra-external-credentials-manager/pull/216

**How**: Update providers.yaml
