### PR TITLE
CTM-472: update sam client and TCL

### DIFF
--- a/service/build.gradle
+++ b/service/build.gradle
@@ -27,7 +27,7 @@ apply from: 'tooling.gradle'
 apply from: 'analysis.gradle'
 
 dependencies {
-	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.208'
+	implementation 'org.broadinstitute.dsde.workbench:sam-client_2.13:v0.0.440'
 
 	// google
 	implementation platform('com.google.cloud:libraries-bom:26.75.0')

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:7.4.3'
 
 	annotationProcessor 'org.immutables:value:2.12.1'
-	implementation('bio.terra:terra-common-lib:1.1.39-SNAPSHOT') {
+	implementation('bio.terra:terra-common-lib:1.1.72-SNAPSHOT') {
 		exclude group: 'io.kubernetes', module: 'client-java'
 	}
 	// https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-logging:7.4.3'
 
 	annotationProcessor 'org.immutables:value:2.12.1'
-	implementation('bio.terra:terra-common-lib:1.1.72-SNAPSHOT') {
+	implementation('bio.terra:terra-common-lib:1.1.73-SNAPSHOT') {
 		exclude group: 'io.kubernetes', module: 'client-java'
 	}
 	// https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on


### PR DESCRIPTION
Jira: CTM-472

Updates to the latest `sam-client`. The version currently in use is from Mar 29, 2024.

Update to latest `terra-common-lib`. The version currently in use is from Mar 21, 2025.