### PR TITLE
[CTM-313] Update ECM logic to handle scope change from federated_identities to federated_identities_ial2

### DIFF
--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderService.java
@@ -188,7 +188,7 @@ public class ProviderService {
                   accessTokenCacheEntry.getAccessToken(),
                   Instant.now(),
                   accessTokenCacheEntry.getExpiresAt()));
-      federatedIdentities = userInfo.getAttribute("federated_identities");
+      federatedIdentities = userInfo.getAttribute("federated_identities_ial2");
     } catch (Exception ex) {
       log.info("Error getting userInfo from provider {}", provider, ex);
     }

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -128,7 +128,7 @@ externalcreds:
       validationEndpoint: "${externalcreds.providers.ras.issuer}/passport/validate"
       additionalAuthorizationParameters: { "prompt": "login" }
       deniedEmailPatterns: ${shared.deniedEmailPatterns}
-      loggedUserInfoFields: [ "email", "txn", "federated_identities" ]
+      loggedUserInfoFields: [ "email", "txn", "federated_identities_ial2" ]
 ---
 #non-prod environments
 spring.config.activate.on-profile: '!prod'

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -1352,7 +1352,7 @@ public class ProviderServiceTest extends BaseTest {
       Map<String, Object> era_identity = Map.of("era", Map.of("userid", "test-era-id"));
       Map<String, Object> federatedIdentities = Map.of("identities", era_identity);
       var userInfo = mock(OAuth2User.class);
-      when(userInfo.getAttribute("federated_identities")).thenReturn(federatedIdentities);
+      when(userInfo.getAttribute("federated_identities_ial2")).thenReturn(federatedIdentities);
 
       when(oAuth2ServiceMock.getUserInfo(
               eq(linkedAccount.getUserId()),


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CTM-313

**Changes:**
Update ECM logic to use the new `federated_identities_ial2` scope (it has already been changed in the providers.yml config): 
- Fix parsing user info for ERA linked identity
- Include the `federated_identities_ial2` field from user info in audit logging
  
