### PR TITLE
CORE-69: dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    open-pull-requests-limit: 10
+    groups:
+      minor-patch-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    schedule:
+      interval: "weekly"
+      time: "06:00"
+      timezone: "America/New_York"
+    target-branch: "dev"
+    reviewers:
+      - "@DataBiosphere/broad-core-services"
+    labels:
+      - "dependency"
+      - "gradle"
+    commit-message:
+      prefix: "[CORE-69]"


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-69

Set config for Dependabot in advance of turning on Dependabot updates.