### PR TITLE
[CORE-110] Store additional info in oauth state param

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -136,6 +136,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/providerParam'
       - $ref: '#/components/parameters/redirectUriParam'
+      - $ref: '#/components/parameters/additionalStateParam'
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ oauth ]
@@ -246,6 +247,7 @@ paths:
     parameters:
       - $ref: '#/components/parameters/providerParam'
       - $ref: '#/components/parameters/redirectUriParam'
+      - $ref: '#/components/parameters/additionalStateParam'
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ oidc ]
@@ -425,6 +427,15 @@ components:
       example: "http://localhost:9000/fence-callback"
       schema:
         type: string
+    additionalStateParam:
+      name: additionalState
+      description: Information to include in the oidc authorization state in the form of key/value pairs
+      in: query
+      required: false
+      content:
+        application/json:
+          schema:
+            type: object
     stateParam:
       name: state
       description: oidc authorization state, must be identical to state embedded in response from getAuthUrl

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -541,6 +541,8 @@ components:
           format: date-time
         authenticated:
           type: boolean
+        additionalState:
+          type: object
     ErrorReport:
       type: object
       required: [ message, statusCode ]

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -526,6 +526,8 @@ components:
       type: object
       additionalProperties:
         type: string
+      example: |
+        {"redirectTo": "https://my.redirect.url/"}
     PassportProvider:
       description: Enum containing valid passport providers.
       type: string

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -136,12 +136,30 @@ paths:
     parameters:
       - $ref: '#/components/parameters/providerParam'
       - $ref: '#/components/parameters/redirectUriParam'
-      - $ref: '#/components/parameters/additionalStateParam'
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ oauth ]
       operationId: getAuthorizationUrl
       description: First step to link a new provider. Creates a 1 time use link. There can only be 1 active link per user per provider. The last link created will invalidate any prior links.
+      responses:
+        '200':
+          description: The authorization URL
+          content:
+            text/plain:
+              schema:
+                type: string
+        '500':
+          $ref: '#/components/responses/ServerError'
+    post:
+      summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance and includes any additional params in the state.
+      tags: [ oauth ]
+      operationId: getAuthorizationUrlWithAdditionalParams
+      description: First step to link a new provider. Creates a 1 time use link. There can only be 1 active link per user per provider. The last link created will invalidate any prior links.
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/GetAuthUrlRequest'
       responses:
         '200':
           description: The authorization URL
@@ -247,7 +265,6 @@ paths:
     parameters:
       - $ref: '#/components/parameters/providerParam'
       - $ref: '#/components/parameters/redirectUriParam'
-      - $ref: '#/components/parameters/additionalStateParam'
     get:
       summary: Builds an OAuth authorization URL that a user must use to initiate the OAuth dance.
       tags: [ oidc ]
@@ -427,15 +444,6 @@ components:
       example: "http://localhost:9000/fence-callback"
       schema:
         type: string
-    additionalStateParam:
-      name: additionalState
-      description: Information to include in the oidc authorization state in the form of key/value pairs
-      in: query
-      required: false
-      content:
-        application/json:
-          schema:
-            type: object
     stateParam:
       name: state
       description: oidc authorization state, must be identical to state embedded in response from getAuthUrl
@@ -514,6 +522,10 @@ components:
             linkExpireTime:
               type: string
               format: date-time
+    GetAuthUrlRequest:
+      type: object
+      additionalProperties:
+        type: string
     PassportProvider:
       description: Enum containing valid passport providers.
       type: string
@@ -543,6 +555,8 @@ components:
           type: boolean
         additionalState:
           type: object
+          additionalProperties:
+            type: string
     ErrorReport:
       type: object
       required: [ message, statusCode ]

--- a/render_config.sh
+++ b/render_config.sh
@@ -54,7 +54,7 @@ fi
   echo export SAM_ADDRESS=https://sam.dsde-${ENV}.broadinstitute.org
 } >> "${SECRET_ENV_VARS_LOCATION}"
 
-$VAULT_COMMAND -field=swagger-client-id "$ECM_VAULT_PATH/swagger-client-id" >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
+gcloud secrets versions access latest --secret=externalcreds-swagger-client-id --project=broad-dsde-dev | jq -r '."swagger-client-id"' >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
 
 $VAULT_COMMAND -field=data -format=json "secret/dsde/firecloud/$ENV/common/firecloud-account.json" >"$INTEGRATION_OUTPUT_LOCATION/user-delegated-sa.json"
 

