### PR TITLE
[CORE-560] Get linked era user id when getting RAS provider info

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -598,6 +598,10 @@ components:
           format: date-time
         authenticated:
           type: boolean
+        additionalProperties:
+          type: object
+          additionalProperties:
+            type: string
         additionalState:
           type: object
           additionalProperties:

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -43,7 +43,20 @@ public record OauthApiController(
   public ResponseEntity<LinkInfo> getLink(Provider provider) {
     var samUser = samUserFactory.from(request);
     var linkedAccount = linkedAccountService.getLinkedAccount(samUser.getSubjectId(), provider);
-    return ResponseEntity.of(linkedAccount.map(OpenApiConverters.Output::convert));
+    Optional<LinkInfo> linkInfo = linkedAccount.map(OpenApiConverters.Output::convert);
+    if (linkInfo.isPresent() && provider == Provider.RAS) {
+      var auditLogEventBuilder =
+          new AuditLogEvent.Builder()
+              .provider(provider)
+              .userId(samUser.getSubjectId())
+              .clientIP(request.getRemoteAddr());
+      var era_user_id =
+          providerService.getLinkedEraIdentity(provider, linkedAccount.get(), auditLogEventBuilder);
+      if (era_user_id != null) {
+        linkInfo.get().additionalProperties(Map.of("era_user_id", era_user_id));
+      }
+    }
+    return ResponseEntity.of(linkInfo);
   }
 
   @Override

--- a/service/src/main/java/bio/terra/externalcreds/models/AccessTokenCacheEntry.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/AccessTokenCacheEntry.java
@@ -10,8 +10,6 @@ public interface AccessTokenCacheEntry extends WithAccessTokenCacheEntry {
 
   String getAccessToken();
 
-  Instant getIssuedAt();
-
   Instant getExpiresAt();
 
   class Builder extends ImmutableAccessTokenCacheEntry.Builder {}

--- a/service/src/main/java/bio/terra/externalcreds/models/AccessTokenCacheEntry.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/AccessTokenCacheEntry.java
@@ -10,6 +10,8 @@ public interface AccessTokenCacheEntry extends WithAccessTokenCacheEntry {
 
   String getAccessToken();
 
+  Instant getIssuedAt();
+
   Instant getExpiresAt();
 
   class Builder extends ImmutableAccessTokenCacheEntry.Builder {}

--- a/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
+++ b/service/src/main/java/bio/terra/externalcreds/models/LinkedAccount.java
@@ -3,6 +3,7 @@ package bio.terra.externalcreds.models;
 import bio.terra.externalcreds.generated.model.Provider;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Optional;
 import org.immutables.value.Value;
 
@@ -25,6 +26,8 @@ public interface LinkedAccount extends WithLinkedAccount {
   default boolean isExpired() {
     return getExpires().toInstant().isBefore(Instant.now());
   }
+
+  Map<String, Object> getAdditionalProperties();
 
   class Builder extends ImmutableLinkedAccount.Builder {}
 }

--- a/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
@@ -41,9 +41,10 @@ public class AccessTokenCacheService {
     this.auditLogger = auditLogger;
   }
 
+  @WriteTransaction
   public String getLinkedAccountAccessToken(
       LinkedAccount linkedAccount, Set<String> scopes, AuditLogEvent.Builder auditLogEventBuilder) {
-    return getOrCreateTokenCacheEntry(linkedAccount, scopes, auditLogEventBuilder).toString();
+    return getOrCreateTokenCacheEntry(linkedAccount, scopes, auditLogEventBuilder).getAccessToken();
   }
 
   @WriteTransaction

--- a/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
@@ -41,28 +41,31 @@ public class AccessTokenCacheService {
     this.auditLogger = auditLogger;
   }
 
-  @WriteTransaction
   public String getLinkedAccountAccessToken(
       LinkedAccount linkedAccount, Set<String> scopes, AuditLogEvent.Builder auditLogEventBuilder) {
-    var tokenCacheEntry =
-        getAccessTokenCacheEntry(linkedAccount)
-            .flatMap(
-                tokenEntry -> {
-                  if (tokenEntry
-                      .getExpiresAt()
-                      .isAfter(
-                          Instant.now()
-                              .plus(externalCredsConfig.getAccessTokenExpirationBuffer()))) {
-                    return Optional.of(tokenEntry.getAccessToken());
-                  }
-                  return Optional.empty();
-                });
-
-    return tokenCacheEntry.orElseGet(
-        () -> getNewProviderAccessToken(linkedAccount, scopes, auditLogEventBuilder));
+    return getOrCreateTokenCacheEntry(linkedAccount, scopes, auditLogEventBuilder).toString();
   }
 
-  private String getNewProviderAccessToken(
+  @WriteTransaction
+  public AccessTokenCacheEntry getOrCreateTokenCacheEntry(
+      LinkedAccount linkedAccount, Set<String> scopes, AuditLogEvent.Builder auditLogEventBuilder) {
+
+    // Try to get a valid token from the cache
+    Optional<AccessTokenCacheEntry> cachedToken = getAccessTokenCacheEntry(linkedAccount);
+
+    // Check if token exists and is not close to expiration
+    if (cachedToken.isPresent()
+        && cachedToken
+            .get()
+            .getExpiresAt()
+            .isAfter(Instant.now().plus(externalCredsConfig.getAccessTokenExpirationBuffer()))) {
+      return cachedToken.get();
+    }
+
+    return getNewProviderAccessToken(linkedAccount, scopes, auditLogEventBuilder);
+  }
+
+  private AccessTokenCacheEntry getNewProviderAccessToken(
       LinkedAccount linkedAccount, Set<String> scopes, AuditLogEvent.Builder auditLogEventBuilder) {
     // get client registration from provider client cache
     var clientRegistration =
@@ -84,12 +87,12 @@ public class AccessTokenCacheService {
     logGetProviderAccessToken(linkedAccount, auditLogEventBuilder);
 
     return upsertAccessTokenCacheEntry(
-            new AccessTokenCacheEntry.Builder()
-                .linkedAccountId(linkedAccount.getId().orElseThrow())
-                .accessToken(accessTokenResponse.getAccessToken().getTokenValue())
-                .expiresAt(accessTokenResponse.getAccessToken().getExpiresAt())
-                .build())
-        .getAccessToken();
+        new AccessTokenCacheEntry.Builder()
+            .linkedAccountId(linkedAccount.getId().orElseThrow())
+            .accessToken(accessTokenResponse.getAccessToken().getTokenValue())
+            .issuedAt(accessTokenResponse.getAccessToken().getIssuedAt())
+            .expiresAt(accessTokenResponse.getAccessToken().getExpiresAt())
+            .build());
   }
 
   private Optional<AccessTokenCacheEntry> getAccessTokenCacheEntry(LinkedAccount linkedAccount) {

--- a/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/AccessTokenCacheService.java
@@ -90,7 +90,6 @@ public class AccessTokenCacheService {
         new AccessTokenCacheEntry.Builder()
             .linkedAccountId(linkedAccount.getId().orElseThrow())
             .accessToken(accessTokenResponse.getAccessToken().getTokenValue())
-            .issuedAt(accessTokenResponse.getAccessToken().getIssuedAt())
             .expiresAt(accessTokenResponse.getAccessToken().getExpiresAt())
             .build());
   }

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -171,22 +171,27 @@ public class ProviderService {
   public String getLinkedEraIdentity(
       Provider provider, LinkedAccount linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
     var userId = linkedAccount.getUserId();
-    var providerClient = providerOAuthClientCache.getProviderClient(provider);
     var providerProperties = externalCredsConfig.getProviderProperties(provider);
-    var accessTokenCacheEntry =
-        accessTokenCacheService.getOrCreateTokenCacheEntry(
-            linkedAccount, new HashSet<>(providerProperties.getScopes()), auditLogEventBuilder);
-    var userInfo =
-        oAuth2Service.getUserInfo(
-            userId,
-            providerClient,
-            provider,
-            new OAuth2AccessToken(
-                TokenType.BEARER,
-                accessTokenCacheEntry.getAccessToken(),
-                Instant.now(),
-                accessTokenCacheEntry.getExpiresAt()));
-    var federatedIdentities = userInfo.getAttribute("federated_identities");
+    Object federatedIdentities = null;
+    try {
+      var providerClient = providerOAuthClientCache.getProviderClient(provider);
+      var accessTokenCacheEntry =
+          accessTokenCacheService.getOrCreateTokenCacheEntry(
+              linkedAccount, new HashSet<>(providerProperties.getScopes()), auditLogEventBuilder);
+      var userInfo =
+          oAuth2Service.getUserInfo(
+              userId,
+              providerClient,
+              provider,
+              new OAuth2AccessToken(
+                  TokenType.BEARER,
+                  accessTokenCacheEntry.getAccessToken(),
+                  Instant.now(),
+                  accessTokenCacheEntry.getExpiresAt()));
+      federatedIdentities = userInfo.getAttribute("federated_identities");
+    } catch (Exception ex) {
+      log.info("Error getting userInfo from provider {}", provider, ex);
+    }
     return ProviderUtils.getLinkedEraIdentity(federatedIdentities);
   }
 

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -38,6 +38,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2AccessToken.TokenType;
 import org.springframework.security.oauth2.core.OAuth2AuthorizationException;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
@@ -164,6 +166,28 @@ public class ProviderService {
   public Optional<Map<String, String>> getAdditionalStateParams(String state) {
     OAuth2State decodedState = OAuth2State.decode(objectMapper, state);
     return decodedState.getAdditionalState();
+  }
+
+  public String getLinkedEraIdentity(
+      Provider provider, LinkedAccount linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+    var userId = linkedAccount.getUserId();
+    var providerClient = providerOAuthClientCache.getProviderClient(provider);
+    var providerProperties = externalCredsConfig.getProviderProperties(provider);
+    var accessTokenCacheEntry =
+        accessTokenCacheService.getOrCreateTokenCacheEntry(
+            linkedAccount, new HashSet<>(providerProperties.getScopes()), auditLogEventBuilder);
+    var userInfo =
+        oAuth2Service.getUserInfo(
+            userId,
+            providerClient,
+            provider,
+            new OAuth2AccessToken(
+                TokenType.BEARER,
+                accessTokenCacheEntry.getAccessToken(),
+                accessTokenCacheEntry.getIssuedAt(),
+                accessTokenCacheEntry.getExpiresAt()));
+    var federatedIdentities = userInfo.getAttribute("federated_identities");
+    return ProviderUtils.getLinkedEraIdentity(federatedIdentities);
   }
 
   protected ImmutablePair<LinkedAccount, OAuth2User> createLinkedAccount(

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -184,7 +184,7 @@ public class ProviderService {
             new OAuth2AccessToken(
                 TokenType.BEARER,
                 accessTokenCacheEntry.getAccessToken(),
-                accessTokenCacheEntry.getIssuedAt(),
+                Instant.now(),
                 accessTokenCacheEntry.getExpiresAt()));
     var federatedIdentities = userInfo.getAttribute("federated_identities");
     return ProviderUtils.getLinkedEraIdentity(federatedIdentities);

--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -3,12 +3,66 @@ package bio.terra.externalcreds.util;
 import static bio.terra.externalcreds.services.JwtUtils.GA4GH_PASSPORT_V1_CLAIM;
 
 import bio.terra.externalcreds.config.ProviderProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ProviderUtils {
+
+  private static final Logger logger = LoggerFactory.getLogger(ProviderUtils.class);
+  private static final ObjectMapper objectMapper = new ObjectMapper();
 
   private ProviderUtils() {}
 
   public static boolean isPassportProvider(ProviderProperties providerProperties) {
     return providerProperties.getScopes().contains(GA4GH_PASSPORT_V1_CLAIM);
+  }
+
+  public static String getLinkedEraIdentity(Object federatedIdentities) {
+    logger.info("Federated Identities: {}", federatedIdentities);
+
+    Map<String, Object> identitiesMap = null;
+    String eraUserId = null;
+    if (federatedIdentities != null) {
+      try {
+        if (federatedIdentities instanceof String) {
+          logger.info("Found federated identities String");
+          identitiesMap = objectMapper.readValue((String) federatedIdentities, Map.class);
+        } else if (federatedIdentities instanceof Map<?, ?>) {
+          logger.info("Found federated identities map");
+          identitiesMap = (Map<String, Object>) federatedIdentities;
+        } else {
+          logger.info(
+              "Found federated identities of unknown type: {}", federatedIdentities.getClass());
+        }
+
+        if (identitiesMap != null
+            && identitiesMap.containsKey("identities")
+            && identitiesMap.get("identities") instanceof List) {
+          @SuppressWarnings("unchecked")
+          List<Map<String, Object>> identitiesList =
+              (List<Map<String, Object>>) identitiesMap.get("identities");
+
+          for (Map<String, Object> identity : identitiesList) {
+            if (identity.containsKey("era") && identity.get("era") instanceof Map) {
+              @SuppressWarnings("unchecked")
+              Map<String, Object> eraInfo = (Map<String, Object>) identity.get("era");
+              eraUserId = (String) eraInfo.get("userid");
+              if (eraUserId != null) {
+                break;
+              }
+            }
+          }
+        }
+      } catch (IOException e) {
+        logger.info("Error parseing federated identities: {}", e.getMessage());
+      } catch (Exception e) {
+        logger.info("Error extracting linked ERA identity: {}", e.getMessage());
+      }
+    }
+    return eraUserId;
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -99,6 +99,31 @@ class OauthApiControllerTest extends BaseTest {
     }
 
     @Test
+    void testGetLinkWithAdditionalProperties() throws Exception {
+      var accessToken = "testToken";
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
+
+      mockSamUser(inputLinkedAccount.getUserId(), accessToken);
+
+      when(linkedAccountServiceMock.getLinkedAccount(
+              inputLinkedAccount.getUserId(), inputLinkedAccount.getProvider()))
+          .thenReturn(Optional.of(inputLinkedAccount));
+
+      when(providerServiceMock.getLinkedEraIdentity(any(), any(), any())).thenReturn("test-era-id");
+
+      var outputLinkedAccount =
+          inputLinkedAccount.withAdditionalProperties(Map.of("era_user_id", "test-era-id"));
+      mvc.perform(
+              get("/api/oauth/v1/" + inputLinkedAccount.getProvider().toString())
+                  .header("authorization", "Bearer " + accessToken))
+          .andExpect(
+              content()
+                  .json(
+                      mapper.writeValueAsString(
+                          OpenApiConverters.Output.convert(outputLinkedAccount))));
+    }
+
+    @Test
     void testGetFenceLink() throws Exception {
       var accessToken = "testToken";
       var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.FENCE);

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -71,6 +73,7 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AccessTokenResponse;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 public class ProviderServiceTest extends BaseTest {
@@ -1304,6 +1307,95 @@ public class ProviderServiceTest extends BaseTest {
           () ->
               providerService.getProviderAccessToken(
                   linkedAccountUserId, provider, auditLogEventBuilder));
+    }
+  }
+
+  @Nested
+  @TestComponent
+  class LinkedEraIdentityTest {
+    @Autowired private ProviderService providerService;
+    @MockitoBean private AuditLogger auditLoggerMock;
+    @MockitoBean private ProviderOAuthClientCache providerOAuthClientCacheMock;
+    @MockitoBean private OAuth2Service oAuth2ServiceMock;
+    @MockitoBean private AccessTokenCacheService accessTokenCacheServiceMock;
+    @MockitoBean private ExternalCredsConfig externalCredsConfigMock;
+
+    private void mockProvider(Provider provider, ClientRegistration clientRegistration) {
+      when(externalCredsConfigMock.getProviderProperties(provider))
+          .thenReturn(TestUtils.createRandomProvider());
+      when(providerOAuthClientCacheMock.getProviderClient(provider)).thenReturn(clientRegistration);
+    }
+
+    private void mockAccessTokenCacheService(
+        LinkedAccount linkedAccount, AuditLogEvent.Builder auditLogEventBuilder) {
+      var accessTokenCacheEntry =
+          new AccessTokenCacheEntry.Builder()
+              .linkedAccountId(linkedAccount.getId().orElse(1))
+              .accessToken("mock-access-token")
+              .expiresAt(Instant.now().plusSeconds(3600))
+              .build();
+      when(accessTokenCacheServiceMock.getOrCreateTokenCacheEntry(
+              eq(linkedAccount), any(), eq(auditLogEventBuilder)))
+          .thenReturn(accessTokenCacheEntry);
+    }
+
+    @Test
+    void testGetLinkedEraIdentity() {
+      var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
+      var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
+      var auditLogEventBuilder =
+          new AuditLogEvent.Builder().provider(Provider.RAS).userId(linkedAccount.getUserId());
+
+      mockProvider(linkedAccount.getProvider(), clientRegistration);
+      mockAccessTokenCacheService(linkedAccount, auditLogEventBuilder);
+
+      Map<String, Object> era_identity = Map.of("era", Map.of("userid", "test-era-id"));
+      Map<String, Object> federatedIdentities = Map.of("identities", List.of(era_identity));
+      var userInfo = mock(OAuth2User.class);
+      when(userInfo.getAttribute("federated_identities")).thenReturn(federatedIdentities);
+
+      // Mock the OAuth2Service getUserInfo method
+      when(oAuth2ServiceMock.getUserInfo(
+              eq(linkedAccount.getUserId()),
+              eq(clientRegistration),
+              eq(linkedAccount.getProvider()),
+              any()))
+          .thenReturn(userInfo);
+
+      // Call the method under test
+      var result =
+          providerService.getLinkedEraIdentity(
+              linkedAccount.getProvider(), linkedAccount, auditLogEventBuilder);
+
+      // Verify the result
+      assertEquals("test-era-id", result);
+    }
+
+    @Test
+    void testGetLinkedEraIdentityHandlesException() {
+      var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
+      var clientRegistration = TestUtils.createClientRegistration(linkedAccount.getProvider());
+      var auditLogEventBuilder =
+          new AuditLogEvent.Builder().provider(Provider.RAS).userId(linkedAccount.getUserId());
+
+      mockProvider(linkedAccount.getProvider(), clientRegistration);
+      mockAccessTokenCacheService(linkedAccount, auditLogEventBuilder);
+
+      // Make getUserInfo throw an IllegalArgumentException
+      when(oAuth2ServiceMock.getUserInfo(
+              eq(linkedAccount.getUserId()),
+              eq(clientRegistration),
+              eq(linkedAccount.getProvider()),
+              any()))
+          .thenThrow(new IllegalArgumentException("Unable to resolve Configuration"));
+
+      // Call the method under test - this should handle the exception gracefully
+      var result =
+          providerService.getLinkedEraIdentity(
+              linkedAccount.getProvider(), linkedAccount, auditLogEventBuilder);
+
+      // Verify the result is null since we couldn't get the user info
+      assertNull(result);
     }
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
@@ -1,11 +1,15 @@
 package bio.terra.externalcreds.util;
 
 import static bio.terra.externalcreds.services.JwtUtils.GA4GH_PASSPORT_V1_CLAIM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.config.ProviderProperties;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +34,26 @@ class ProviderUtilsTest extends BaseTest {
   void testNoScopeProvider() {
     var providerProperties = ProviderProperties.create().setScopes(Set.of());
     assertFalse(ProviderUtils.isPassportProvider(providerProperties));
+  }
+
+  @Test
+  void testGetLinkedEraIdentity() {
+    String federatedIdentitiesJSON =
+        "{\"identities\": [{\"login.gov\": {\"userid\": \"12345\"}}, {\"era\": {\"userid\": \"test-era-id\"}}]}";
+    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentitiesJSON));
+
+    Map<String, Object> loginGovIdentity = Map.of("login.gov", Map.of("userid", "12345"));
+    Map<String, Object> era_identity = Map.of("era", Map.of("userid", "test-era-id"));
+    Map<String, Object> federatedIdentities =
+        Map.of("identities", List.of(loginGovIdentity, era_identity));
+    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentities));
+  }
+
+  @Test
+  void testGetLinkedEraIdentityReturnsNull() {
+    assertNull(ProviderUtils.getLinkedEraIdentity(null));
+    assertNull(ProviderUtils.getLinkedEraIdentity(Map.of("identities", List.of())));
+    assertNull(ProviderUtils.getLinkedEraIdentity("{}"));
+    assertNull(ProviderUtils.getLinkedEraIdentity("{\"identities\": []}"));
   }
 }


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CORE-560

What: Update the GET provider details endpoint to include the ERA commons user id for the RAS provider (if their account is linked)

Why: Make it easier for a user to know if their ERA commons account is linked to the account they used to link with RAS

How: When getting RAS linked account info, get user info from RAS and extract the era userid from the "federated_identities" attribute

Testing:
I tested this locally with my dev RAS account to confirm that I can at least get `userInfo` when I call the `getLink` endpoint. It is currently not possible to link an ERA Commons account in dev or staging, so it does not have the "federated_identities" attribute. Instead I wrote unit tests based on the expected format.