### PR TITLE
[CORE-223] Rework VisaCriterion inheritance to fix ValidatePassportResult deserialization issue

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -671,8 +671,7 @@ components:
         criteria:
           type: array
           items:
-            oneOf:
-              - $ref: '#/components/schemas/RASv1Dot1VisaCriterion'
+            $ref: '#/components/schemas/VisaCriterion'
 
     ValidatePassportResult:
       type: object
@@ -681,8 +680,7 @@ components:
         valid:
           type: boolean
         matchedCriterion:
-          oneOf:
-            - $ref: '#/components/schemas/RASv1Dot1VisaCriterion'
+          $ref: '#/components/schemas/VisaCriterion'
         auditInfo:
           type: object
           additionalProperties:
@@ -696,6 +694,12 @@ components:
           type: string
         issuer:
           type: string
+      discriminator:
+        propertyName: type
+        mapping:
+          RASv1Dot1VisaCriterion: '#/components/schemas/RASv1Dot1VisaCriterion'
+      oneOf:
+        - $ref: '#/components/schemas/RASv1Dot1VisaCriterion'
 
     RASv1Dot1VisaCriterion:
       allOf:

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
@@ -4,10 +4,9 @@ import bio.terra.common.exception.BadRequestException;
 import bio.terra.externalcreds.ExternalCredsException;
 import bio.terra.externalcreds.generated.model.AdminLinkInfo;
 import bio.terra.externalcreds.generated.model.LinkInfo;
-import bio.terra.externalcreds.generated.model.OneOfValidatePassportRequestCriteriaItems;
-import bio.terra.externalcreds.generated.model.OneOfValidatePassportResultMatchedCriterion;
 import bio.terra.externalcreds.generated.model.RASv1Dot1VisaCriterion;
 import bio.terra.externalcreds.generated.model.ValidatePassportResult;
+import bio.terra.externalcreds.generated.model.VisaCriterion;
 import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.models.ValidatePassportResultInternal;
 import bio.terra.externalcreds.visaComparators.RASv1Dot1VisaCriterionInternal;
