### PR TITLE
[CORE-560] Return Linked Era Commons User Id

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -598,6 +598,10 @@ components:
           format: date-time
         authenticated:
           type: boolean
+        additionalProperties:
+          type: object
+          additionalProperties:
+            type: string
         additionalState:
           type: object
           additionalProperties:

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -63,6 +63,8 @@ dependencies {
 
 	implementation 'org.apache.commons:commons-compress:1.27.1'
 
+	implementation 'org.postgresql:postgresql:42.6.0'
+
 }
 
 dependencyManagement {

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAO.java
@@ -23,16 +23,34 @@ import org.springframework.stereotype.Repository;
 public class LinkedAccountDAO {
 
   private static final RowMapper<LinkedAccount> LINKED_ACCOUNT_ROW_MAPPER =
-      ((rs, rowNum) ->
-          new LinkedAccount.Builder()
-              .id(rs.getInt("id"))
-              .userId(rs.getString("user_id"))
-              .provider(Provider.valueOf(rs.getString("provider")))
-              .refreshToken(rs.getString("refresh_token"))
-              .expires(rs.getTimestamp("expires"))
-              .externalUserId(rs.getString("external_user_id"))
-              .isAuthenticated(rs.getBoolean("is_authenticated"))
-              .build());
+      ((rs, rowNum) -> {
+        Map<String, String> additionalProperties;
+        try {
+          String jsonStr = rs.getString("additional_properties");
+          additionalProperties =
+              jsonStr != null
+                  ? new com.fasterxml.jackson.databind.ObjectMapper()
+                      .readValue(
+                          jsonStr,
+                          new com.fasterxml.jackson.core.type.TypeReference<
+                              Map<String, String>>() {})
+                  : new HashMap<>();
+        } catch (Exception e) {
+          log.error("Error parsing additional_properties JSON", e);
+          additionalProperties = new HashMap<>();
+        }
+
+        return new LinkedAccount.Builder()
+            .id(rs.getInt("id"))
+            .userId(rs.getString("user_id"))
+            .provider(Provider.valueOf(rs.getString("provider")))
+            .refreshToken(rs.getString("refresh_token"))
+            .expires(rs.getTimestamp("expires"))
+            .externalUserId(rs.getString("external_user_id"))
+            .isAuthenticated(rs.getBoolean("is_authenticated"))
+            .additionalProperties(additionalProperties)
+            .build();
+      });
 
   final NamedParameterJdbcTemplate jdbcTemplate;
 
@@ -82,13 +100,13 @@ public class LinkedAccountDAO {
   public LinkedAccount upsertLinkedAccount(LinkedAccount linkedAccount) {
     var query =
         "INSERT INTO linked_account (user_id, provider, refresh_token, expires, external_user_id, is_authenticated, additional_properties)"
-            + " VALUES (:userId, :provider::provider_enum, :refreshToken, :expires, :externalUserId, :isAuthenticated, :additionalProperties)"
+            + " VALUES (:userId, :provider::provider_enum, :refreshToken, :expires, :externalUserId, :isAuthenticated, CAST(:additionalProperties AS json))"
             + " ON CONFLICT (user_id, provider) DO UPDATE SET"
             + " refresh_token = excluded.refresh_token,"
             + " expires = excluded.expires,"
             + " external_user_id = excluded.external_user_id,"
             + " is_authenticated = excluded.is_authenticated,"
-            + " additional_properties = jsonb_set(excluded.additional_properties, '{}', '{}'::jsonb, true)"
+            + " additional_properties = CAST(:additionalProperties AS json)"
             + " RETURNING id";
 
     var namedParameters =
@@ -98,8 +116,18 @@ public class LinkedAccountDAO {
             .addValue("refreshToken", linkedAccount.getRefreshToken())
             .addValue("expires", linkedAccount.getExpires())
             .addValue("externalUserId", linkedAccount.getExternalUserId())
-            .addValue("isAuthenticated", linkedAccount.isAuthenticated())
-            .addValue("additionalProperties", linkedAccount.getAdditionalProperties());
+            .addValue("isAuthenticated", linkedAccount.isAuthenticated());
+
+    try {
+      org.postgresql.util.PGobject jsonObject = new org.postgresql.util.PGobject();
+      jsonObject.setType("json");
+      jsonObject.setValue(
+          new com.fasterxml.jackson.databind.ObjectMapper()
+              .writeValueAsString(linkedAccount.getAdditionalProperties()));
+      namedParameters.addValue("additionalProperties", jsonObject);
+    } catch (Exception e) {
+      throw new RuntimeException("Error converting additional properties to JSON", e);
+    }
 
     // generatedKeyHolder will hold the id returned by the query as specified by the RETURNING
     // clause

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAO.java
@@ -81,13 +81,14 @@ public class LinkedAccountDAO {
   @WithSpan
   public LinkedAccount upsertLinkedAccount(LinkedAccount linkedAccount) {
     var query =
-        "INSERT INTO linked_account (user_id, provider, refresh_token, expires, external_user_id, is_authenticated)"
-            + " VALUES (:userId, :provider::provider_enum, :refreshToken, :expires, :externalUserId, :isAuthenticated)"
+        "INSERT INTO linked_account (user_id, provider, refresh_token, expires, external_user_id, is_authenticated, additional_properties)"
+            + " VALUES (:userId, :provider::provider_enum, :refreshToken, :expires, :externalUserId, :isAuthenticated, :additionalProperties)"
             + " ON CONFLICT (user_id, provider) DO UPDATE SET"
             + " refresh_token = excluded.refresh_token,"
             + " expires = excluded.expires,"
             + " external_user_id = excluded.external_user_id,"
-            + " is_authenticated = excluded.is_authenticated"
+            + " is_authenticated = excluded.is_authenticated,"
+            + " additional_properties = jsonb_set(excluded.additional_properties, '{}', '{}'::jsonb, true)"
             + " RETURNING id";
 
     var namedParameters =
@@ -97,7 +98,8 @@ public class LinkedAccountDAO {
             .addValue("refreshToken", linkedAccount.getRefreshToken())
             .addValue("expires", linkedAccount.getExpires())
             .addValue("externalUserId", linkedAccount.getExternalUserId())
-            .addValue("isAuthenticated", linkedAccount.isAuthenticated());
+            .addValue("isAuthenticated", linkedAccount.isAuthenticated())
+            .addValue("additionalProperties", linkedAccount.getAdditionalProperties());
 
     // generatedKeyHolder will hold the id returned by the query as specified by the RETURNING
     // clause

--- a/service/src/main/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAO.java
+++ b/service/src/main/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAO.java
@@ -100,13 +100,13 @@ public class LinkedAccountDAO {
   public LinkedAccount upsertLinkedAccount(LinkedAccount linkedAccount) {
     var query =
         "INSERT INTO linked_account (user_id, provider, refresh_token, expires, external_user_id, is_authenticated, additional_properties)"
-            + " VALUES (:userId, :provider::provider_enum, :refreshToken, :expires, :externalUserId, :isAuthenticated, CAST(:additionalProperties AS json))"
+            + " VALUES (:userId, :provider::provider_enum, :refreshToken, :expires, :externalUserId, :isAuthenticated, CAST(:additionalProperties AS jsonb))"
             + " ON CONFLICT (user_id, provider) DO UPDATE SET"
             + " refresh_token = excluded.refresh_token,"
             + " expires = excluded.expires,"
             + " external_user_id = excluded.external_user_id,"
             + " is_authenticated = excluded.is_authenticated,"
-            + " additional_properties = CAST(:additionalProperties AS json)"
+            + " additional_properties = CAST(excluded.additional_properties AS jsonb)"
             + " RETURNING id";
 
     var namedParameters =
@@ -120,13 +120,13 @@ public class LinkedAccountDAO {
 
     try {
       org.postgresql.util.PGobject jsonObject = new org.postgresql.util.PGobject();
-      jsonObject.setType("json");
+      jsonObject.setType("jsonb");
       jsonObject.setValue(
           new com.fasterxml.jackson.databind.ObjectMapper()
               .writeValueAsString(linkedAccount.getAdditionalProperties()));
       namedParameters.addValue("additionalProperties", jsonObject);
     } catch (Exception e) {
-      throw new RuntimeException("Error converting additional properties to JSON", e);
+      throw new RuntimeException("Error converting additional properties to JSONB", e);
     }
 
     // generatedKeyHolder will hold the id returned by the query as specified by the RETURNING

--- a/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
@@ -3,6 +3,7 @@ package bio.terra.externalcreds.models;
 import bio.terra.externalcreds.generated.model.Provider;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -25,6 +26,8 @@ public interface LinkedAccount extends WithLinkedAccount {
   default boolean isExpired() {
     return getExpires().toInstant().isBefore(Instant.now());
   }
+
+  Map<String, String> getAdditionalProperties();
 
   class Builder extends ImmutableLinkedAccount.Builder {}
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -203,15 +203,21 @@ public class ProviderService {
               "user info from provider %s did not contain external id claim %s",
               provider, providerInfo.getExternalIdClaim()));
     }
-    LinkedAccount linkedAccount =
+    LinkedAccount.Builder linkedAccountBuilder =
         new LinkedAccount.Builder()
             .provider(provider)
             .userId(userId)
             .expires(expires)
             .externalUserId(externalUserId)
             .refreshToken(refreshToken.getTokenValue())
-            .isAuthenticated(true)
-            .build();
+            .isAuthenticated(true);
+
+    if (provider == Provider.RAS) {
+      var federatedIdentities = userInfo.getAttribute("federated_identities");
+      var eraUserId = ProviderUtils.getLinkedEraIdentity(federatedIdentities);
+      linkedAccountBuilder.additionalProperties(Map.of("era_user_id", eraUserId));
+    }
+    LinkedAccount linkedAccount = linkedAccountBuilder.build();
     return new ImmutablePair<>(linkedAccount, userInfo);
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -29,9 +29,13 @@ public class ProviderUtils {
     if (federatedIdentities != null) {
       try {
         if (federatedIdentities instanceof String) {
+          logger.info("Found federated identities String");
           identitiesMap = objectMapper.readValue((String) federatedIdentities, Map.class);
         } else if (federatedIdentities instanceof Map<?, ?>) {
+          logger.info("Found federated identities map");
           identitiesMap = (Map<String, Object>) federatedIdentities;
+        } else {
+          logger.info("Found federated identities of unknown type: {}", federatedIdentities.getClass());
         }
 
         if (identitiesMap != null

--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -35,7 +35,8 @@ public class ProviderUtils {
           logger.info("Found federated identities map");
           identitiesMap = (Map<String, Object>) federatedIdentities;
         } else {
-          logger.info("Found federated identities of unknown type: {}", federatedIdentities.getClass());
+          logger.info(
+              "Found federated identities of unknown type: {}", federatedIdentities.getClass());
         }
 
         if (identitiesMap != null

--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -3,12 +3,61 @@ package bio.terra.externalcreds.util;
 import static bio.terra.externalcreds.services.JwtUtils.GA4GH_PASSPORT_V1_CLAIM;
 
 import bio.terra.externalcreds.config.ProviderProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ProviderUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProviderUtils.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private ProviderUtils() {}
 
   public static boolean isPassportProvider(ProviderProperties providerProperties) {
     return providerProperties.getScopes().contains(GA4GH_PASSPORT_V1_CLAIM);
+  }
+
+  public static String getLinkedEraIdentity(Object federatedIdentities) {
+    logger.info("Federated Identities: {}", federatedIdentities);
+
+    Map<String, Object> identitiesMap = null;
+    String eraUserId = null;
+    if (federatedIdentities != null) {
+      try {
+        if (federatedIdentities instanceof String) {
+          identitiesMap = objectMapper.readValue((String) federatedIdentities, Map.class);
+        } else if (federatedIdentities instanceof Map<?, ?>) {
+          identitiesMap = (Map<String, Object>) federatedIdentities;
+        }
+
+        if (identitiesMap != null
+            && identitiesMap.containsKey("identities")
+            && identitiesMap.get("identities") instanceof List) {
+          @SuppressWarnings("unchecked")
+          List<Map<String, Object>> identitiesList =
+              (List<Map<String, Object>>) identitiesMap.get("identities");
+
+          for (Map<String, Object> identity : identitiesList) {
+            if (identity.containsKey("era") && identity.get("era") instanceof Map) {
+              @SuppressWarnings("unchecked")
+              Map<String, Object> eraInfo = (Map<String, Object>) identity.get("era");
+              eraUserId = (String) eraInfo.get("userid");
+              if (eraUserId != null) {
+                break;
+              }
+            }
+          }
+        }
+      } catch (IOException e) {
+        logger.info("Error parseing federated identities: {}", e.getMessage());
+      } catch (Exception e) {
+        logger.info("Error extracting linked ERA identity: {}", e.getMessage());
+      }
+    }
+    return eraUserId;
   }
 }

--- a/service/src/main/resources/db/changelog/changesets/20250714_add_linked_account_properties.yaml
+++ b/service/src/main/resources/db/changelog/changesets/20250714_add_linked_account_properties.yaml
@@ -8,6 +8,6 @@ databaseChangeLog:
             columns:
               - column:
                   name: additional_properties
-                  type: json
+                  type: jsonb
                   constraints:
                     nullable: true

--- a/service/src/main/resources/db/changelog/changesets/20250714_add_linked_account_properties.yaml
+++ b/service/src/main/resources/db/changelog/changesets/20250714_add_linked_account_properties.yaml
@@ -1,0 +1,13 @@
+databaseChangeLog:
+  - changeSet:
+      id: "202530714_add_linked_account_properties"
+      author: sehsan
+      changes:
+        - addColumn:
+            tableName: linked_account
+            columns:
+              - column:
+                  name: additional_properties
+                  type: json
+                  constraints:
+                    nullable: true

--- a/service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -50,3 +50,6 @@ databaseChangeLog:
   - include:
       file: changesets/20250307_add_sage_provider.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/20250714_add_linked_account_properties.yaml
+      relativeToChangelogFile: true

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -99,6 +99,28 @@ class OauthApiControllerTest extends BaseTest {
     }
 
     @Test
+    void testGetLinkWithAdditionalProperties() throws Exception {
+      var accessToken = "testToken";
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
+      inputLinkedAccount.withAdditionalProperties(Map.of("era_user_id", "test-era-id"));
+
+      mockSamUser(inputLinkedAccount.getUserId(), accessToken);
+
+      when(linkedAccountServiceMock.getLinkedAccount(
+              inputLinkedAccount.getUserId(), inputLinkedAccount.getProvider()))
+          .thenReturn(Optional.of(inputLinkedAccount));
+
+      mvc.perform(
+              get("/api/oauth/v1/" + inputLinkedAccount.getProvider().toString())
+                  .header("authorization", "Bearer " + accessToken))
+          .andExpect(
+              content()
+                  .json(
+                      mapper.writeValueAsString(
+                          OpenApiConverters.Output.convert(inputLinkedAccount))));
+    }
+
+    @Test
     void testGetFenceLink() throws Exception {
       var accessToken = "testToken";
       var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.FENCE);

--- a/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
@@ -1,7 +1,9 @@
 package bio.terra.externalcreds.util;
 
 import static bio.terra.externalcreds.services.JwtUtils.GA4GH_PASSPORT_V1_CLAIM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
@@ -30,5 +32,20 @@ class ProviderUtilsTest extends BaseTest {
   void testNoScopeProvider() {
     var providerProperties = ProviderProperties.create().setScopes(Set.of());
     assertFalse(ProviderUtils.isPassportProvider(providerProperties));
+  }
+
+  @Test
+  void testGetLinkedEraIdentity() {
+    String federatedIdentities =
+        "{\"identities\": [{\"login.gov\": {\"userid\": \"12345\"}}, {\"era\": {\"userid\": \"test-era-id\"}}]}";
+    String linkedEraIdentity = ProviderUtils.getLinkedEraIdentity(federatedIdentities);
+    assertEquals("test-era-id", linkedEraIdentity);
+  }
+
+  @Test
+  void testGetLinkedEraIdentityReturnsNull() {
+    assertNull(ProviderUtils.getLinkedEraIdentity(null));
+    assertNull(ProviderUtils.getLinkedEraIdentity("{}"));
+    assertNull(ProviderUtils.getLinkedEraIdentity("{\"identities\": []}"));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.config.ProviderProperties;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -36,15 +38,21 @@ class ProviderUtilsTest extends BaseTest {
 
   @Test
   void testGetLinkedEraIdentity() {
-    String federatedIdentities =
+    String federatedIdentitiesJSON =
         "{\"identities\": [{\"login.gov\": {\"userid\": \"12345\"}}, {\"era\": {\"userid\": \"test-era-id\"}}]}";
-    String linkedEraIdentity = ProviderUtils.getLinkedEraIdentity(federatedIdentities);
-    assertEquals("test-era-id", linkedEraIdentity);
+    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentitiesJSON));
+
+    Map<String, Object> loginGovIdentity = Map.of("login.gov", Map.of("userid", "12345"));
+    Map<String, Object> era_identity = Map.of("era", Map.of("userid", "test-era-id"));
+    Map<String, Object> federatedIdentities =
+        Map.of("identities", List.of(loginGovIdentity, era_identity));
+    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentities));
   }
 
   @Test
   void testGetLinkedEraIdentityReturnsNull() {
     assertNull(ProviderUtils.getLinkedEraIdentity(null));
+    assertNull(ProviderUtils.getLinkedEraIdentity(Map.of("identities", List.of())));
     assertNull(ProviderUtils.getLinkedEraIdentity("{}"));
     assertNull(ProviderUtils.getLinkedEraIdentity("{\"identities\": []}"));
   }


### PR DESCRIPTION
**Jira:** https://broadworkbench.atlassian.net/browse/CORE-560

**What:** Update the GET provider details endpoint to include the ERA commons user id for the RAS provider (if their account is linked)

**Why:** Make it easier for a user to know if their ERA commons account is linked to the account they used to link with RAS

**How:**
- Add field to LinkedAccount database table & update API model
- Get the era userid from the userInfo "federated_identities" property when a user links a RAS account and store it in the `additionalProperties` field.
- Update API response to return this info
  
