### PR TITLE
[CTM-284] Update RAS dev and staging scopes

### DIFF
--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -121,7 +121,6 @@ externalcreds:
       clientId: "${RAS_CLIENT_ID}"
       clientSecret: "${RAS_CLIENT_SECRET}"
       externalIdClaim: "email"
-      scopes: [ "openid","email","ga4gh_passport_v1","profile", "federated_identities" ]
       linkLifespan: "15d"
       revokeEndpoint: "${externalcreds.providers.ras.issuer}/auth/oauth/v2/token/revoke"
       userInfoEndpoint: "${externalcreds.providers.ras.issuer}/openid/connect/v1.1/userinfo"
@@ -150,6 +149,7 @@ spring.config.activate.on-profile: 'dev'
 externalcreds:
   providers:
     ras:
+      scopes: [ "openid","email","ga4gh_passport_v1","profile", "federated_identities_ial2" ]
       issuer: "https://stsstg.nih.gov"
       allowedRedirectUriPatterns: [ "https://[A-Za-z0-9-]*bvdp-saturn-dev.appspot.com/ecm-callback",
                                     "http://localhost:3000/ecm-callback",
@@ -202,6 +202,7 @@ spring.config.activate.on-profile: 'staging'
 externalcreds:
   providers:
     ras:
+      scopes: [ "openid","email","ga4gh_passport_v1","profile", "federated_identities_ial2" ]
       issuer: "https://stsstg.nih.gov"
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/ecm-callback",
                                     "https://duos-k8s.dsde-staging.broadinstitute.org"]
@@ -226,6 +227,7 @@ spring.config.activate.on-profile: 'prod'
 externalcreds:
   providers:
     ras:
+      scopes: [ "openid","email","ga4gh_passport_v1","profile", "federated_identities" ]
       issuer: "https://sts.nih.gov"
       allowedRedirectUriPatterns: [ "https://[A-Za-z-]+.terra.bio/ecm-callback",
                                     "https://terra.biodatacatalyst.nhlbi.nih.gov/ecm-callback",


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CTM-284

What:
Update the existing `federated_identities` scope to `federated_identities_ial2` for the RAS dev and staging clients. Previously all RAS clients had the same scopes in every environment, so in order to make this change the scopes are now defined per-environment.

Why:
We have a new RAS client that supports the NIST Identity Assurance Level 2 (IAL2) standard but it requires a different scope. 

How:
Update the ECM providers config, just for dev and staging RAS.
  
