### PR TITLE
CORE-357: update spotbugs to 6.1.6, with compatibility fixes

### DIFF
--- a/service/analysis.gradle
+++ b/service/analysis.gradle
@@ -15,8 +15,14 @@ jacocoTestReport {
 }
 
 spotbugs {
-	reportLevel = 'high'
-	effort = 'max'
+	// using a classloader here is ugly, but is the consensus solution from
+	// https://github.com/spotbugs/spotbugs-gradle-plugin/issues/972
+	def classLoader = plugins["com.github.spotbugs"].class.classLoader
+	def SpotBugsConfidence = classLoader.findLoadedClass("com.github.spotbugs.snom.Confidence")
+	def SpotBugsEffort = classLoader.findLoadedClass("com.github.spotbugs.snom.Effort")
+
+	reportLevel = SpotBugsConfidence.HIGH
+	effort = SpotBugsEffort.MAX
 	reportsDir = file("${project.reporting.baseDir}/spotbugs")
 	excludeFilter = file('../common/spotbugsExclude.xml')
 }

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 	id 'com.diffplug.spotless'
 	id 'com.github.ben-manes.versions' version '0.52.0'
-	id 'com.github.spotbugs' version '5.1.3'
+	id 'com.github.spotbugs' version '6.1.6'
 	id 'com.google.cloud.tools.jib'
 	id 'com.gorylenko.gradle-git-properties' version '2.4.2'
 	id 'io.freefair.lombok'


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-357

What:

Updates spotbugs to latest, with compatibility fixes. https://github.com/spotbugs/spotbugs-gradle-plugin/releases/tag/6.0.0 notes there are breaking changes; see code comment inline for our workaround.

Supersedes #231