--- a/render_config.sh
+++ b/render_config.sh
@@ -25,36 +25,38 @@ if [ -f "${SECRET_ENV_VARS_LOCATION}" ]; then
   rm "${SECRET_ENV_VARS_LOCATION}"
 fi
 
+
+GOOGLE_PROJECT=broad-dsde-${ENV}
 {
   if $LIVE_DB; then
-    echo export DATABASE_NAME="$(gcloud secrets versions access latest --secret=externalcreds-postgres-creds --project=broad-dsde-dev | jq -r '.db')"
-    echo export DATABASE_USER="$(gcloud secrets versions access latest --secret=externalcreds-postgres-creds --project=broad-dsde-dev | jq -r '.username')"
-    echo export DATABASE_USER_PASSWORD="$(gcloud secrets versions access latest --secret=externalcreds-postgres-creds --project=broad-dsde-dev | jq -r '.password')"
+    echo export DATABASE_NAME="$(gcloud secrets versions access latest --secret=externalcreds-postgres-creds --project="${GOOGLE_PROJECT}" | jq -r '.db')"
+    echo export DATABASE_USER="$(gcloud secrets versions access latest --secret=externalcreds-postgres-creds --project="${GOOGLE_PROJECT}" | jq -r '.username')"
+    echo export DATABASE_USER_PASSWORD="$(gcloud secrets versions access latest --secret=externalcreds-postgres-creds --project="${GOOGLE_PROJECT}" | jq -r '.password')"
   fi
 
   if [ $ENV != 'prod' ]; then
-      echo export RAS_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-providers --project=broad-dsde-dev | jq -r '.ras_client_id')"
-      echo export RAS_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-providers --project=broad-dsde-dev | jq -r '.ras_client_secret')"
-      echo export ERA_COMMONS_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-providers --project=broad-dsde-dev | jq -r '.era_commons_client_id')"
-      echo export ERA_COMMONS_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-providers --project=broad-dsde-dev | jq -r '.era_commons_client_secret')"
+      echo export RAS_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-providers --project="${GOOGLE_PROJECT}" | jq -r '.ras_client_id')"
+      echo export RAS_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-providers --project="${GOOGLE_PROJECT}" | jq -r '.ras_client_secret')"
+      echo export ERA_COMMONS_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-providers --project="${GOOGLE_PROJECT}" | jq -r '.era_commons_client_id')"
+      echo export ERA_COMMONS_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-providers --project="${GOOGLE_PROJECT}" | jq -r '.era_commons_client_secret')"
   fi
 
-  echo export GITHUB_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-providers --project=broad-dsde-dev | jq -r '.github_client_id')"
-  echo export GITHUB_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-providers --project=broad-dsde-dev | jq -r '.github_client_secret')"
-  echo export ANVIL_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."anvil-client-id"')"
-  echo export ANVIL_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."anvil-client-secret"')"
-  echo export FENCE_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."client-id"')"
-  echo export FENCE_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."client-secret"')"
-  echo export DCF_FENCE_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."dcf-fence-client-id"')"
-  echo export DCF_FENCE_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."dcf-fence-client-secret"')"
-  echo export KIDS_FIRST_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."kids-first-client-id"')"
-  echo export KIDS_FIRST_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project=broad-dsde-dev | jq -r '."kids-first-client-secret"')"
+  echo export GITHUB_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-providers --project="${GOOGLE_PROJECT}" | jq -r '.github_client_id')"
+  echo export GITHUB_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-providers --project="${GOOGLE_PROJECT}" | jq -r '.github_client_secret')"
+  echo export ANVIL_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."anvil-client-id"')"
+  echo export ANVIL_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."anvil-client-secret"')"
+  echo export FENCE_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."client-id"')"
+  echo export FENCE_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."client-secret"')"
+  echo export DCF_FENCE_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."dcf-fence-client-id"')"
+  echo export DCF_FENCE_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."dcf-fence-client-secret"')"
+  echo export KIDS_FIRST_CLIENT_ID="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."kids-first-client-id"')"
+  echo export KIDS_FIRST_CLIENT_SECRET="$(gcloud secrets versions access latest --secret=externalcreds-fence --project="${GOOGLE_PROJECT}" | jq -r '."kids-first-client-secret"')"
 
   echo export DEPLOY_ENV=$ENV
   echo export SAM_ADDRESS=https://sam.dsde-${ENV}.broadinstitute.org
 } >> "${SECRET_ENV_VARS_LOCATION}"
 