@@ -23,8 +22,7 @@ public class OpenApiConverters {
 
   /** Converts openapi inputs to internal ECM models */
   public static class Input {
-    public static Collection<VisaCriterionInternal> convert(
-        Collection<OneOfValidatePassportRequestCriteriaItems> criteria) {
+    public static Collection<VisaCriterionInternal> convert(Collection<VisaCriterion> criteria) {
       return criteria.stream()
           .map(
               c -> {
@@ -52,8 +50,7 @@ public class OpenApiConverters {
       return returnVal;
     }
 
-    public static OneOfValidatePassportResultMatchedCriterion convert(
-        VisaCriterionInternal visaCriterion) {
+    public static VisaCriterion convert(VisaCriterionInternal visaCriterion) {
       if (visaCriterion instanceof RASv1Dot1VisaCriterionInternal rasCrit) {
         var converted =
             new RASv1Dot1VisaCriterion()

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OpenApiConverters.java
@@ -28,6 +28,7 @@ public class OpenApiConverters {
               c -> {
                 if (c instanceof RASv1Dot1VisaCriterion rasCrit) {
                   return new RASv1Dot1VisaCriterionInternal.Builder()
+                      .type(rasCrit.getType())
                       .issuer(rasCrit.getIssuer())
                       .phsId(rasCrit.getPhsId())
                       .consentCode(rasCrit.getConsentCode())
@@ -57,6 +58,7 @@ public class OpenApiConverters {
                 .consentCode(rasCrit.getConsentCode())
                 .phsId(rasCrit.getPhsId());
         converted.issuer(rasCrit.getIssuer());
+        converted.type(rasCrit.getType());
         return converted;
       } else {
         throw new ExternalCredsException(String.format("unknown visa criterion %s", visaCriterion));

--- a/service/src/main/java/bio/terra/externalcreds/visaComparators/VisaCriterionInternal.java
+++ b/service/src/main/java/bio/terra/externalcreds/visaComparators/VisaCriterionInternal.java
@@ -1,5 +1,7 @@
 package bio.terra.externalcreds.visaComparators;
 
 public interface VisaCriterionInternal {
+  String getType();
+
   String getIssuer();
 }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/PassportApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/PassportApiControllerTest.java
@@ -37,7 +37,7 @@ public class PassportApiControllerTest extends BaseTest {
   void testValidatePassport() throws Exception {
     var criteria = new ArrayList<VisaCriterion>();
     var criterion = new RASv1Dot1VisaCriterion().consentCode("c1").phsId("phs001234");
-    criterion.issuer("visa issuer");
+    criterion.issuer("visa issuer").type("RASv1Dot1VisaCriterion");
     criteria.add(criterion);
     var passportJwts = List.of("I am a passport");
     var req = new ValidatePassportRequest().passports(passportJwts).criteria(criteria);
@@ -47,6 +47,7 @@ public class PassportApiControllerTest extends BaseTest {
             .phsId(criterion.getPhsId())
             .consentCode(criterion.getConsentCode())
             .issuer(criterion.getIssuer())
+            .type(criterion.getType())
             .build();
 
     var resultInternal =

--- a/service/src/test/java/bio/terra/externalcreds/controllers/PassportApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/PassportApiControllerTest.java
@@ -6,10 +6,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import bio.terra.externalcreds.BaseTest;
-import bio.terra.externalcreds.generated.model.OneOfValidatePassportRequestCriteriaItems;
 import bio.terra.externalcreds.generated.model.RASv1Dot1VisaCriterion;
 import bio.terra.externalcreds.generated.model.ValidatePassportRequest;
 import bio.terra.externalcreds.generated.model.ValidatePassportResult;
+import bio.terra.externalcreds.generated.model.VisaCriterion;
 import bio.terra.externalcreds.models.ValidatePassportResultInternal;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.visaComparators.RASv1Dot1VisaCriterionInternal.Builder;
@@ -35,7 +35,7 @@ public class PassportApiControllerTest extends BaseTest {
 
   @Test
   void testValidatePassport() throws Exception {
-    var criteria = new ArrayList<OneOfValidatePassportRequestCriteriaItems>();
+    var criteria = new ArrayList<VisaCriterion>();
     var criterion = new RASv1Dot1VisaCriterion().consentCode("c1").phsId("phs001234");
     criterion.issuer("visa issuer");
     criteria.add(criterion);

--- a/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/PassportServiceTest.java
@@ -175,7 +175,12 @@ class PassportServiceTest extends BaseTest {
     @Test
     void testInvalidPassportThrows() {
       var criterion =
-          new RASv1Dot1VisaCriterionInternal.Builder().phsId("").consentCode("").issuer("").build();
+          new RASv1Dot1VisaCriterionInternal.Builder()
+              .phsId("")
+              .consentCode("")
+              .issuer("")
+              .type("")
+              .build();
 
       assertThrows(
           BadRequestException.class,
@@ -203,7 +208,12 @@ class PassportServiceTest extends BaseTest {
               .build());
 
       var criterion =
-          new RASv1Dot1VisaCriterionInternal.Builder().phsId("").consentCode("").issuer("").build();
+          new RASv1Dot1VisaCriterionInternal.Builder()
+              .phsId("")
+              .consentCode("")
+              .issuer("")
+              .type("")
+              .build();
 
       assertThrows(
           BadRequestException.class,
@@ -273,6 +283,7 @@ class PassportServiceTest extends BaseTest {
               .phsId(params.criterionPhsId)
               .consentCode(matchingPermission.getConsentGroup())
               .issuer(params.issuer)
+              .type("RASv1Dot1VisaCriterion")
               .build();
 
       var result =


### PR DESCRIPTION
Jira: [CORE-223](https://broadworkbench.atlassian.net/browse/CORE-223)


**What:**
* Make `RASv1Dot1VisaCriterion` a subtype of `VisaCriterion` and reference `VisaCriterion` directly instead of `RASv1Dot1VisaCriterion`.
* Breaking change: `OneOfValidatePassportRequestCriteriaItems` and `OneOfValidatePassportResultMatchedCriterion` are no longer part of the generated client. Replace usage with either `VisaCriterion` or `RASv1Dot1VisaCriterion` as needed.

**Why:**
TDR was failing to deserialize the `ValidatePassportResult` response from ECM because of a bug in the generated ECM model classes caused by the change introduced in https://github.com/swagger-api/swagger-codegen-generators/pull/1259 which was pulled into ECM when upgrading `swagger-codegen-cli` past 3.0.54 (https://github.com/DataBiosphere/terra-external-credentials-manager/pull/227, ECM `v1.63.0`). Before this change, the class representing the validation criterion looked like this:

```
@JsonTypeInfo(
  use = Id.NAME,
  include = As.PROPERTY,
  property = "type"
)
@JsonSubTypes({@Type(
  value = RASv1Dot1VisaCriterion.class,
  name = "RASv1Dot1VisaCriterion"
)})
public interface OneOfValidatePassportResultMatchedCriterion {
}
```

Note the `property = "type"` in the `@JsonTypeInfo` annotation. After https://github.com/DataBiosphere/terra-external-credentials-manager/pull/227, the same class was generated as:
```
@JsonTypeInfo(
  use = Id.NAME,
  include = As.PROPERTY,
  property = ""
)
@JsonSubTypes({@Type(
  value = RASv1Dot1VisaCriterion.class,
  name = "RASv1Dot1VisaCriterion"
)})
public interface OneOfValidatePassportResultMatchedCriterion {
}
```
The empty string set as the `property` value meant TDR was unable to determine which class the JSON was meant to deserialize into and led to errors like
```
com.fasterxml.jackson.databind.exc.InvalidTypeIdException: Could not resolve subtype of [simple type, class bio.terra.externalcreds.model.OneOfValidatePassportResultMatchedCriterion]: missing type id property '@type' (for POJO property 'matchedCriterion')
```


**How:**
This PR redesigns the inheritance of these model classes and introduces the `discriminator` which is designed to help API consumers determine the type of the object when using polymorphism ([source](https://swagger.io/docs/specification/v3_0/data-models/inheritance-and-polymorphism/#discriminator)). The change in the swagger generator that necessitated this fix was about better supporting the use of discriminators and specifically changed the `property` value in the `@JsonTypeInfo` annotation to stop hardcoding `type` and instead use `discriminator.propertyName` ([source](https://github.com/swagger-api/swagger-codegen-generators/pull/1259/files#diff-498a38db7b07d65092d59ecad0b461af287603cf288eb8e6201293bdf221d38f)). 

I tested this by generating and publishing a client from this branch, pulling that client library into TDR on my BEE, and verifying that TDR could successfully gate access to snapshots based on the visas in my passport.

[CORE-223]: https://broadworkbench.atlassian.net/browse/CORE-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