### PR TITLE
[CTM-42] Remove obsolete anvil and era-commons OAuth providers from ECM

### DIFF
--- a/common/openapi.yml
+++ b/common/openapi.yml
@@ -7,25 +7,6 @@ paths:
   /api/admin/v1/{provider}:
     parameters:
       - $ref: '#/components/parameters/providerParam'
-    put:
-      summary: Link a user to an external account with a fake refresh token. For eRA Commons only.
-      tags: [ admin ]
-      operationId: putLinkedAccountWithFakeToken
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AdminLinkInfo'
-        required: true
-      responses:
-        '204':
-          description: Linked Account Created
-        '400':
-          $ref: '#/components/responses/BadRequest'
-        '403':
-          $ref: '#/components/responses/PermissionDenied'
-        '500':
-          $ref: '#/components/responses/ServerError'
     delete:
       summary: Unlink a user from an external account
       tags: [ admin ]
@@ -654,12 +635,10 @@ components:
       type: string
       enum:
         - ras
-        - era-commons
         - github
         - fence
         - dcf-fence
         - kids-first
-        - anvil
         - sage
     LinkInfo:
       type: object

--- a/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
+++ b/service/src/main/java/bio/terra/externalcreds/config/ExternalCredsConfigInterface.java
@@ -69,6 +69,4 @@ public interface ExternalCredsConfigInterface {
   }
 
   Collection<String> getAuthorizedAdmins();
-
-  boolean getEraCommonsLinkingEnabled();
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
@@ -4,16 +4,13 @@ import bio.terra.common.exception.ForbiddenException;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.SamAdminDAO;
 import bio.terra.externalcreds.generated.api.AdminApi;
-import bio.terra.externalcreds.generated.model.AdminLinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.generated.model.RasSupportInfo;
-import bio.terra.externalcreds.models.LinkedAccount;
 import bio.terra.externalcreds.services.LinkedAccountService;
 import bio.terra.externalcreds.services.PassportService;
 import bio.terra.externalcreds.visaComparators.RASv1Dot1VisaComparator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
-import java.sql.Timestamp;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -30,24 +27,6 @@ public record AdminApiController(
     ExternalCredsConfig externalCredsConfig,
     SamAdminDAO samAdminDAO)
     implements AdminApi {
-
-  @Override
-  public ResponseEntity<Void> putLinkedAccountWithFakeToken(
-      Provider provider, AdminLinkInfo adminLinkInfo) {
-    requireWriteAdmin();
-    requireEraCommons(provider);
-    var linkedAccount =
-        new LinkedAccount.Builder()
-            .isAuthenticated(true)
-            .provider(provider)
-            .userId(adminLinkInfo.getUserId())
-            .refreshToken("fake-refresh-token")
-            .externalUserId(adminLinkInfo.getLinkedExternalId())
-            .expires(Timestamp.from(adminLinkInfo.getLinkExpireTime().toInstant()))
-            .build();
-    linkedAccountService.upsertLinkedAccount(linkedAccount);
-    return ResponseEntity.noContent().build();
-  }
 
   @Override
   public ResponseEntity<Void> adminDeleteLinkedAccount(Provider provider, String userId) {
@@ -125,11 +104,5 @@ public record AdminApiController(
       log.warn("Sam resourceTypeAdminPermission check failed", e);
     }
     throw new ForbiddenException("Admin permissions required");
-  }
-
-  private void requireEraCommons(Provider provider) {
-    if (provider != Provider.ERA_COMMONS) {
-      throw new ForbiddenException("Only eRA Commons is supported");
-    }
   }
 }

--- a/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/AdminApiController.java
@@ -4,6 +4,7 @@ import bio.terra.common.exception.ForbiddenException;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.SamAdminDAO;
 import bio.terra.externalcreds.generated.api.AdminApi;
+import bio.terra.externalcreds.generated.model.AdminLinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.generated.model.RasSupportInfo;
 import bio.terra.externalcreds.services.LinkedAccountService;

--- a/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
+++ b/service/src/main/java/bio/terra/externalcreds/controllers/OauthApiController.java
@@ -1,11 +1,8 @@
 package bio.terra.externalcreds.controllers;
 
-import static bio.terra.externalcreds.generated.model.Provider.ERA_COMMONS;
-
 import bio.terra.externalcreds.auditLogging.AuditLogEvent;
 import bio.terra.externalcreds.auditLogging.AuditLogEventType;
 import bio.terra.externalcreds.auditLogging.AuditLogger;
