### PR TITLE
CTM-424: Upgrade spring-boot-starter-actuator to 3.5.12

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 	id 'idea'
 
 	id 'io.spring.dependency-management' version '1.1.7' apply false
-	id 'org.springframework.boot' version '3.5.7' apply false
+	id 'org.springframework.boot' version '3.5.12' apply false
 	id 'com.diffplug.spotless' version '8.2.1' apply false
 	// ^^ for some reason, can't use spotless in multiple subprojects without this ^^
 	id 'com.google.cloud.tools.jib' version '3.5.2' apply false


### PR DESCRIPTION
Ticket: [CTM-424](https://broadworkbench.atlassian.net/browse/CTM-424)

Upgrades spring-boot from 3.5.7 to 3.5.12 to address security vulnerabilities in spring-boot-starter-actuator.

[CTM-424]: https://broadworkbench.atlassian.net/browse/CTM-424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