### PR TITLE
[CORE-560] Fix Parsing ERA User Id

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -4,7 +4,6 @@ import static bio.terra.externalcreds.services.JwtUtils.GA4GH_PASSPORT_V1_CLAIM;
 
 import bio.terra.externalcreds.config.ProviderProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.io.IOException;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -5,7 +5,6 @@ import static bio.terra.externalcreds.services.JwtUtils.GA4GH_PASSPORT_V1_CLAIM;
 import bio.terra.externalcreds.config.ProviderProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,22 +38,14 @@ public class ProviderUtils {
               "Found federated identities of unknown type: {}", federatedIdentities.getClass());
         }
 
-        if (identitiesMap != null
-            && identitiesMap.containsKey("identities")
-            && identitiesMap.get("identities") instanceof List) {
+        if (identitiesMap != null && identitiesMap.containsKey("identities")) {
           @SuppressWarnings("unchecked")
-          List<Map<String, Object>> identitiesList =
-              (List<Map<String, Object>>) identitiesMap.get("identities");
+          Map<String, Object> identities = (Map<String, Object>) identitiesMap.get("identities");
 
-          for (Map<String, Object> identity : identitiesList) {
-            if (identity.containsKey("era") && identity.get("era") instanceof Map) {
-              @SuppressWarnings("unchecked")
-              Map<String, Object> eraInfo = (Map<String, Object>) identity.get("era");
-              eraUserId = (String) eraInfo.get("userid");
-              if (eraUserId != null) {
-                break;
-              }
-            }
+          if (identities.containsKey("era")) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> eraInfo = (Map<String, Object>) identities.get("era");
+            eraUserId = (String) eraInfo.get("userid");
           }
         }
       } catch (IOException e) {

--- a/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
+++ b/service/src/main/java/bio/terra/externalcreds/util/ProviderUtils.java
@@ -22,22 +22,11 @@ public class ProviderUtils {
 
   public static String getLinkedEraIdentity(Object federatedIdentities) {
     logger.info("Federated Identities: {}", federatedIdentities);
-
-    Map<String, Object> identitiesMap = null;
     String eraUserId = null;
+
     if (federatedIdentities != null) {
       try {
-        if (federatedIdentities instanceof String) {
-          logger.info("Found federated identities String");
-          identitiesMap = objectMapper.readValue((String) federatedIdentities, Map.class);
-        } else if (federatedIdentities instanceof Map<?, ?>) {
-          logger.info("Found federated identities map");
-          identitiesMap = (Map<String, Object>) federatedIdentities;
-        } else {
-          logger.info(
-              "Found federated identities of unknown type: {}", federatedIdentities.getClass());
-        }
-
+        Map<String, Object> identitiesMap = (Map<String, Object>) federatedIdentities;
         if (identitiesMap != null && identitiesMap.containsKey("identities")) {
           @SuppressWarnings("unchecked")
           Map<String, Object> identities = (Map<String, Object>) identitiesMap.get("identities");
@@ -48,8 +37,6 @@ public class ProviderUtils {
             eraUserId = (String) eraInfo.get("userid");
           }
         }
-      } catch (IOException e) {
-        logger.info("Error parseing federated identities: {}", e.getMessage());
       } catch (Exception e) {
         logger.info("Error extracting linked ERA identity: {}", e.getMessage());
       }

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -1350,7 +1350,7 @@ public class ProviderServiceTest extends BaseTest {
       mockAccessTokenCacheService(linkedAccount, auditLogEventBuilder);
 
       Map<String, Object> era_identity = Map.of("era", Map.of("userid", "test-era-id"));
-      Map<String, Object> federatedIdentities = Map.of("identities", List.of(era_identity));
+      Map<String, Object> federatedIdentities = Map.of("identities", era_identity);
       var userInfo = mock(OAuth2User.class);
       when(userInfo.getAttribute("federated_identities")).thenReturn(federatedIdentities);
 

--- a/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
@@ -38,14 +38,14 @@ class ProviderUtilsTest extends BaseTest {
 
   @Test
   void testGetLinkedEraIdentity() {
-    String federatedIdentitiesJSON =
-        "{\"identities\": [{\"login.gov\": {\"userid\": \"12345\"}}, {\"era\": {\"userid\": \"test-era-id\"}}]}";
-    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentitiesJSON));
+    //    String federatedIdentitiesJSON =
+    //        "{\"identities\": {\"login.gov\": {\"userid\": \"12345\"}, \"era\": {\"userid\":
+    // \"test-era-id\"}}";
+    //    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentitiesJSON));
 
-    Map<String, Object> loginGovIdentity = Map.of("login.gov", Map.of("userid", "12345"));
-    Map<String, Object> era_identity = Map.of("era", Map.of("userid", "test-era-id"));
-    Map<String, Object> federatedIdentities =
-        Map.of("identities", List.of(loginGovIdentity, era_identity));
+    Map<String, Object> identities =
+        Map.of("login.gov", Map.of("userid", "12345"), "era", Map.of("userid", "test-era-id"));
+    Map<String, Object> federatedIdentities = Map.of("identities", identities);
     assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentities));
   }
 
@@ -54,6 +54,6 @@ class ProviderUtilsTest extends BaseTest {
     assertNull(ProviderUtils.getLinkedEraIdentity(null));
     assertNull(ProviderUtils.getLinkedEraIdentity(Map.of("identities", List.of())));
     assertNull(ProviderUtils.getLinkedEraIdentity("{}"));
-    assertNull(ProviderUtils.getLinkedEraIdentity("{\"identities\": []}"));
+    assertNull(ProviderUtils.getLinkedEraIdentity("{\"identities\": {}}"));
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/util/ProviderUtilsTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.config.ProviderProperties;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -38,11 +37,6 @@ class ProviderUtilsTest extends BaseTest {
 
   @Test
   void testGetLinkedEraIdentity() {
-    //    String federatedIdentitiesJSON =
-    //        "{\"identities\": {\"login.gov\": {\"userid\": \"12345\"}, \"era\": {\"userid\":
-    // \"test-era-id\"}}";
-    //    assertEquals("test-era-id", ProviderUtils.getLinkedEraIdentity(federatedIdentitiesJSON));
-
     Map<String, Object> identities =
         Map.of("login.gov", Map.of("userid", "12345"), "era", Map.of("userid", "test-era-id"));
     Map<String, Object> federatedIdentities = Map.of("identities", identities);
@@ -52,8 +46,7 @@ class ProviderUtilsTest extends BaseTest {
   @Test
   void testGetLinkedEraIdentityReturnsNull() {
     assertNull(ProviderUtils.getLinkedEraIdentity(null));
-    assertNull(ProviderUtils.getLinkedEraIdentity(Map.of("identities", List.of())));
-    assertNull(ProviderUtils.getLinkedEraIdentity("{}"));
-    assertNull(ProviderUtils.getLinkedEraIdentity("{\"identities\": {}}"));
+    assertNull(ProviderUtils.getLinkedEraIdentity(Map.of()));
+    assertNull(ProviderUtils.getLinkedEraIdentity(Map.of("identities", Map.of())));
   }
 }


### PR DESCRIPTION
**Jira:** https://broadworkbench.atlassian.net/browse/CORE-560

**Changes:**
After being able to test out this change in production, it turns out that the "identities" key in the "federated_identities" user info attribute is a map. This ticket updates the parsing logic and tests accordingly.