### PR TITLE
CORE-288: exclude k8s client, which excludes jose4j

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,9 @@ dependencies {
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:4.9.0'
 
 	annotationProcessor 'org.immutables:value:2.9.2'
-	implementation 'bio.terra:terra-common-lib:0.1.9-SNAPSHOT'
+	implementation('bio.terra:terra-common-lib:0.1.9-SNAPSHOT') {
+		exclude group: 'io.kubernetes', module: 'client-java'
+	}
 	// https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on
 	implementation 'org.bouncycastle:bcprov-jdk18on:1.78'
 	implementation 'org.codehaus.janino:janino:3.1.9' // Provides if/else xml parsing for logback config


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-288

Exclude the k8s java client from the `terra-common-lib` dependency. The k8s client has a transitive dependency on `jose4j`. By excluding the k8s client, we exclude `jose4j` as requested in CORE-288.

This addresses part of CORE-288 but does not complete that ticket.