-gcloud secrets versions access latest --secret=externalcreds-swagger-client-id --project=broad-dsde-dev | jq -r '."swagger-client-id"' >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
+gcloud secrets versions access latest --secret=externalcreds-swagger-client-id --project="${GOOGLE_PROJECT}" | jq -r '."swagger-client-id"' >"$SERVICE_OUTPUT_LOCATION/swagger-client-id"
 
 $VAULT_COMMAND -field=data -format=json "secret/dsde/firecloud/$ENV/common/firecloud-account.json" >"$INTEGRATION_OUTPUT_LOCATION/user-delegated-sa.json"
 

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -46,11 +46,13 @@ public record OauthApiController(
   }
 
   @Override
-  public ResponseEntity<String> getAuthorizationUrl(Provider provider, String redirectUri) {
+  public ResponseEntity<String> getAuthorizationUrl(
+      Provider provider, String redirectUri, Object additionalState) {
     var samUser = samUserFactory.from(request);
 
     var authorizationUrl =
-        providerService.getProviderAuthorizationUrl(samUser.getSubjectId(), provider, redirectUri);
+        providerService.getProviderAuthorizationUrl(
+            samUser.getSubjectId(), provider, redirectUri, additionalState);
 
     return ResponseEntity.ok(authorizationUrl);
   }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -117,6 +117,11 @@ public record OauthApiController(
               }
             }
           };
