### PR TITLE
CORE-332: don't send client errors to Sentry

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/controllers/GlobalExceptionHandler.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/GlobalExceptionHandler.java
@@ -65,7 +65,13 @@ public class GlobalExceptionHandler {
 
   private ResponseEntity<ErrorReport> buildErrorReport(
       @NotNull Throwable ex, HttpStatus statusCode) {
-    log.error("Global exception handler:", ex);
+    // only log server errors at error level, which will alert sentry; log other
+    // errors at warn
+    if (statusCode.is5xxServerError() || statusCode.value() == 0) {
+      log.error("Global exception handler:", ex);
+    } else {
+      log.warn("Global exception handler:", ex);
+    }
 
     var errorReport = new ErrorReport().message(ex.getMessage()).statusCode(statusCode.value());
     return ResponseEntity.status(statusCode).body(errorReport);


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-332

#253 started throwing a `NotFoundException` when asking for a fence key. That exception is showing up in Sentry.

This PR changes ECM's logging such that it only logs 5xx errors (or status code 0) at error level, which Sentry reads. Other errors, such as the 404 from `NotFoundException`, are now logged at warn level.