-import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.generated.api.OauthApi;
 import bio.terra.externalcreds.generated.model.LinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
@@ -27,8 +24,7 @@ public record OauthApiController(
     ObjectMapper mapper,
     LinkedAccountService linkedAccountService,
     ProviderService providerService,
-    ExternalCredsSamUserFactory samUserFactory,
-    ExternalCredsConfig externalCredsConfig)
+    ExternalCredsSamUserFactory samUserFactory)
     implements OauthApi {
 
   @Override
@@ -98,11 +94,6 @@ public record OauthApiController(
 
   @Override
   public ResponseEntity<LinkInfo> createLink(Provider provider, String state, String oauthcode) {
-    if (!externalCredsConfig.getEraCommonsLinkingEnabled() && provider.equals(ERA_COMMONS)) {
-      throw new UnsupportedOperationException(
-          "eRA Commons is not supported for link creation (yet)");
-    }
-
     var samUser = samUserFactory.from(request);
 
     var auditLogEventBuilder =

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderOAuthClientCache.java
@@ -55,22 +55,12 @@ public class ProviderOAuthClientCache {
                 .redirectUri(redirectUri)
                 .userNameAttributeName(providerInfo.getUserNameAttributeName());
           }
-          case FENCE, DCF_FENCE, ANVIL, KIDS_FIRST ->
+          case FENCE, DCF_FENCE, KIDS_FIRST ->
               ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
                   .clientId(providerInfo.getClientId())
                   .clientSecret(providerInfo.getClientSecret())
                   .issuerUri(providerInfo.getIssuer())
                   .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS);
-          case ERA_COMMONS -> {
-            if (externalCredsConfig.getEraCommonsLinkingEnabled()) {
-              yield ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
-                  .clientId(providerInfo.getClientId())
-                  .clientSecret(providerInfo.getClientSecret())
-                  .issuerUri(providerInfo.getIssuer());
-            } else {
-              throw new UnsupportedOperationException("eRA Commons does not support OAuth (yet)");
-            }
-          }
         };
 
     // set optional overrides

--- a/service/src/main/java/bio/terra/externalcreds/services/ProviderTokenClientCache.java
+++ b/service/src/main/java/bio/terra/externalcreds/services/ProviderTokenClientCache.java
@@ -37,7 +37,7 @@ public class ProviderTokenClientCache {
 
     ClientRegistration.Builder builder =
         switch (provider) {
-          case RAS, FENCE, DCF_FENCE, ANVIL, KIDS_FIRST, SAGE ->
+          case RAS, FENCE, DCF_FENCE, KIDS_FIRST, SAGE ->
               ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
                   .clientId(providerInfo.getClientId())
                   .clientSecret(providerInfo.getClientSecret())
@@ -55,16 +55,6 @@ public class ProviderTokenClientCache {
                 .issuerUri(providerInfo.getIssuer())
                 .redirectUri(redirectUri)
                 .userNameAttributeName(providerInfo.getUserNameAttributeName());
-          }
-          case ERA_COMMONS -> {
-            if (externalCredsConfig.getEraCommonsLinkingEnabled()) {
-              yield ClientRegistrations.fromOidcIssuerLocation(providerInfo.getIssuer())
-                  .clientId(providerInfo.getClientId())
-                  .clientSecret(providerInfo.getClientSecret())
-                  .issuerUri(providerInfo.getIssuer());
-            } else {
-              throw new UnsupportedOperationException("eRA Commons does not support OAuth (yet)");
-            }
           }
         };
 

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -14,7 +14,6 @@ externalcreds:
   access-token-expiration-buffer: 5m
   authorized-admins:
     - ${FIRECLOUD_ACCOUNT_EMAIL:firecloud-dev@broad-dsde-dev.iam.gserviceaccount.com}
-  era-commons-linking-enabled: true
 
 logging:
   level.bio.terra.externalcreds: ${EXTERNALCREDS_LOG_LEVEL:debug}
@@ -118,5 +117,3 @@ sentry:
   dsn: "https://7faae828388bc09ba384f7b290dbcbf3@o54426.ingest.us.sentry.io/4507097154322432"
   environment: production
   logging.minimum-breadcrumb-level: info
-externalcreds:
-  era-commons-linking-enabled: false

--- a/service/src/main/resources/providers.yml
+++ b/service/src/main/resources/providers.yml
@@ -96,19 +96,6 @@ externalcreds:
       tokenEndpoint: "${externalcreds.providers.kids-first.issuer}/oauth2/token"
       keyEndpoint: "${externalcreds.providers.kids-first.issuer}/credentials/google"
       deniedEmailPatterns: ${shared.deniedEmailPatterns}
-    anvil:
-      clientId: "${ANVIL_CLIENT_ID}"
-      clientSecret: "${ANVIL_CLIENT_SECRET}"
-      linkLifespan: "30d"
-      scopes: [ "openid", "user" ]
-      externalIdClaim: "username"
-      issuer: "${ANVIL_BASE_URL:https://staging.theanvil.io/user}"
-      revokeEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/revoke"
-      userInfoEndpoint: "${externalcreds.providers.anvil.issuer}/user"
-      authorizationEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/authorize"
-      tokenEndpoint: "${externalcreds.providers.anvil.issuer}/oauth2/token"
-      keyEndpoint: "${externalcreds.providers.anvil.issuer}/credentials/google"
-      deniedEmailPatterns: ${shared.deniedEmailPatterns}
     sage:
       clientId: "${SAGE_CLIENT_ID}"
       clientSecret: "${SAGE_CLIENT_SECRET}"
@@ -130,22 +117,6 @@ externalcreds:
       deniedEmailPatterns: ${shared.deniedEmailPatterns}
       loggedUserInfoFields: [ "email", "txn", "federated_identities_ial2" ]
 ---
-#non-prod environments
-spring.config.activate.on-profile: '!prod'
-externalcreds:
-  providers:
-    era-commons:
-      clientId: "${ERA_COMMONS_CLIENT_ID}"
-      clientSecret: "${ERA_COMMONS_CLIENT_SECRET}"
-      externalIdClaim: "preferred_username"
-      scopes: [ "openid", "email", "profile" ]
-      linkLifespan: "15d"
-      issuer: "https://stsstg.nih.gov"
-      revokeEndpoint: "${externalcreds.providers.era-commons.issuer}/auth/oauth/v2/token/revoke"
-      userInfoEndpoint: "${externalcreds.providers.era-commons.issuer}/openid/connect/v1.1/userinfo"
-      additionalAuthorizationParameters: { "prompt": "login" }
-
----
 spring.config.activate.on-profile: 'dev'
 externalcreds:
   providers:
@@ -156,11 +127,6 @@ externalcreds:
                                     "https://dev.ukbiobank.terra.bio/ecm-callback",
                                     "https://dev.terra.biodatacatalyst.nhlbi.nih.gov/ecm-callback",
                                     "https://terra.dsde-dev.broadinstitute.org/ecm-callback",
-                                    "https://local.dsde-dev.broadinstitute.org",
-                                    "https://local.dsde-dev.broadinstitute.org:3000",
-                                    "https://duos-k8s.dsde-dev.broadinstitute.org"]
-    era-commons:
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback",
                                     "https://local.dsde-dev.broadinstitute.org",
                                     "https://local.dsde-dev.broadinstitute.org:3000",
                                     "https://duos-k8s.dsde-dev.broadinstitute.org"]