+
+      Object additionalState = providerService.getAdditionalStateParams(state);
+      if (additionalState != null) {
+        linkInfo.additionalState(additionalState);
+      }
       return ResponseEntity.ok(linkInfo);
     } catch (Exception e) {
       auditLogger.logEvent(

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -13,6 +13,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -46,13 +48,24 @@ public record OauthApiController(
   }
 
   @Override
-  public ResponseEntity<String> getAuthorizationUrl(
-      Provider provider, String redirectUri, Object additionalState) {
+  public ResponseEntity<String> getAuthorizationUrl(Provider provider, String redirectUri) {
     var samUser = samUserFactory.from(request);
 
     var authorizationUrl =
         providerService.getProviderAuthorizationUrl(
-            samUser.getSubjectId(), provider, redirectUri, additionalState);
+            samUser.getSubjectId(), provider, redirectUri, null);
+
+    return ResponseEntity.ok(authorizationUrl);
+  }
+
+  @Override
+  public ResponseEntity<String> getAuthorizationUrlWithAdditionalParams(
+      String redirectUri, Provider provider, Map<String, String> body) {
+    var samUser = samUserFactory.from(request);
+
+    var authorizationUrl =
+        providerService.getProviderAuthorizationUrl(
+            samUser.getSubjectId(), provider, redirectUri, body);
 
     return ResponseEntity.ok(authorizationUrl);
   }
@@ -118,10 +131,9 @@ public record OauthApiController(
             }
           };
 
-      Object additionalState = providerService.getAdditionalStateParams(state);
-      if (additionalState != null) {
-        linkInfo.additionalState(additionalState);
-      }
+      Optional<Map<String, String>> additionalState =
+          providerService.getAdditionalStateParams(state);
+      additionalState.ifPresent(linkInfo::additionalState);
       return ResponseEntity.ok(linkInfo);
     } catch (Exception e) {
       auditLogger.logEvent(

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -48,9 +48,13 @@ public record OidcApiController(
   }
 
   @Override
-  public ResponseEntity<String> getAuthUrl(Provider provider, String redirectUri) {
+  public ResponseEntity<String> getAuthUrl(
+      Provider provider, String redirectUri, Object additionalState) {
     return ResponseEntity.ok(
-        jsonString(oauthApiController.getAuthorizationUrl(provider, redirectUri).getBody()));
+        jsonString(
+            oauthApiController
+                .getAuthorizationUrl(provider, redirectUri, additionalState)
+                .getBody()));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OidcApiController.java
@@ -48,13 +48,9 @@ public record OidcApiController(
   }
 
   @Override
-  public ResponseEntity<String> getAuthUrl(
-      Provider provider, String redirectUri, Object additionalState) {
+  public ResponseEntity<String> getAuthUrl(Provider provider, String redirectUri) {
     return ResponseEntity.ok(
-        jsonString(
-            oauthApiController
-                .getAuthorizationUrl(provider, redirectUri, additionalState)
-                .getBody()));
+        jsonString(oauthApiController.getAuthorizationUrl(provider, redirectUri).getBody()));
   }
 
   @Override

--- a/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
@@ -19,6 +19,8 @@ public interface OAuth2State extends WithOAuth2State {
 
   String getRedirectUri();
 
+  Object getAdditionalState();
+
   class Builder extends ImmutableOAuth2State.Builder {}
 
   default String encode(ObjectMapper objectMapper) {

--- a/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -19,7 +20,7 @@ public interface OAuth2State extends WithOAuth2State {
 
   String getRedirectUri();
 
-  Object getAdditionalState();
+  Optional<Object> getAdditionalState();
 
   class Builder extends ImmutableOAuth2State.Builder {}
 

--- a/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/OAuth2State.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -20,7 +21,7 @@ public interface OAuth2State extends WithOAuth2State {
 
   String getRedirectUri();
 
-  Optional<Object> getAdditionalState();
+  Optional<Map<String, String>> getAdditionalState();
 
   class Builder extends ImmutableOAuth2State.Builder {}
 

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -110,13 +110,16 @@ public class ProviderService {
     // oAuth2State is used to prevent CRSF attacks
     // see https://auth0.com/docs/secure/attack-protection/state-parameters
     // a random value is generated and stored here then validated in createLink below
-    var oAuth2State =
+    var oAuth2StateBuilder =
         new OAuth2State.Builder()
             .provider(provider)
             .random(OAuth2State.generateRandomState(secureRandom))
-            .redirectUri(redirectUri)
-            .additionalState(additionalState)
-            .build();
+            .redirectUri(redirectUri);
+    if (additionalState != null) {
+      oAuth2StateBuilder.additionalState(additionalState);
+    }
+    var oAuth2State = oAuth2StateBuilder.build();
+
     linkedAccountService.upsertOAuth2State(userId, oAuth2State);
 
     return oAuth2Service.getAuthorizationRequestUri(
@@ -145,6 +148,11 @@ public class ProviderService {
     } catch (CannotDecodeOAuth2State e) {
       throw new InvalidOAuth2State(e);
     }
+  }
+
+  public Object getAdditionalStateParams(String state) {
+    OAuth2State decodedState = OAuth2State.decode(objectMapper, state);
+    return decodedState.getAdditionalState();
   }
 
   protected ImmutablePair<LinkedAccount, OAuth2User> createLinkedAccount(

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -96,6 +96,11 @@ public class ProviderService {
   }
 
   public String getProviderAuthorizationUrl(String userId, Provider provider, String redirectUri) {
+    return getProviderAuthorizationUrl(userId, provider, redirectUri, null);
+  }
+
+  public String getProviderAuthorizationUrl(
+      String userId, Provider provider, String redirectUri, Object additionalState) {
     var providerClient = providerOAuthClientCache.getProviderClient(provider);
 
     var providerInfo = externalCredsConfig.getProviderProperties(provider);
@@ -110,6 +115,7 @@ public class ProviderService {
             .provider(provider)
             .random(OAuth2State.generateRandomState(secureRandom))
             .redirectUri(redirectUri)
+            .additionalState(additionalState)
             .build();
     linkedAccountService.upsertOAuth2State(userId, oAuth2State);
 

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -96,7 +97,7 @@ public class ProviderService {
   }
 
   public String getProviderAuthorizationUrl(
-      String userId, Provider provider, String redirectUri, Object additionalState) {
+      String userId, Provider provider, String redirectUri, Map<String, String> additionalState) {
     var providerClient = providerOAuthClientCache.getProviderClient(provider);
 
     var providerInfo = externalCredsConfig.getProviderProperties(provider);
@@ -146,7 +147,7 @@ public class ProviderService {
     }
   }
 
-  public Object getAdditionalStateParams(String state) {
+  public Optional<Map<String, String>> getAdditionalStateParams(String state) {
     OAuth2State decodedState = OAuth2State.decode(objectMapper, state);
     return decodedState.getAdditionalState();
   }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -95,10 +95,6 @@ public class ProviderService {
         .collect(Collectors.toSet());
   }
 
-  public String getProviderAuthorizationUrl(String userId, Provider provider, String redirectUri) {
-    return getProviderAuthorizationUrl(userId, provider, redirectUri, null);
-  }
-
   public String getProviderAuthorizationUrl(
       String userId, Provider provider, String redirectUri, Object additionalState) {
     var providerClient = providerOAuthClientCache.getProviderClient(provider);

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -364,6 +364,29 @@ class OauthApiControllerTest extends BaseTest {
     }
 
     @Test
+    void testGetAuthUrlWithAdditionalState() throws Exception {
+      var userId = "fakeUser";
+      var accessToken = "fakeAccessToken";
+      var result = "https://test/authorization/uri";
+      var redirectUri = "fakeuri";
+
+      mockSamUser(userId, accessToken);
+
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
+          .thenReturn(result);
+
+      var queryParams = new LinkedMultiValueMap<String, String>();
+      var additionalState = "{\"redirectTo\", \"http://fake-url.org\"}";
+      queryParams.add("redirectUri", redirectUri);
+      queryParams.add("additionalState", additionalState);
+      mvc.perform(
+              get("/api/oauth/v1/{provider}/authorization-url", provider)
+                  .header("authorization", "Bearer " + accessToken)
+                  .queryParams(queryParams))
+          .andExpect(content().string(result));
+    }
+
+    @Test
     void testGetAuthUrlBadRequest() throws Exception {
       var userId = "fakeUser";
       var accessToken = "fakeAccessToken";

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OidcApiControllerTest.java
@@ -88,7 +88,7 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri, null))
           .thenReturn(result);
 
       var queryParams = new LinkedMultiValueMap<String, String>();
@@ -108,7 +108,7 @@ class OidcApiControllerTest extends BaseTest {
 
       mockSamUser(userId, accessToken);
 
-      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri))
+      when(providerServiceMock.getProviderAuthorizationUrl(userId, provider, redirectUri, null))
           .thenThrow(new BadRequestException("Invalid redirectUri"));
 
       var queryParams = new LinkedMultiValueMap<String, String>();

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -925,7 +925,7 @@ public class ProviderServiceTest extends BaseTest {
 
       var result =
           providerService.getProviderAuthorizationUrl(
-              linkedAccount.getUserId(), linkedAccount.getProvider(), redirectUri);
+              linkedAccount.getUserId(), linkedAccount.getProvider(), redirectUri, null);
       assertNotNull(result);
       // the result here should be only the state because of the mock above
       var savedState = bio.terra.externalcreds.models.OAuth2State.decode(objectMapper, result);
@@ -1150,7 +1150,7 @@ public class ProviderServiceTest extends BaseTest {
           .thenReturn("");
 
       return providerService.getProviderAuthorizationUrl(
-          linkedAccount.getUserId(), linkedAccount.getProvider(), redirectUri);
+          linkedAccount.getUserId(), linkedAccount.getProvider(), redirectUri, null);
     }
   }
 

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -974,7 +974,7 @@ public class ProviderServiceTest extends BaseTest {
       // the result here should be only the state because of the mock above
       var savedState = bio.terra.externalcreds.models.OAuth2State.decode(objectMapper, result);
       assertEquals(linkedAccount.getProvider(), savedState.getProvider());
-      //      assertEquals(Optional.of(additionalStateParam), savedState.getAdditionalState());
+      assertEquals(Optional.of(additionalStateParam), savedState.getAdditionalState());
 
       assertTrue(oAuth2StateDAO.deleteOidcStateIfExists(linkedAccount.getUserId(), savedState));
       // double check that the state gets removed just in case


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-110

What:
Add a new POST authorization-url endpoint that allows users of ECM to include additional information in the oauth state parameter (which will persist after the user goes through the oauth flow). The information in the state will be returned in the createLink endpoint response.

Why:
This will allow a DUOS to specify a "redirectTo" location when a user links their NIH account.

How:
- Add a POST authorization-url endpoint that accepts arbitrary keys/values in the request body and includes them in the oauth state
<img width="1206" alt="Screenshot 2024-10-31 at 2 22 55 PM" src="https://github.com/user-attachments/assets/73c64ef4-0cb9-46ac-8cb1-aed7f1f98b1d">

- After ECM creates a linked account, decode the state and add `additionalState` to the response
<img width="1174" alt="Screenshot 2024-10-31 at 2 24 17 PM" src="https://github.com/user-attachments/assets/fa06e49f-9263-4597-bd6b-d2f20fa69423">


Testing:
In addition to unit testing, I ran ECM locally and tested the endpoints using the Github provider.