### PR TITLE
CORE-251 implemented admin get visas api

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -90,6 +90,47 @@ paths:
         '500':
           $ref: '#/components/responses/ServerError'
 
+  /api/admin/v1/{provider}/visas/{userId}:
+    get:
+      summary: Gets the visas a user has for a provider with the given type and issuer
+      tags: [ admin ]
+      operationId: getVisas
+      parameters:
+        - $ref: '#/components/parameters/providerParam'
+        - name: userId
+          in: path
+          description: The Sam User Id for a user
+          required: true
+          schema:
+            type: string
+        - name: visaType
+          in: query
+          description: The type of the requested visa
+          schema:
+            type: string
+          required: true
+        - name: issuer
+          in: query
+          description: The issuer of the requested visa
+          schema:
+            type: string
+          required: true
+      responses:
+        '200':
+          description: Visas matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '403':
+          $ref: '#/components/responses/PermissionDenied'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
   /api/oauth/v1/providers:
     get:
       summary: Lists the available OAuth providers.

--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -103,15 +103,15 @@ paths:
           required: true
           schema:
             type: string
-        - name: visaType
-          in: query
-          description: The type of the requested visa
-          schema:
-            type: string
-          required: true
         - name: issuer
           in: query
           description: The issuer of the requested visa
+          schema:
+            type: string
+          required: true
+        - name: visaType
+          in: query
+          description: The type of the requested visa
           schema:
             type: string
           required: true

