### PR TITLE
CORE-376: turn off double-tracing and 'failed to export spans' error

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:6.1.0'
 
 	annotationProcessor 'org.immutables:value:2.10.1'
-	implementation('bio.terra:terra-common-lib:1.1.35-SNAPSHOT') {
+	implementation('bio.terra:terra-common-lib:1.1.39-SNAPSHOT') {
 		exclude group: 'io.kubernetes', module: 'client-java'
 	}
 	// https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-376

Update TCL to get its fix for the "failed to export spans" error.

See https://github.com/DataBiosphere/terra-common-lib/pull/229