### PR TITLE
[CORE-418] Make dependabot run monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
           - "minor"
           - "patch"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       time: "06:00"
       timezone: "America/New_York"
     target-branch: "dev"


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-418

What: Update dependabot alert to run on the 1st of each month to reduce maintenance effort from team.