### PR TITLE
CORE-594: bump spotbugs and spotbugs-annotations

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -5,7 +5,7 @@ plugins {
 
 	id 'com.diffplug.spotless'
 	id 'com.github.ben-manes.versions' version '0.52.0'
-	id 'com.github.spotbugs' version '6.1.13'
+	id 'com.github.spotbugs' version '6.2.1'
 	id 'com.google.cloud.tools.jib'
 	id 'com.gorylenko.gradle-git-properties' version '2.5.0'
 	id 'io.freefair.lombok'
@@ -63,6 +63,13 @@ dependencies {
 
 	implementation 'org.apache.commons:commons-compress:1.27.1'
 
+}
+
+dependencyManagement {
+	dependencies {
+		// required by SpotBugs 6.2
+		dependency ("com.github.spotbugs:spotbugs-annotations:4.9.3")
+	}
 }
 
 gitProperties {


### PR DESCRIPTION
Jira: CORE-594

Bumps the spotbugs plugin to 6.2.1. Dependabot tried this in #280 but the build failed.

This PR reimplements that bump along with the recommended fix from `https://github.com/spotbugs/spotbugs-gradle-plugin/issues/1395` which also bumps spotbugs-annotations.