### PR TITLE
CORE-490 federated_identities scope and logging

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
+++ b/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
@@ -19,9 +19,10 @@ public interface AuditLogEvent extends WithAuditLogEvent {
   @JsonInclude(Include.NON_EMPTY)
   @Value.Derived
   default Optional<String> getProviderName() {
-    return Optional.of(provider().toString());
+    return provider().map(Provider::toString);
   }
 
+  @JsonInclude(Include.NON_EMPTY)
   Optional<Provider> provider();
 
   @JsonInclude(Include.NON_EMPTY)

--- a/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
+++ b/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEvent.java
@@ -4,6 +4,7 @@ import bio.terra.externalcreds.generated.model.Provider;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -31,6 +32,9 @@ public interface AuditLogEvent extends WithAuditLogEvent {
 
   @JsonInclude(Include.NON_EMPTY)
   Optional<String> getTransactionClaim();
+
+  @JsonInclude(Include.NON_EMPTY)
+  Optional<Map<String, Object>> getAdditionalInfo();
 
   AuditLogEventType getAuditLogEventType();
 

--- a/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEventType.java
+++ b/service/src/main/java/bio/terra/externalcreds/auditLogging/AuditLogEventType.java
@@ -16,4 +16,5 @@ public enum AuditLogEventType {
   SshKeyPairDeleted,
   SshKeyPairDeletionFailed,
   PutSshKeyPair,
+  GetUserInfo,
 }

--- a/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ProviderPropertiesInterface.java
@@ -48,4 +48,9 @@ public interface ProviderPropertiesInterface {
   Optional<String> getJwksUri();
 
   Optional<String> getValidationEndpoint();
+
+  @Value.Default
+  default Collection<String> getLoggedUserInfoFields() {
+    return List.of();
+  }
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/OAuth2Service.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/OAuth2Service.java
@@ -1,6 +1,11 @@
 package bio.terra.externalcreds.services;
 
+import bio.terra.externalcreds.auditLogging.AuditLogEvent.Builder;
+import bio.terra.externalcreds.auditLogging.AuditLogEventType;
+import bio.terra.externalcreds.auditLogging.AuditLogger;
+import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.config.ProviderProperties;
+import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.models.LinkedAccount;
 import com.nimbusds.oauth2.sdk.TokenRevocationRequest;
 import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
@@ -11,7 +16,9 @@ import java.io.IOException;
 import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.DefaultRefreshTokenTokenResponseClient;
@@ -44,6 +51,14 @@ import org.springframework.stereotype.Service;
 @Service
 @Slf4j
 public class OAuth2Service {
+  private final ExternalCredsConfig externalCredsConfig;
+  private final AuditLogger auditLogger;
+
+  public OAuth2Service(ExternalCredsConfig externalCredsConfig, AuditLogger auditLogger) {
+    this.externalCredsConfig = externalCredsConfig;
+    this.auditLogger = auditLogger;
+  }
+
   /**
    * Construct authorization uri user should visit to authenticate
    *
@@ -143,9 +158,30 @@ public class OAuth2Service {
     return refreshTokenTokenResponseClient.getTokenResponse(refreshTokenGrantRequest);
   }
 
-  public OAuth2User getUserInfo(ClientRegistration providerClient, OAuth2AccessToken accessToken) {
+  public OAuth2User getUserInfo(
+      String userId,
+      ClientRegistration providerClient,
+      Provider provider,
+      OAuth2AccessToken accessToken) {
     var userRequest = new OAuth2UserRequest(providerClient, accessToken);
-    return new DefaultOAuth2UserService().loadUser(userRequest);
+    var oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+    var additionalAuditInfo =
+        externalCredsConfig.getProviderProperties(provider).getLoggedUserInfoFields().stream()
+            .flatMap(
+                field ->
+                    Optional.ofNullable(oAuth2User.getAttribute(field)).stream()
+                        .map(value -> Map.entry(field, value)))
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    var auditLogBuilder =
+        new Builder()
+            .userId(userId)
+            .provider(provider)
+            .auditLogEventType(AuditLogEventType.GetUserInfo)
+            .additionalInfo(additionalAuditInfo);
+    auditLogger.logEvent(auditLogBuilder.build());
+
+    return oAuth2User;
   }
 
   /**

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -193,7 +193,8 @@ public class ProviderService {
 
     var expires = new Timestamp(Instant.now().plus(providerInfo.getLinkLifespan()).toEpochMilli());
 
-    var userInfo = oAuth2Service.getUserInfo(providerClient, tokenResponse.getAccessToken());
+    var userInfo =
+        oAuth2Service.getUserInfo(userId, providerClient, provider, tokenResponse.getAccessToken());
 
     String externalUserId = userInfo.getAttribute(providerInfo.getExternalIdClaim());
     if (externalUserId == null) {
@@ -290,11 +291,6 @@ public class ProviderService {
               providerClient);
 
       var linkedAccountWithPassportAndVisas = upsertLinkedAccount(providerInfo, linkedAccount);
-
-      var federatedIdentities =
-          Optional.ofNullable(linkedAccount.getRight().getAttribute("federated_identities"));
-      federatedIdentities.ifPresent(
-          fi -> auditLogEventBuilder.additionalInfo(Map.of("federated_identities", fi)));
 
       logLinkCreation(Optional.of(linkedAccountWithPassportAndVisas), auditLogEventBuilder);
       return linkedAccountWithPassportAndVisas;
@@ -496,7 +492,11 @@ public class ProviderService {
 
     // update the passport and visas
     var userInfo =
-        oAuth2Service.getUserInfo(clientRegistration, accessTokenResponse.getAccessToken());
+        oAuth2Service.getUserInfo(
+            linkedAccount.getUserId(),
+            clientRegistration,
+            linkedAccount.getProvider(),
+            accessTokenResponse.getAccessToken());
     return jwtUtils.enrichAccountWithPassportAndVisas(linkedAccountWithRefreshToken, userInfo);
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -291,6 +291,11 @@ public class ProviderService {
 
       var linkedAccountWithPassportAndVisas = upsertLinkedAccount(providerInfo, linkedAccount);
 
+      var federatedIdentities =
+          Optional.ofNullable(linkedAccount.getRight().getAttribute("federated_identities"));
+      federatedIdentities.ifPresent(
+          fi -> auditLogEventBuilder.additionalInfo(Map.of("federated_identities", fi)));
+
       logLinkCreation(Optional.of(linkedAccountWithPassportAndVisas), auditLogEventBuilder);
       return linkedAccountWithPassportAndVisas;
     } catch (OAuth2AuthorizationException oauthEx) {

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -120,12 +120,14 @@ externalcreds:
 #non-prod environments
 spring.config.activate.on-profile: '!prod'
 externalcreds:
+  allowed-jwt-issuers:
+    - ${externalcreds.providers.ras.issuer}
   providers:
     ras:
       clientId: "${RAS_CLIENT_ID}"
       clientSecret: "${RAS_CLIENT_SECRET}"
       externalIdClaim: "preferred_username"
-      scopes: [ "openid","email","ga4gh_passport_v1","profile" ]
+      scopes: [ "openid","email","ga4gh_passport_v1","profile", "federated_identities" ]
       linkLifespan: "15d"
       issuer: "https://stsstg.nih.gov"
       revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke"

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -135,6 +135,7 @@ externalcreds:
       validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
       additionalAuthorizationParameters: { "prompt": "login" }
       deniedEmailPatterns: ${shared.deniedEmailPatterns}
+      loggedUserInfoFields: [ "preferred_username", "txn", "federated_identities" ]
     era-commons:
       clientId: "${ERA_COMMONS_CLIENT_ID}"
       clientSecret: "${ERA_COMMONS_CLIENT_SECRET}"

--- a/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/AuthorizationCodeExchangeTest.java
@@ -248,7 +248,11 @@ class AuthorizationCodeExchangeTest extends BaseTest {
             encodedState,
             providerInfo.getAdditionalAuthorizationParameters()))
         .thenReturn(tokenResponse);
-    when(oAuth2ServiceMock.getUserInfo(providerClient, tokenResponse.getAccessToken()))
+    when(oAuth2ServiceMock.getUserInfo(
+            linkedAccount.getUserId(),
+            providerClient,
+            linkedAccount.getProvider(),
+            tokenResponse.getAccessToken()))
         .thenReturn(new DefaultOAuth2User(null, Map.of("foo", "bar"), "foo"));
 
     assertThrows(
@@ -305,7 +309,11 @@ class AuthorizationCodeExchangeTest extends BaseTest {
             state,
             providerInfo.getAdditionalAuthorizationParameters()))
         .thenReturn(accessTokenResponse);
-    when(oAuth2ServiceMock.getUserInfo(providerClient, accessTokenResponse.getAccessToken()))
+    when(oAuth2ServiceMock.getUserInfo(
+            linkedAccount.getUserId(),
+            providerClient,
+            linkedAccount.getProvider(),
+            accessTokenResponse.getAccessToken()))
         .thenReturn(user);
   }
 

--- a/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/OAuth2ServiceTest.java
@@ -69,7 +69,9 @@ public class OAuth2ServiceTest {
         "refresh token:__________" + tokenResponse.getRefreshToken().getTokenValue());
 
     // 4) test getUserInfo
-    var oAuth2User = oAuth2Service.getUserInfo(providerClient, tokenResponse.getAccessToken());
+    var oAuth2User =
+        oAuth2Service.getUserInfo(
+            "doesn't matter", providerClient, provider, tokenResponse.getAccessToken());
 
     // oAuth2User should have the user's passport and email address in the attributes
     System.out.println(oAuth2User.toString());

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -503,7 +503,12 @@ public class ProviderServiceTest extends BaseTest {
           .thenReturn(oAuth2TokenResponse);
 
       // returning null here because it's passed to another mocked function and isn't worth mocking
-      when(oAuth2ServiceMock.getUserInfo(eq(clientRegistration), Mockito.any())).thenReturn(null);
+      when(oAuth2ServiceMock.getUserInfo(
+              eq(savedLinkedAccount.getUserId()),
+              eq(clientRegistration),
+              eq(savedLinkedAccount.getProvider()),
+              Mockito.any()))
+          .thenReturn(null);
 
       // mock the LinkedAccountWithPassportAndVisas that would normally be read from a JWT
       var refreshedPassport =


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-490

adds `federated_identities` to the list of scopes requested of RAS and implements some configurable logging of user info fields each time user info is requested (which is how we get passports)