--- a/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
@@ -7,6 +7,7 @@ import bio.terra.externalcreds.generated.model.AdminLinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.services.LinkedAccountService;
+import bio.terra.externalcreds.services.PassportService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import java.sql.Timestamp;
@@ -19,6 +20,7 @@ public record AdminApiController(
     HttpServletRequest request,
     ObjectMapper mapper,
     LinkedAccountService linkedAccountService,
+    PassportService passportService,
     ExternalCredsSamUserFactory samUserFactory,
     ExternalCredsConfig externalCredsConfig)
     implements AdminApi {
@@ -65,6 +67,16 @@ public record AdminApiController(
     requireAdmin();
     var linkedAccount = linkedAccountService.getLinkedAccountForExternalId(provider, externalId);
     return ResponseEntity.of(linkedAccount.map(OpenApiConverters.Output::convertAdmin));
+  }
+
+  @Override
+  public ResponseEntity<List<Object>> getVisas(
+      Provider provider, String userId, String visaType, String issuer) {
+    requireAdmin();
+    return ResponseEntity.ok(
+        passportService.getVisaClaims(provider, userId, issuer, visaType).stream()
+            .map(mapper::valueToTree)
+            .toList());
   }
 
   private void requireAdmin() {

--- a/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
@@ -71,7 +71,7 @@ public record AdminApiController(
 
   @Override
   public ResponseEntity<List<Object>> getVisas(
-      Provider provider, String userId, String visaType, String issuer) {
+      Provider provider, String userId, String issuer, String visaType) {
     requireAdmin();
     return ResponseEntity.ok(
         passportService.getVisaClaims(provider, userId, issuer, visaType).stream()

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAO.java
@@ -73,7 +73,7 @@ public class GA4GHVisaDAO {
   }
 
   @WithSpan
-  public List<GA4GHVisa> listUnexpiredVisasForIssuer(
+  public List<GA4GHVisa> listUnexpiredVisas(
       Provider provider, String userId, String issuer, String visaType) {
     var namedParameters =
         new MapSqlParameterSource()

--- a/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/JwtUtils.java
@@ -8,7 +8,6 @@ import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.LinkedAccountWithPassportAndVisas;
 import bio.terra.externalcreds.models.PassportWithVisas;
 import bio.terra.externalcreds.models.TokenTypeEnum;
-import com.google.common.annotations.VisibleForTesting;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTParser;
 import java.net.URI;
@@ -130,8 +129,7 @@ public record JwtUtils(ExternalCredsConfig externalCredsConfig, JwtDecoderCache 
         : TokenTypeEnum.access_token;
   }
 
-  @VisibleForTesting
-  Jwt decodeAndValidateJwt(String jwtString) {
+  public Jwt decodeAndValidateJwt(String jwtString) {
     try {
       // first we need to get the issuer from the jwt, the issuer is needed to validate
       var jwt = JWTParser.parse(jwtString);

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -147,7 +147,7 @@ public class PassportService {
   @ReadTransaction
   public List<Map<String, Object>> getVisaClaims(
       Provider provider, String userId, String issuer, String visaType) {
-    return visaDAO.listUnexpiredVisasForIssuer(provider, userId, issuer, visaType).stream()
+    return visaDAO.listUnexpiredVisas(provider, userId, issuer, visaType).stream()
         .map(GA4GHVisa::getJwt)
         .map(jwtUtils::decodeAndValidateJwt)
         .map(Jwt::getClaims)

--- a/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/PassportService.java
@@ -10,6 +10,7 @@ import bio.terra.externalcreds.dataAccess.GA4GHVisaDAO;
 import bio.terra.externalcreds.dataAccess.LinkedAccountDAO;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.GA4GHPassport;
+import bio.terra.externalcreds.models.GA4GHVisa;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.PassportWithVisas;
 import bio.terra.externalcreds.models.ValidatePassportResultInternal;
@@ -27,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -140,6 +142,16 @@ public class PassportService {
       invalidResult.auditInfo(Map.of("internal_user_id", linkedAccount.getUserId()));
     }
     return invalidResult.build();
+  }
+
+  @ReadTransaction
+  public List<Map<String, Object>> getVisaClaims(
+      Provider provider, String userId, String issuer, String visaType) {
+    return visaDAO.listUnexpiredVisasForIssuer(provider, userId, issuer, visaType).stream()
+        .map(GA4GHVisa::getJwt)
+        .map(jwtUtils::decodeAndValidateJwt)
+        .map(Jwt::getClaims)
+        .toList();
   }
 
   private boolean isPassportIssueTimeValid(GA4GHPassport passport) {

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
@@ -208,4 +208,90 @@ class GA4GHVisaDAOTest extends BaseTest {
     assertEquals(1, visas.size());
     assertEquals(expectedLastValidated, visas.get(0).getLastValidated().get());
   }
+
+  @Nested
+  class ListUnexpiredVisasForIssuer {
+    @Test
+    void testHappyPath() {
+      var randomVisa = TestUtils.createRandomVisa();
+
+      // insert some other user with a visa to make sure it doesn't get returned
+      var savedLinkedAccountOther =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassportOther =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport()
+                  .withLinkedAccountId(savedLinkedAccountOther.getId()));
+      visaDAO.insertVisa(randomVisa.withPassportId(savedPassportOther.getId()));
+
+      var savedLinkedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassport =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId()));
+      var savedVisa = visaDAO.insertVisa(randomVisa.withPassportId(savedPassport.getId()));
+      // insert some other visa to make sure it doesn't get returned
+      visaDAO.insertVisa(TestUtils.createRandomVisa().withPassportId(savedPassport.getId()));
+
+      var visas =
+          visaDAO.listUnexpiredVisasForIssuer(
+              savedLinkedAccount.getProvider(),
+              savedLinkedAccount.getUserId(),
+              savedVisa.getIssuer(),
+              savedVisa.getVisaType());
+      assertEquals(1, visas.size());
+      assertEquals(savedVisa, visas.get(0));
+    }
+
+    @Test
+    void testNoVisas() {
+      var savedLinkedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassport =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId()));
+      var savedVisa =
+          visaDAO.insertVisa(TestUtils.createRandomVisa().withPassportId(savedPassport.getId()));
+      assertEquals(
+          0,
+          visaDAO
+              .listUnexpiredVisasForIssuer(
+                  savedLinkedAccount.getProvider(),
+                  savedLinkedAccount.getUserId(),
+                  "different_issuer",
+                  savedVisa.getVisaType())
+              .size());
+      assertEquals(
+          0,
+          visaDAO
+              .listUnexpiredVisasForIssuer(
+                  savedLinkedAccount.getProvider(),
+                  savedLinkedAccount.getUserId(),
+                  savedVisa.getIssuer(),
+                  "different_type")
+              .size());
+    }
+
+    @Test
+    void testExpiredVisas() {
+      var savedLinkedAccount =
+          linkedAccountDAO.upsertLinkedAccount(TestUtils.createRandomLinkedAccount());
+      var savedPassport =
+          passportDAO.insertPassport(
+              TestUtils.createRandomPassport().withLinkedAccountId(savedLinkedAccount.getId()));
+      var savedVisa =
+          visaDAO.insertVisa(
+              TestUtils.createRandomVisa()
+                  .withPassportId(savedPassport.getId())
+                  .withExpires(
+                      new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli())));
+      var visas =
+          visaDAO.listUnexpiredVisasForIssuer(
+              savedLinkedAccount.getProvider(),
+              savedLinkedAccount.getUserId(),
+              savedVisa.getIssuer(),
+              savedVisa.getVisaType());
+      assertEquals(0, visas.size());
+    }
+  }
 }

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/GA4GHVisaDAOTest.java
@@ -210,7 +210,7 @@ class GA4GHVisaDAOTest extends BaseTest {
   }
 
   @Nested
-  class ListUnexpiredVisasForIssuer {
+  class ListUnexpiredVisas {
     @Test
     void testHappyPath() {
       var randomVisa = TestUtils.createRandomVisa();
@@ -234,7 +234,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       visaDAO.insertVisa(TestUtils.createRandomVisa().withPassportId(savedPassport.getId()));
 
       var visas =
-          visaDAO.listUnexpiredVisasForIssuer(
+          visaDAO.listUnexpiredVisas(
               savedLinkedAccount.getProvider(),
               savedLinkedAccount.getUserId(),
               savedVisa.getIssuer(),
@@ -255,7 +255,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       assertEquals(
           0,
           visaDAO
-              .listUnexpiredVisasForIssuer(
+              .listUnexpiredVisas(
                   savedLinkedAccount.getProvider(),
                   savedLinkedAccount.getUserId(),
                   "different_issuer",
@@ -264,7 +264,7 @@ class GA4GHVisaDAOTest extends BaseTest {
       assertEquals(
           0,
           visaDAO
-              .listUnexpiredVisasForIssuer(
+              .listUnexpiredVisas(
                   savedLinkedAccount.getProvider(),
                   savedLinkedAccount.getUserId(),
                   savedVisa.getIssuer(),
@@ -286,7 +286,7 @@ class GA4GHVisaDAOTest extends BaseTest {
                   .withExpires(
                       new Timestamp(Instant.now().minus(Duration.ofDays(1)).toEpochMilli())));
       var visas =
-          visaDAO.listUnexpiredVisasForIssuer(
+          visaDAO.listUnexpiredVisas(
               savedLinkedAccount.getProvider(),
               savedLinkedAccount.getUserId(),
               savedVisa.getIssuer(),


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-251

api response for a RAS visa looks like

```
[
  {
    "sub": "OFp5WRj7ewm8NxLHRTZ2Cyh4iYgpL3vpU3WbIZUDoRk",
    "ras_dbgap_permissions": [
      {
        "consent_name": "Unrestricted",
        "phs_id": "phs002409",
        "version": "v1",
        "participant_set": "p1",
        "consent_group": "c1",
        "role": "pi",
        "expiration": 1750444028
      },
      {
        "consent_name": "Unrestricted",
        "phs_id": "phs002410",
        "version": "v1",
        "participant_set": "p1",
        "consent_group": "c1",
        "role": "pi",
        "expiration": 1750444028
      }
    ],
    "ga4gh_visa_v1": {
      "type": "https://ras.nih.gov/visas/v1.1",
      "asserted": 1736867260,
      "value": "https://stsstg.nih.gov/passport/dbgap/v1.1",
      "source": "https://ncbi.nlm.nih.gov/gap",
      "by": "dac"
    },
    "scope": "openid ga4gh_passport_v1",
    "iss": "https://stsstg.nih.gov",
    "txn": "435d47c09c46b264.310e6e98e1791306",
    "exp": "2025-01-15T03:07:40Z",
    "iat": "2025-01-14T15:07:40Z",
    "jti": "bd241b6e-d148-4829-aa50-2e07dd295226"
  }
]
```