### PR TITLE
DDO-4131 read artifacts from google artifact registry

### DIFF
--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-snapshot' }
+	maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
 }
 
 dependencies {

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -16,8 +16,8 @@ plugins {
 
 repositories {
 	mavenCentral()
-	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-snapshot' }
-	maven { url 'https://broadinstitute.jfrog.io/artifactory/libs-release' }
+	maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/' }
+	maven { url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-release/' }
 }
 
 apply from: 'publishing.gradle'

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,8 +8,7 @@ pluginManagement {
 			}
 		}
 		maven {
-			// todo: plugins-snapshot not provisioned yet in GAR
-			url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
+			url 'https://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot/'
 		}
 		gradlePluginPortal()
 	}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ pluginManagement {
 			}
 		}
 		maven {
+			// todo: plugins-snapshot not provisioned yet in GAR
 			url 'https://broadinstitute.jfrog.io/artifactory/plugins-snapshot'
 		}
 		gradlePluginPortal()


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/DDO-4131

**Summary of changes**
Updated the artifact source for this service to read artifacts from Google Artifact Registry instead of JFrog.

**What**
Modified the config to pull artifacts from GAR. No publishing changes were made.

**Why**
This is part of Phase 2 of the artifact migration effort to deprecated JFrog and consolidate artifacts in GAR.

**Testing these changes**
Relied on passing CI checks and tests. Artifact reading-related issues are expected to surface as pipeline failures. For example these jobs [here](https://github.com/DataBiosphere/terra-scientific-pipelines-service/actions/runs/15309876591/job/43071753325?pr=222) and [here](https://github.com/DataBiosphere/leonardo/actions/runs/15324072477/job/43114134405?pr=4858) failed due to access issues (which have since been resolved).