@@ -188,12 +154,6 @@ externalcreds:
                                     "https://dev.ukbiobank.terra.bio/#fence-callback",
                                     "https://dev.terra.biodatacatalyst.nhlbi.nih.gov/#fence-callback",
                                     "https://terra.dsde-dev.broadinstitute.org/#fence-callback" ]
-    anvil:
-      allowedRedirectUriPatterns: [ "https://[A-Za-z0-9-]*bvdp-saturn-dev.appspot.com/#fence-callback",
-                                    "http://localhost:3000/#fence-callback",
-                                    "https://dev.ukbiobank.terra.bio/#fence-callback",
-                                    "https://dev.terra.biodatacatalyst.nhlbi.nih.gov/#fence-callback",
-                                    "https://terra.dsde-dev.broadinstitute.org/#fence-callback" ]
     sage:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-dev.appspot.com/ecm-callback" ]
       authorizationEndpoint: "https://dev-signin.synapse.org/"
@@ -205,9 +165,6 @@ externalcreds:
       issuer: "https://stsstg.nih.gov"
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/ecm-callback",
                                     "https://duos-k8s.dsde-staging.broadinstitute.org"]
-    era-commons:
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/ecm-callback",
-                                    "https://duos-k8s.dsde-staging.broadinstitute.org" ]
     github:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/oauth_callback" ]
     fence:
@@ -215,8 +172,6 @@ externalcreds:
     dcf-fence:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/#fence-callback" ]
     kids-first:
-      allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/#fence-callback" ]
-    anvil:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/#fence-callback" ]
     sage:
       allowedRedirectUriPatterns: [ "https://bvdp-saturn-staging.appspot.com/ecm-callback" ]
@@ -242,9 +197,6 @@ externalcreds:
       allowedRedirectUriPatterns: [ "https://[A-Za-z-]+.terra.bio/#fence-callback",
                                     "https://terra.biodatacatalyst.nhlbi.nih.gov/#fence-callback" ]
     kids-first:
-      allowedRedirectUriPatterns: [ "https://[A-Za-z-]+.terra.bio/#fence-callback",
-                                    "https://terra.biodatacatalyst.nhlbi.nih.gov/#fence-callback" ]
-    anvil:
       allowedRedirectUriPatterns: [ "https://[A-Za-z-]+.terra.bio/#fence-callback",
                                     "https://terra.biodatacatalyst.nhlbi.nih.gov/#fence-callback" ]
     sage:

--- a/service/src/test/java/bio/terra/externalcreds/controllers/AdminApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/AdminApiControllerTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -15,7 +14,6 @@ import bio.terra.externalcreds.BaseTest;
 import bio.terra.externalcreds.TestUtils;
 import bio.terra.externalcreds.config.ExternalCredsConfig;
 import bio.terra.externalcreds.dataAccess.SamAdminDAO;
-import bio.terra.externalcreds.generated.model.AdminLinkInfo;
 import bio.terra.externalcreds.generated.model.Provider;
 import bio.terra.externalcreds.services.LinkedAccountService;
 import bio.terra.externalcreds.services.PassportService;
@@ -48,78 +46,18 @@ class AdminApiControllerTest extends BaseTest {
   @MockitoBean private SamAdminDAO samAdminDAO;
 
   @Nested
-  class PutLinkedAccountWithFakeToken {
-    @Test
-    void testPutLinkedAccountWithFakeTokenAdmin() throws Exception {
-      var accessToken = mockAdminSamUser();
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
-      var inputAdminLinkInfo =
-          new AdminLinkInfo()
-              .linkedExternalId(inputLinkedAccount.getExternalUserId())
-              .linkExpireTime(inputLinkedAccount.getExpires())
-              .userId(inputLinkedAccount.getUserId());
-
-      when(linkedAccountService.upsertLinkedAccount(inputLinkedAccount))
-          .thenReturn(inputLinkedAccount.withId(1));
-
-      mvc.perform(
-              put("/api/admin/v1/" + Provider.ERA_COMMONS)
-                  .header("authorization", "Bearer " + accessToken)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(mapper.writeValueAsString(inputAdminLinkInfo)))
-          .andExpect(status().isNoContent());
-    }
-
-    @Test
-    void testPutLinkedAccountWithFakeTokenAdminNotEraCommons() throws Exception {
-      var accessToken = mockAdminSamUser();
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.GITHUB);
-      var inputAdminLinkInfo =
-          new AdminLinkInfo()
-              .linkedExternalId(inputLinkedAccount.getExternalUserId())
-              .linkExpireTime(inputLinkedAccount.getExpires())
-              .userId(inputLinkedAccount.getUserId());
-
-      mvc.perform(
-              put("/api/admin/v1/" + Provider.GITHUB)
-                  .header("authorization", "Bearer " + accessToken)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(mapper.writeValueAsString(inputAdminLinkInfo)))
-          .andExpect(status().isForbidden());
-    }
-
-    @Test
-    void testPutLinkedAccountWithFakeTokenNonAdmin() throws Exception {
-      var accessToken = mockSamUser("userId");
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
-      var inputAdminLinkInfo =
-          new AdminLinkInfo()
-              .linkedExternalId(inputLinkedAccount.getExternalUserId())
-              .linkExpireTime(inputLinkedAccount.getExpires())
-              .userId(inputLinkedAccount.getUserId());
-
-      mvc.perform(
-              put("/api/admin/v1/" + Provider.ERA_COMMONS)
-                  .header("authorization", "Bearer " + accessToken)
-                  .contentType(MediaType.APPLICATION_JSON)
-                  .content(mapper.writeValueAsString(inputAdminLinkInfo)))
-          .andExpect(status().isForbidden());
-    }
-  }
-
-  @Nested
   class AdminDeleteLinkedAccount {
     @Test
     void testAdminLinkedAccountAdmin() throws Exception {
       var accessToken = mockAdminSamUser();
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
       when(linkedAccountService.deleteLinkedAccount(
-              inputLinkedAccount.getUserId(), Provider.ERA_COMMONS))
+              inputLinkedAccount.getUserId(), Provider.RAS))
           .thenReturn(true);
 
       mvc.perform(
-              delete("/api/admin/v1/" + Provider.ERA_COMMONS)
+              delete("/api/admin/v1/" + Provider.RAS)
                   .header("authorization", "Bearer " + accessToken)
                   .contentType(MediaType.TEXT_PLAIN)
                   .content(inputLinkedAccount.getUserId()))
@@ -129,14 +67,14 @@ class AdminApiControllerTest extends BaseTest {
     @Test
     void testAdminLinkedAccountAdminNotFound() throws Exception {
       var accessToken = mockAdminSamUser();
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
       when(linkedAccountService.deleteLinkedAccount(
-              inputLinkedAccount.getUserId(), Provider.ERA_COMMONS))
+              inputLinkedAccount.getUserId(), Provider.RAS))
           .thenReturn(false);
 
       mvc.perform(
-              delete("/api/admin/v1/" + Provider.ERA_COMMONS)
+              delete("/api/admin/v1/" + Provider.RAS)
                   .header("authorization", "Bearer " + accessToken)
                   .contentType(MediaType.TEXT_PLAIN)
                   .content(inputLinkedAccount.getUserId()))
@@ -146,10 +84,10 @@ class AdminApiControllerTest extends BaseTest {
     @Test
     void testPutLinkedAccountWithFakeTokenNonAdmin() throws Exception {
       var accessToken = mockSamUser("userId");
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
       mvc.perform(
-              delete("/api/admin/v1/" + Provider.ERA_COMMONS)
+              delete("/api/admin/v1/" + Provider.RAS)
                   .header("authorization", "Bearer " + accessToken)
                   .contentType(MediaType.TEXT_PLAIN)
                   .content(inputLinkedAccount.getUserId()))
@@ -163,15 +101,15 @@ class AdminApiControllerTest extends BaseTest {
     @Test
     void testGetLinkedAccountForExternalIdAdmin() throws Exception {
       var accessToken = mockAdminSamUser();
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
       when(linkedAccountService.getLinkedAccountForExternalId(
-              Provider.ERA_COMMONS, inputLinkedAccount.getExternalUserId()))
+              Provider.RAS, inputLinkedAccount.getExternalUserId()))
           .thenReturn(Optional.of(inputLinkedAccount));
 
       mvc.perform(
               get("/api/admin/v1/"
-                      + Provider.ERA_COMMONS
+                      + Provider.RAS
                       + "/userForExternalId/"
                       + inputLinkedAccount.getExternalUserId())
                   .header("authorization", "Bearer " + accessToken))
@@ -185,11 +123,11 @@ class AdminApiControllerTest extends BaseTest {
     @Test
     void testGetLinkedAccountForExternalIdNonAdmin() throws Exception {
       var accessToken = mockSamUser("userId");
-      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var inputLinkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
       mvc.perform(
               get("/api/admin/v1/"
-                      + Provider.ERA_COMMONS
+                      + Provider.RAS
                       + "/userForExternalId/"
                       + inputLinkedAccount.getExternalUserId())
                   .header("authorization", "Bearer " + accessToken))
@@ -203,14 +141,14 @@ class AdminApiControllerTest extends BaseTest {
     @Test
     void testGetActiveLinkedAccountsAdmin() throws Exception {
       var accessToken = mockAdminSamUser();
-      var inputLinkedAccount1 = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
-      var inputLinkedAccount2 = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var inputLinkedAccount1 = TestUtils.createRandomLinkedAccount(Provider.RAS);
+      var inputLinkedAccount2 = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
-      when(linkedAccountService.getActiveLinkedAccounts(Provider.ERA_COMMONS))
+      when(linkedAccountService.getActiveLinkedAccounts(Provider.RAS))
           .thenReturn(List.of(inputLinkedAccount1, inputLinkedAccount2));
 
       mvc.perform(
-              get("/api/admin/v1/" + Provider.ERA_COMMONS + "/activeAccounts")
+              get("/api/admin/v1/" + Provider.RAS + "/activeAccounts")
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(
               content()
@@ -226,7 +164,7 @@ class AdminApiControllerTest extends BaseTest {
       var accessToken = mockSamUser("userId");
 
       mvc.perform(
-              get("/api/admin/v1/" + Provider.ERA_COMMONS + "/activeAccounts")
+              get("/api/admin/v1/" + Provider.RAS + "/activeAccounts")
                   .header("authorization", "Bearer " + accessToken))
           .andExpect(status().isForbidden());
     }

--- a/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/controllers/OauthApiControllerTest.java
@@ -181,7 +181,7 @@ class OauthApiControllerTest extends BaseTest {
     @ParameterizedTest
     @EnumSource(
         value = Provider.class,
-        names = {"RAS", "ERA_COMMONS"}, // run for all providers except these
+        names = {"RAS"}, // run for all providers except these
         mode = Mode.EXCLUDE)
     void testCreatesTokenProviderLinkSuccessfully(Provider provider) throws Exception {
       var inputLinkedAccount = TestUtils.createRandomLinkedAccount(provider);

--- a/service/src/test/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAOTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/dataAccess/LinkedAccountDAOTest.java
@@ -306,14 +306,14 @@ class LinkedAccountDAOTest extends BaseTest {
 
     @Test
     void testGetsLinkedAccountByExternalId() {
-      var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
       linkedAccountDAO.upsertLinkedAccount(
           TestUtils.createRandomLinkedAccount(
-              Provider.ERA_COMMONS)); // To make sure we get the right one.
+              Provider.RAS)); // To make sure we get the right one.
       var savedLinkedAccount = linkedAccountDAO.upsertLinkedAccount(linkedAccount);
       var loadedLinkedAccount =
           linkedAccountDAO.getLinkedAccountForExternalId(
-              Provider.ERA_COMMONS, savedLinkedAccount.getExternalUserId());
+              Provider.RAS, savedLinkedAccount.getExternalUserId());
 
       // Assert that only the user_id for the username we supplied
       assertEquals(linkedAccount.getUserId(), loadedLinkedAccount.get().getUserId());
@@ -322,21 +322,21 @@ class LinkedAccountDAOTest extends BaseTest {
     @Test
     void testGetsAllActiveLinkedAccounts() {
       // Create a non-expired linked account
-      var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
-      var linkedAccount2 = TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS);
+      var linkedAccount = TestUtils.createRandomLinkedAccount(Provider.RAS);
+      var linkedAccount2 = TestUtils.createRandomLinkedAccount(Provider.RAS);
 
       var savedLinkedAccount = linkedAccountDAO.upsertLinkedAccount(linkedAccount);
       var savedLinkedAccount2 = linkedAccountDAO.upsertLinkedAccount(linkedAccount2);
 
       // Create an expired linked account
       var expiredLinkedAccount =
-          TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS)
+          TestUtils.createRandomLinkedAccount(Provider.RAS)
               .withExpires(Timestamp.from(Instant.now().minus(Duration.ofMinutes(1))));
       linkedAccountDAO.upsertLinkedAccount(expiredLinkedAccount);
 
       // Create an unauthenticated linked account
       var unauthenticatedLinkedAccount =
-          TestUtils.createRandomLinkedAccount(Provider.ERA_COMMONS).withIsAuthenticated(false);
+          TestUtils.createRandomLinkedAccount(Provider.RAS).withIsAuthenticated(false);
       linkedAccountDAO.upsertLinkedAccount(unauthenticatedLinkedAccount);
 
       // Create a linked account with a different provider
@@ -347,7 +347,7 @@ class LinkedAccountDAOTest extends BaseTest {
       // of the requested provider are returned
       assertEquals(
           List.of(savedLinkedAccount, savedLinkedAccount2),
-          linkedAccountDAO.getActiveLinkedAccounts(Provider.ERA_COMMONS));
+          linkedAccountDAO.getActiveLinkedAccounts(Provider.RAS));
     }
   }
 }

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderOAuthClientCacheTest.java
@@ -77,32 +77,6 @@ class ProviderOAuthClientCacheTest extends BaseTest {
   }
 
   @Test
-  void testEraCommonsBuildClientRegistration() {
-    try (var mockServer = ClientAndServer.startClientAndServer()) {
-      var issuerPath = "/does/not/exist";
-      var url = "http://localhost:" + mockServer.getPort() + issuerPath;
-      Provider provider = Provider.ERA_COMMONS;
-      when(externalCredsConfig.getProviderProperties(provider))
-          .thenReturn(TestUtils.createRandomProvider().setIssuer(url));
-
-      //  Mock the server response
-      mockServer
-          .when(
-              HttpRequest.request(issuerPath + "/.well-known/openid-configuration")
-                  .withMethod("GET"))
-          .respond(
-              HttpResponse.response()
-                  .withStatusCode(200)
-                  .withContentType(MediaType.APPLICATION_JSON)
-                  .withBody(ProviderTestUtil.wellKnownResponse(url)));
-
-      assertThrows(
-          UnsupportedOperationException.class,
-          () -> providerOAuthClientCache.getProviderClient(provider));
-    }
-  }
-
-  @Test
   void testFenceBuildClientRegistration() {
     try (var mockServer = ClientAndServer.startClientAndServer()) {
       var issuerPath = "/does/not/exist";

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderServiceTest.java
@@ -954,7 +954,7 @@ public class ProviderServiceTest extends BaseTest {
       additionalStateParam.put("redirectTo", "http://foo.org");
       OAuth2State oAuth2State =
           new OAuth2State.Builder()
-              .provider(Provider.ERA_COMMONS)
+              .provider(Provider.RAS)
               .random(OAuth2State.generateRandomState(new SecureRandom()))
               .redirectUri(redirectUri)
               .additionalState(additionalStateParam)

--- a/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
+++ b/service/src/test/java/bio/terra/externalcreds/services/ProviderTokenClientCacheTest.java
@@ -76,32 +76,6 @@ class ProviderTokenClientCacheTest extends BaseTest {
   }
 
   @Test
-  void testEraCommonsBuildClientRegistration() {
-    try (var mockServer = ClientAndServer.startClientAndServer()) {
-      var issuerPath = "/does/not/exist";
-      var url = "http://localhost:" + mockServer.getPort() + issuerPath;
-      Provider provider = Provider.ERA_COMMONS;
-      when(externalCredsConfig.getProviderProperties(provider))
-          .thenReturn(TestUtils.createRandomProvider().setIssuer(url));
-
-      //  Mock the server response
-      mockServer
-          .when(
-              HttpRequest.request(issuerPath + "/.well-known/openid-configuration")
-                  .withMethod("GET"))
-          .respond(
-              HttpResponse.response()
-                  .withStatusCode(200)
-                  .withContentType(MediaType.APPLICATION_JSON)
-                  .withBody(ProviderTestUtil.wellKnownResponse(url)));
-
-      assertThrows(
-          UnsupportedOperationException.class,
-          () -> providerTokenClientCache.getProviderClient(provider));
-    }
-  }
-
-  @Test
   void testFenceBuildClientRegistration() {
     try (var mockServer = ClientAndServer.startClientAndServer()) {
       var issuerPath = "/does/not/exist";

--- a/service/src/test/resources/application-test.yaml
+++ b/service/src/test/resources/application-test.yaml
@@ -17,5 +17,3 @@ retry:
     maxAttempts: 3
     delay: 100
 
-externalcreds:
-  era-commons-linking-enabled: false


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/CTM-42

What:

With RAS as the sole compliant provider for AnVIL authorizations, the anvil and era-commons providers are no longer needed. The era-commons OAuth provider was originally planned as a migration path away from Shibboleth prior to RAS, but was never promoted to prod. RAS IAL2 enforcement (part of new NIH security requirements) makes it fully obsolete.                                                                                                                               

  Changes

  - Removed anvil and era-commons from the ECM provider registry across all environments (dev, staging, prod)                                                          
  - Removed the admin endpoint (PUT /api/admin/v1/{provider}) used by Orchestration to sync eRA Commons links into ECM — this was the orch→ECM linking/provider sync logic referenced in ID-1301                                                                                                                                          
  - Removed the era-commons-linking-enabled feature flag, which was already set to false in prod                                                                    
  - Removed era-commons and anvil from the Provider API enum, so they are no longer valid values in any ECM request    

Why:

  \<For your reviewers' sake, please describe in ~1 paragraph what the value of this PR is to our users or to ourselves.\>

How:

  \<For your reviewers' sake, please describe in ~1 paragraph how this PR accomplishes its goal.\>

  \<If the PR is big, please indicate where a reviewer should start reading it (i.e. which file or function).\>
  
